### PR TITLE
increase check_job_script_integrity_count

### DIFF
--- a/group_vars/gxconfig.yml
+++ b/group_vars/gxconfig.yml
@@ -427,7 +427,8 @@ base_app_main: &BASE_APP_MAIN
 
   # Number of checks to execute if check_job_script_integrity is
   # enabled.
-  #check_job_script_integrity_count: 35
+  # retry harder, can be hopefully reverted with 20.05 and the new job_script location
+  check_job_script_integrity_count: 70
 
   # Time to sleep between checks if check_job_script_integrity is
   # enabled (in seconds).


### PR DESCRIPTION
With the new job_script location I see very rarely, but I see in large workflows with 1000 jobs in parallel, that the job file can not be written. Try harder.

This can hopefully be removed once we write the job scripts to the working_dir in 20.05.