### PR TITLE
Multicore variant calling with MiModD

### DIFF
--- a/files/galaxy/dynamic_rules/tool_destinations.yaml
+++ b/files/galaxy/dynamic_rules/tool_destinations.yaml
@@ -515,6 +515,7 @@ methtools_calling: {cores: 12, mem: 40}
 methtools_filter: {mem: 10}
 methtools_plot: {cores: 12, mem: 20}
 metilene: {cores: 12, mem: 20}
+mimodd_varcall: {cores: 6}
 minced: {mem: 10}
 migmap:
   env:


### PR DESCRIPTION
6 cores is the optimal setting for analyzing standard model organism genomes like C.elegans (6 chromosomes) and A.thaliana (5).