### PR TITLE
changed memory allocation for peptide shaker

### DIFF
--- a/files/galaxy/dynamic_rules/usegalaxy/tool_destinations.yaml
+++ b/files/galaxy/dynamic_rules/usegalaxy/tool_destinations.yaml
@@ -634,8 +634,8 @@ peakachu: {mem: 16}
 peptide_shaker:
   cores: 12
   env:
-    _JAVA_OPTIONS: -XX:MaxPermSize=2G -Xmx32G -Xms1G -Djava.io.tmpdir=/data/2/galaxy_db/tmp
-  mem: 32
+    _JAVA_OPTIONS: -XX:MaxPermSize=4G -Xmx64G -Xms4G -Djava.io.tmpdir=/data/2/galaxy_db/tmp
+  mem: 64
   name: _special
 picard_ARRG: {mem: 12}
 picard_AddOrReplaceReadGroups: {mem: 12}


### PR DESCRIPTION
Updated following lines for "peptide_shaker"
    _JAVA_OPTIONS: -XX:MaxPermSize=4G -Xmx64G -Xms4G -Djava.io.tmpdir=/data/2/galaxy_db/tmp
mem: 64

changed "-XX:MaxPermSize=2G -Xmx32G -Xms1G" to "-XX:MaxPermSize=4G -Xmx64G -Xms4G";