### PR TITLE
reactivate geoexplorer, radiant and Wallace ecology related IT

### DIFF
--- a/templates/galaxy/config/tool_conf.xml.j2
+++ b/templates/galaxy/config/tool_conf.xml.j2
@@ -520,6 +520,9 @@
 	<tool file="interactive/interactivetool_panoply.xml" />
 	<tool file="interactive/interactivetool_askomics.xml" />
 	<tool file="interactive/interactivetool_cellxgene.xml" />
+	<tool file="interactive/interactivetool_wallace.xml" />
+	<tool file="interactive/interactivetool_geoexplorer.xml" />
+	<tool file="interactive/interactivetool_radiant.xml" />
 	<!--tool file="interactive/interactivetool_bam_iobio.xml" />
 	<tool file="interactive/interactivetool_vcf_iobio.xml" />	
 	<tool file="interactive/interactivetool_neo4j.xml" />
@@ -527,9 +530,6 @@
 	<tool file="interactive/interactivetool_paraview.xml" />
 	<tool file="interactive/interactivetool_askomics.xml" />
 	<tool file="interactive/interactivetool_wilson.xml" />
-	<tool file="interactive/interactivetool_wallace.xml" />
-	<tool file="interactive/interactivetool_geoexplorer.xml" />
-	<tool file="interactive/interactivetool_radiant.xml" />
 	<tool file="interactive/codingSnps.xml" />
 	<tool file="interactive/interactivetool_ethercalc.xml" /-->
   </section>


### PR DESCRIPTION
For sure there is good reasons these Galaxy IT are disable, so here is a manner to discuss about that and to see how we can update theses Galaxy IT if needed