### PR TITLE
set propper telegraf hostname

### DIFF
--- a/group_vars/galaxy.yml
+++ b/group_vars/galaxy.yml
@@ -12,6 +12,7 @@ usegalaxy_eu_autofs_mounts:
 
 # Telegraf
 custom_telegraf_env: "/usr/bin/env GDPR_MODE=1 PGUSER=galaxy PGHOST=sn03.bi.uni-freiburg.de GALAXY_ROOT=/opt/galaxy/server GALAXY_CONFIG_FILE=/opt/galaxy/config/galaxy.ini GALAXY_LOG_DIR=/var/log/galaxy/ GXADMIN_PYTHON=/opt/galaxy/venv/bin/python"
+telegraf_agent_hostname: "sn06.galaxyproject.eu"
 telegraf_plugins_extra:
   postgres:
     plugin: "postgresql"

--- a/group_vars/galaxy.yml
+++ b/group_vars/galaxy.yml
@@ -91,6 +91,13 @@ telegraf_plugins_extra:
       - timeout = "15s"
       - data_format = "influx"
       - interval = "1m"
+  galaxy_jobs_queue_overview:
+    plugin: "exec"
+    config:
+      - commands = ["{{ custom_telegraf_env }} /usr/bin/gxadmin iquery queue-overview --short-tool-id"]
+      - timeout = "15s"
+      - data_format = "influx"
+      - interval = "1m"
   galaxy_oidc:
     plugin: "exec"
     config:


### PR DESCRIPTION
I hope this is the correct spot to set this variable. In the end what I want is to set this hostname in /etc/telegraf/telegraf.conf 