### PR TITLE
specify cmsearch core option

### DIFF
--- a/files/galaxy/dynamic_rules/usegalaxy/tool_destinations.yaml
+++ b/files/galaxy/dynamic_rules/usegalaxy/tool_destinations.yaml
@@ -498,6 +498,7 @@ hmmer_hmmsearch: {mem: 10}
 htseq_count: {mem: 32}
 humann2: {mem: 16}
 infernal_cmbuild: {cores: 10, mem: 20}
+infernal_cmsearch: {cores: 10, mem: 20}
 interproscan: {cores: 12, mem: 40}
 iqtree: {cores: 12}
 iterative_map_pipeline: {mem: 60}


### PR DESCRIPTION
Due to the high overload of the tool on quasi large entries if  not paralleled.
Merci adimins!