### PR TITLE
Corrects repeated fasta_fastq_manipulation in GENERAL_NGS_SECTION

### DIFF
--- a/templates/galaxy/config/global_host_filters.py.j2
+++ b/templates/galaxy/config/global_host_filters.py.j2
@@ -40,7 +40,7 @@ BASE_SECTIONS = ["text_manipulation", "get_data", "collection_operations",
 
 GENERAL_NGS_SECTIONS = ["deeptools", "bed",
         "operate_on_genomic_intervals", "fasta_fastq_manipulation",
-        "fasta_fastq_manipulation", "fastq_quality_control",
+        "fasta_fastq", "fastq_quality_control",
         "picard", "mapping"]
 
 DOMAIN_SECTIONS = {


### PR DESCRIPTION
and adds fasta_fastq to general NGS section.

This should fix in particular https://github.com/usegalaxy-eu/issues/issues/263 and possibly in other flavours as well.