### PR TITLE
Increase RAM for prosit csv to dlib tool

### DIFF
--- a/files/galaxy/dynamic_rules/usegalaxy/tool_destinations.yaml
+++ b/files/galaxy/dynamic_rules/usegalaxy/tool_destinations.yaml
@@ -117,7 +117,7 @@ pilon:
 encyclopedia_prosit_csv_to_library:
   mem: 128
   env:
-    _JAVA_OPTIONS: -Xmx64G -Xms1G
+    _JAVA_OPTIONS: -Xmx128G -Xms1G
 
 vardict_java:
   mem: 512

--- a/files/galaxy/dynamic_rules/usegalaxy/tool_destinations.yaml
+++ b/files/galaxy/dynamic_rules/usegalaxy/tool_destinations.yaml
@@ -115,7 +115,7 @@ pilon:
     _JAVA_OPTIONS: -Xmx32G -Xms1G
 
 encyclopedia_prosit_csv_to_library:
-  mem: 64
+  mem: 128
   env:
     _JAVA_OPTIONS: -Xmx64G -Xms1G
 


### PR DESCRIPTION
The tool failed in galaxy due to max memory error.
Please increase the allocated memory for this tool.

Cheers and thank you
Matthias