### PR TITLE
Increase rnaSPAdes RAM memory

### DIFF
--- a/files/galaxy/dynamic_rules/usegalaxy/tool_destinations.yaml
+++ b/files/galaxy/dynamic_rules/usegalaxy/tool_destinations.yaml
@@ -1008,7 +1008,7 @@ spades: {cores: 20, mem: 400}
 spyboat: {cores: 8, mem: 4}
 sshmm: {mem: 16}
 structurefold: {mem: 12}
-rnaspades: {cores: 10, mem: 90}
+rnaspades: {cores: 10, mem: 300}
 stringtie: {mem: 25}
 t_coffee:
   mem: 100


### PR DESCRIPTION
This PR has been created because one of the user processes needs 280 GB of RAM.