### PR TITLE
Sampcomp ncores

### DIFF
--- a/files/galaxy/dynamic_rules/usegalaxy/tool_destinations.yaml
+++ b/files/galaxy/dynamic_rules/usegalaxy/tool_destinations.yaml
@@ -126,7 +126,7 @@ nanopolish_methylation: {cores: 5, mem: 12}
 nanopolish_variants: {cores: 5, mem: 12}
 nanopolish_eventalign: {cores: 5, mem: 12}
 nanopolishcomp_eventaligncollapse: {cores: 10, mem: 12}
-nanocompore_sampcomp: {mem: 48}
+nanocompore_sampcomp: {cores:9, mem: 48}
 AccurateMassSearch: {cores: 4, mem: 8}
 AdditiveSeries: {cores: 20, mem: 12}
 # augustus: {runner: remote_cluster_mq_be01}


### PR DESCRIPTION
Since the Sampcomp run issue was traced back to the conda package, let's add some cores to check if they can help in the case of multiple replication. 