### PR TITLE
Increase gmx cores again

### DIFF
--- a/files/galaxy/dynamic_rules/usegalaxy/tool_destinations.yaml
+++ b/files/galaxy/dynamic_rules/usegalaxy/tool_destinations.yaml
@@ -141,9 +141,9 @@ InternalCalibration: {cores: 4, mem: 8}
 IsobaricAnalyzer: {cores: 4, mem: 8}
 LabeledEval: {cores: 4, mem: 8}
 # maker: {cores: 8, mem: 8, runner: remote_cluster_mq_be01}
-gmx_sim: {cores: 12, mem: 2}
-gmx_em: {cores: 12, mem: 2}
-gmx_fep: {cores: 12, mem: 2}
+gmx_sim: {cores: 16, mem: 8}
+gmx_em: {cores: 16, mem: 8}
+gmx_fep: {cores: 16, mem: 8}
 
 # gmx_md: {runner: remote_cluster_mq_de02}
 # gmx_merge_topology_files: {runner: remote_cluster_mq_de02}


### PR DESCRIPTION
GB has 80 nodes with 16 cores each so may as well increase this to 16.