### PR TITLE
add new extended metadata strategy

### DIFF
--- a/files/galaxy-test/config/object_store_conf.xml
+++ b/files/galaxy-test/config/object_store_conf.xml
@@ -1,10 +1,17 @@
 <?xml version="1.0"?>
 <object_store type="distributed" id="primary" order="0">
     <backends>
-        <backend id="testserver" type="disk" weight="1" metadata_strategy="extended">
+        <backend id="testserver" type="disk" weight="0">
             <files_dir path="/data/dnb01/galaxy_db/files-test"/>
             <extra_dir type="temp" path="/data/dnb01/galaxy_db/tmp-test"/>
             <extra_dir type="job_work" path="/data/dnb01/galaxy_db/job_working_directory-test"/>
+        </backend>
+    </backends>
+    <backends>
+        <backend id="testserver" type="disk" weight="1" metadata_strategy="extended">
+            <files_dir path="/data/dnb03/galaxy_db/test/files"/>
+            <extra_dir type="temp" path="/data/dnb03/galaxy_db/test/tmp"/>
+            <extra_dir type="job_work" path="/data/dnb03/galaxy_db/test/job_working_directory"/>
         </backend>
     </backends>
 </object_store>

--- a/files/galaxy-test/config/object_store_conf.xml
+++ b/files/galaxy-test/config/object_store_conf.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <object_store type="distributed" id="primary" order="0">
     <backends>
-        <backend id="testserver" type="disk" weight="1">
+        <backend id="testserver" type="disk" weight="1" metadata_strategy="extended">
             <files_dir path="/data/dnb01/galaxy_db/files-test"/>
             <extra_dir type="temp" path="/data/dnb01/galaxy_db/tmp-test"/>
             <extra_dir type="job_work" path="/data/dnb01/galaxy_db/job_working_directory-test"/>

--- a/group_vars/gxconfig-test.yml
+++ b/group_vars/gxconfig-test.yml
@@ -544,7 +544,8 @@ base_app_main: &BASE_APP_MAIN
   # on how the object store is configured, starting with 20.05 Galaxy
   # will try to default to 'uuid' if it can be sure this is a new Galaxy
   # instance - but the default will be 'id' in many cases.
-  #object_store_store_by: null
+  # Not strictly needed since 20.05, but be better explicit here.
+  object_store_store_by: uuid
 
   # Galaxy sends mail for various things: subscribing users to the
   # mailing list if they request it, password resets, reporting dataset


### PR DESCRIPTION
It would be nice to enable this one. In production, we will disable an old object store and start a new one with this setting (dnb03).

background: https://github.com/galaxyproject/galaxy/pull/8930