### PR TITLE
Fix fasta/fastq_manipulation section id

### DIFF
--- a/templates/galaxy/config/global_host_filters.py.j2
+++ b/templates/galaxy/config/global_host_filters.py.j2
@@ -37,7 +37,7 @@ def per_host_tool_sections( context, section ):
     host = context.trans.request.host
     # Core tools used by all virtual hosts.
     valid_sections = [ "text_manipulation", "get_data", "collection_operations", "convert_formats", "filter_and_sort", "join,_subtract_and_group" ]
-    general_ngs_sections = [ "deeptools", "bed_tools", "operate_on_genomic_intervals", "fasta_fastq_manipulation", "quality_control", "picard", "mapping" ]
+    general_ngs_sections = [ "deeptools", "bed_tools", "operate_on_genomic_intervals", "fasta/fastq_manipulation", "quality_control", "picard", "mapping" ]
     # HiCtools mode: published in NAR 2018
     if "hicexplorer.usegalaxy.eu" in host:
         valid_sections += general_ngs_sections


### PR DESCRIPTION
This section is not displayed in any of subdomains

Example for rna.usegalaxy.eu:
![screenshot 2019-01-30 at 16 53 08](https://user-images.githubusercontent.com/1842467/51993644-89b92600-24af-11e9-852c-5f77564f8ced.png)
