### PR TITLE
Update tool_destinations.yaml

### DIFF
--- a/files/galaxy/dynamic_rules/usegalaxy/tool_destinations.yaml
+++ b/files/galaxy/dynamic_rules/usegalaxy/tool_destinations.yaml
@@ -102,6 +102,10 @@ pilon:
   mem: 32
   env:
     _JAVA_OPTIONS: -Xmx32G -Xms1G
+vardict_java:
+  mem: 32
+  env:
+    _JAVA_OPTIONS: -Xmx32G -Xms1G
 
 cuffmerge: {mem: 8}
 bio3d_pca: {mem: 64}


### PR DESCRIPTION
VarDict fails with
```
Exception in thread "main" java.lang.OutOfMemoryError: Java heap space
	at java.base/java.util.Arrays.copyOf(Arrays.java:3689)
	at java.base/java.util.ArrayList.grow(ArrayList.java:238)
	at java.base/java.util.ArrayList.grow(ArrayList.java:243)
	at java.base/java.util.ArrayList.add(ArrayList.java:486)
	at java.base/java.util.ArrayList.add(ArrayList.java:499)
	at com.astrazeneca.vardict.data.ReferenceResource.addPositionsToSeedSequence(ReferenceResource.java:144)
	at com.astrazeneca.vardict.data.ReferenceResource.getReference(ReferenceResource.java:120)
	at com.astrazeneca.vardict.data.ReferenceResource.getReference(ReferenceResource.java:74)
	at com.astrazeneca.vardict.modes.AbstractMode.tryToGetReference(AbstractMode.java:153)
	at com.astrazeneca.vardict.modes.SomaticMode.notParallel(SomaticMode.java:48)
	at com.astrazeneca.vardict.VarDictLauncher.start(VarDictLauncher.java:65)
	at com.astrazeneca.vardict.Main.main(Main.java:15)
```
