### PR TITLE
add assign_with="db-preassign" to workflow handler

### DIFF
--- a/templates/galaxy/config/galaxy_workflow_scheduler.j2
+++ b/templates/galaxy/config/galaxy_workflow_scheduler.j2
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
-    <workflow_schedulers default="core">
+<workflow_schedulers default="core">
     <core id="core" />
-    <handlers default="schedulers">
+    <handlers assign_with="db-preassign" default="schedulers">
 {% for n in range(galaxy_workflow_scheduler_count) %}
         <handler id="workflow_scheduler_{{ galaxy_instance_codename }}_{{ n }}" tags="schedulers"/>
 {% endfor %}


### PR DESCRIPTION
According to @natefoo in https://github.com/galaxyproject/galaxy/issues/8209

It's still not clear to my why this is not the default as it should be.