### PR TITLE
Add spanish, localize

### DIFF
--- a/files/galaxy-test/config/user_preferences_extra_conf.yml
+++ b/files/galaxy-test/config/user_preferences_extra_conf.yml
@@ -18,10 +18,11 @@ preferences:
               required: False
               options:
                   - [Navigator default, auto]
-                  - [Chinese, zh]
+                  - [中文, zh]
                   - [English, en]
-                  - [French, fr]
-                  - [Japanese, ja]
+                  - [Español, es]
+                  - [Français, fr]
+                  - [日本語, ja]
 
     distributed_compute:
         description: Use distributed compute resources

--- a/files/galaxy/config/user_preferences_extra_conf.yml
+++ b/files/galaxy/config/user_preferences_extra_conf.yml
@@ -18,10 +18,11 @@ preferences:
               required: False
               options:
                   - [Navigator default, auto]
-                  - [Chinese, zh]
+                  - [中文, zh]
                   - [English, en]
-                  - [French, fr]
-                  - [Japanese, ja]
+                  - [Español, es]
+                  - [Français, fr]
+                  - [日本語, ja]
 
     distributed_compute:
         description: Use distributed compute resources
@@ -74,7 +75,7 @@ preferences:
               label: Dropbox access token
               type: password
               required: False
-              
+
     b2drop:
         description: Your B2DROP account (https://b2drop.eudat.eu/)
         inputs:


### PR DESCRIPTION
Spanish was missing from this list (thanks @nomadscientist @shiltemann) but it is included in the Galaxy codebase. Additionally it's best practice to localise these to their native languages.