### PR TITLE
add post-buffering

### DIFF
--- a/templates/galaxy/config/uwsgi.ini.j2
+++ b/templates/galaxy/config/uwsgi.ini.j2
@@ -6,6 +6,7 @@ threads = 4
 
 ; uwsgi performance/robustness features
 single-interpreter = true
+post-buffering = 65536
 thunder-lock = true
 harakiri = 600
 buffer-size = 16384


### PR DESCRIPTION
This will fix the following warning:

```
I have found this here: *** WARNING: you have enabled harakiri without post buffering. Slow upload could be rejected on post-unbuffered webservers ***
```

.org has a few more options enabled, but post-buffering seems to be needed.

xref: https://github.com/galaxyproject/infrastructure-playbook/blob/35423adc74455d796074c72d2428dcbe93037b2a/roles/sentry/templates/uwsgi.ini.j2#L24
