### PR TITLE
Update apollo 2.5.0 -> 2.6.3

### DIFF
--- a/group_vars/apollo.yml
+++ b/group_vars/apollo.yml
@@ -27,7 +27,7 @@ tomcat7_catalina_port: 8080
 tomcat7_ajp_port: 8009
 tomcat7_uriencoding: ""
 
-apollo_version: eu-2.5.0
+apollo_version: eu-2.6.3
 
 apollo_config_apollo: |
     extraTabs = [
@@ -38,7 +38,7 @@ apollo_config_jbrowse: |
     jbrowse {
         git {
             url= "https://github.com/GMOD/jbrowse"
-            tag = "1.16.6-release"
+            tag = "1.16.10-release"
             alwaysPull = true
             alwaysRecheck = true
         }


### PR DESCRIPTION
Hi!
I think that's the way to update apollo on usegalaxy.eu...
I always feel nervous updating apollo, this time the biggest UI change is "Remove popups for annotations in favor of annotator panel" since 2.6.0

ping @hexylena 