### PR TITLE
Update tool_destinations.yaml

### DIFF
--- a/files/galaxy/dynamic_rules/usegalaxy/tool_destinations.yaml
+++ b/files/galaxy/dynamic_rules/usegalaxy/tool_destinations.yaml
@@ -125,7 +125,7 @@ nanopolish_methylation: {cores: 5, mem: 12}
 nanopolish_variants: {cores: 5, mem: 12}
 nanopolish_eventalign: {cores: 5, mem: 12}
 nanopolishcomp_eventaligncollapse: {cores: 10, mem: 12}
-nanocompore_sampcomp: {cores: 20, mem: 32}
+nanocompore_sampcomp: {cores: 4, mem: 32}
 AccurateMassSearch: {cores: 4, mem: 8}
 AdditiveSeries: {cores: 20, mem: 12}
 # augustus: {runner: remote_cluster_mq_be01}

--- a/files/galaxy/dynamic_rules/usegalaxy/tool_destinations.yaml
+++ b/files/galaxy/dynamic_rules/usegalaxy/tool_destinations.yaml
@@ -125,7 +125,7 @@ nanopolish_methylation: {cores: 5, mem: 12}
 nanopolish_variants: {cores: 5, mem: 12}
 nanopolish_eventalign: {cores: 5, mem: 12}
 nanopolishcomp_eventaligncollapse: {cores: 10, mem: 12}
-nanocompore_sampcomp: {cores: 4, mem: 32}
+nanocompore_sampcomp: {cores: 8, mem: 32}
 AccurateMassSearch: {cores: 4, mem: 8}
 AdditiveSeries: {cores: 20, mem: 12}
 # augustus: {runner: remote_cluster_mq_be01}


### PR DESCRIPTION
SampComp step is running very slowly. This could be due to the overloaded number of threads that was set 2 days ago.