### PR TITLE
[WIP] batch-remove gops tools from Text Manipulation section

### DIFF
--- a/templates/galaxy/config/global_host_filters.py.j2
+++ b/templates/galaxy/config/global_host_filters.py.j2
@@ -52,7 +52,7 @@ DOMAIN_SECTIONS = {
     'hicexplorer': GENERAL_NGS_SECTIONS + ["hicexplorer", "graph_display_data", "peak_calling"],
     'virology': GENERAL_NGS_SECTIONS + ["assembly", "annotation", "phylogenetics"],
     'nanopore': GENERAL_NGS_SECTIONS + ["nanopore", "ncbi_blast", "fasta_fastq", "assembly", "graph_display_data"],
-    'ecology': ["join__subtract_and_group", "statistics", "graph_display_data",
+    'ecology': ["operate_on_genomic_intervals", "join__subtract_and_group", "statistics", "graph_display_data",
         "ncbi_blast", "fasta_fastq", "fastq_quality_control", "assembly", "dna_metabarcoding", "metagenomic_analysis",
         "mothur", "qiime", "rad_seq", "animal_detection_on_acoustic_recordings","species_abundance",
         "gis_data_handling", "climate_analysis", "interactivetools"],


### PR DESCRIPTION
First step, add the `operate_on_genomic_intervals` section to the ecology subdomain cause the tools would otherwise get lost there.