### PR TITLE
Change RAM for prsoti csv to dlib tool

### DIFF
--- a/files/galaxy/dynamic_rules/usegalaxy/tool_destinations.yaml
+++ b/files/galaxy/dynamic_rules/usegalaxy/tool_destinations.yaml
@@ -117,7 +117,7 @@ pilon:
 encyclopedia_prosit_csv_to_library:
   mem: 40
   env:
-    _JAVA_OPTIONS: -Xmx512G -Xms1G
+    _JAVA_OPTIONS: -Xmx40G -Xms1G
 
 vardict_java:
   mem: 512

--- a/files/galaxy/dynamic_rules/usegalaxy/tool_destinations.yaml
+++ b/files/galaxy/dynamic_rules/usegalaxy/tool_destinations.yaml
@@ -115,7 +115,7 @@ pilon:
     _JAVA_OPTIONS: -Xmx32G -Xms1G
 
 encyclopedia_prosit_csv_to_library:
-  mem: 512
+  mem: 40
   env:
     _JAVA_OPTIONS: -Xmx512G -Xms1G
 


### PR DESCRIPTION
Noticed that with the correct inputs the RAM usage for a complete human predicted csv to dlib is about 35 GB RAM.
40 GB RAM would be enough for this tool to run most of the intended jobs.