### PR TITLE
Update tool_destinations.yaml

### DIFF
--- a/files/galaxy/dynamic_rules/usegalaxy/tool_destinations.yaml
+++ b/files/galaxy/dynamic_rules/usegalaxy/tool_destinations.yaml
@@ -540,7 +540,7 @@ featurecounts: {cores: 8, mem: 18}
 feebayes: {cores: 10, mem: 12}
 flashlfq:
   env:
-    MONO_GC_PARAMS: max-heap-size=32g
+    MONO_GC_PARAMS: max-heap-size=64g
   mem: 64
 flexbar: {cores: 10, mem: 12}
 flexbar_no_split: {cores: 10, mem: 12}


### PR DESCRIPTION
Increased max-heap-size of Mono during FlashLFQ from 32g to 64g due to OutOfMemory by Mono (assertation based SIGABRT).