### PR TITLE
Adds sc get scrna section for SCXA and HCA retrieval

### DIFF
--- a/templates/galaxy/config/global_host_filters.py.j2
+++ b/templates/galaxy/config/global_host_filters.py.j2
@@ -62,7 +62,7 @@ DOMAIN_SECTIONS = {
         "graph_display_data", "single-cell"],
     'humancellatlas': GENERAL_NGS_SECTIONS + ["rna_seq", "annotation",
         "graph_display_data", "single-cell", 'hca_sc_seurat_tools', 'hca_sc_sc3_tools', 
-                      'hca_sc_scanpy_tools', 'hca_sc_monocle3_tools', 
+                      'hca_sc_scanpy_tools', 'hca_sc_monocle3_tools', 'hca_sc_get-scrna',
                       'hca_sc_scmap_tools', 'hca_sc_sccaf_tools', 'hca_sc_utils_viz'],
     'clipseq': GENERAL_NGS_SECTIONS + ["rna_seq", "peak_calling",
         "motif_tools"],


### PR DESCRIPTION
The section id for the download modules for SCXA and HCA was missing in the humancellatlas part in the filters.