### PR TITLE
Reorganises SC tools for Human Cell Atlas subsite

### DIFF
--- a/templates/galaxy/config/global_host_filters.py.j2
+++ b/templates/galaxy/config/global_host_filters.py.j2
@@ -60,7 +60,9 @@ DOMAIN_SECTIONS = {
     'singlecell': GENERAL_NGS_SECTIONS + ["rna_seq", "annotation",
         "graph_display_data", "single_cell"],
     'humancellatlas': GENERAL_NGS_SECTIONS + ["rna_seq", "annotation",
-        "graph_display_data", "single_cell", "hca_single_cell"],
+        "graph_display_data", "single_cell", 'hca_sc_seurat_tools', 'hca_sc_sc3_tools', 
+                      'hca_sc_scanpy_tools', 'hca_sc_monocle3_tools', 
+                      'hca_sc_scmap_tools', 'hca_sc_sccaf_tools', 'hca_sc_utils_viz'],
     'clipseq': GENERAL_NGS_SECTIONS + ["rna_seq", "peak_calling",
         "motif_tools"],
     'graphclust': GENERAL_NGS_SECTIONS + ["rna_seq", "graphclust"],
@@ -86,7 +88,9 @@ def per_host_tool_sections( context, section ):
     subdomain = host.replace('.usegalaxy.eu', '')
 
     # hide HCA tools from other subdomains than humancellatlas, do not confuse users by duplicated tools
-    if section.id in ['hca_single_cell']:
+    if section.id in ['hca_sc_seurat_tools', 'hca_sc_sc3_tools', 
+                      'hca_sc_scanpy_tools', 'hca_sc_monocle3_tools', 
+                      'hca_sc_scmap_tools', 'hca_sc_sccaf_tools', 'hca_sc_utils_viz']:
         if 'humancellatlas' in host:
             return True
         else:

--- a/templates/galaxy/config/tool_conf.xml.j2
+++ b/templates/galaxy/config/tool_conf.xml.j2
@@ -260,8 +260,25 @@
     </section>
   <section id="single_cell" name="Single-cell">
   </section>
-  <section id="hca_single_cell" name="HCA-Single Cell">
+  <!-- HCA Single Cell tools -->
+  <section id="hca_sc_get-scrna" name="Get scRNAseq data">
   </section>
+  <section id="hca_sc_seurat_tools" name="Seurat">
+  </section>
+  <section id="hca_sc_sc3_tools" name="SC3">
+  </section>
+  <section id="hca_sc_scanpy_tools" name="Scanpy">
+  </section>	
+  <section id="hca_sc_monocle3_tools" name="Monocl3">
+  </section>	
+  <section id="hca_sc_scmap_tools" name="SCMap">
+  </section>	
+  <section id="hca_sc_scmap_tools" name="SCCAF">
+  </section>
+  <section id="hca_sc_utils_viz" name="Single Cell Utils & Viz">
+  </section>
+  
+  
 
   <label id="genomics_toolkits_label" text="Genomics Toolkits"/>
   <section id="picard" name="Picard" version="">

--- a/templates/galaxy/config/tool_conf.xml.j2
+++ b/templates/galaxy/config/tool_conf.xml.j2
@@ -273,7 +273,7 @@
   </section>	
   <section id="hca_sc_scmap_tools" name="SCMap">
   </section>	
-  <section id="hca_sc_scmap_tools" name="SCCAF">
+  <section id="hca_sc_sccaf_tools" name="SCCAF">
   </section>
   <section id="hca_sc_utils_viz" name="Single Cell Utils & Viz">
   </section>


### PR DESCRIPTION
This exposes better the single cell tools developed for HCA on that subsite. It also activates the hiding of the new section ids introduced here, so that they don't interfere with what is being shown in other use-galaxy.eu sites.

This needs to be merged in conjunction with https://github.com/usegalaxy-eu/usegalaxy-eu-tools/pull/236