### PR TITLE
lower_memory requirement of spades

### DIFF
--- a/files/galaxy/dynamic_rules/usegalaxy/tool_destinations.yaml
+++ b/files/galaxy/dynamic_rules/usegalaxy/tool_destinations.yaml
@@ -1027,11 +1027,11 @@ snpSift_caseControl: {mem: 12}
 snpSift_filter: {mem: 18}
 snpSift_geneSets: {mem: 12}
 snpSift_int: {mem: 12}
-spades: {cores: 20, mem: 120}
+spades: {cores: 20, mem: 110}
 spyboat: {cores: 8, mem: 4}
 sshmm: {mem: 16}
 structurefold: {mem: 12}
-rnaspades: {cores: 10, mem: 120}
+rnaspades: {cores: 10, mem: 110}
 stringtie: {mem: 25}
 t_coffee:
   mem: 100

--- a/files/galaxy/dynamic_rules/usegalaxy/tool_destinations.yaml
+++ b/files/galaxy/dynamic_rules/usegalaxy/tool_destinations.yaml
@@ -1027,11 +1027,11 @@ snpSift_caseControl: {mem: 12}
 snpSift_filter: {mem: 18}
 snpSift_geneSets: {mem: 12}
 snpSift_int: {mem: 12}
-spades: {cores: 20, mem: 400}
+spades: {cores: 20, mem: 120}
 spyboat: {cores: 8, mem: 4}
 sshmm: {mem: 16}
 structurefold: {mem: 12}
-rnaspades: {cores: 10, mem: 300}
+rnaspades: {cores: 10, mem: 120}
 stringtie: {mem: 25}
 t_coffee:
   mem: 100


### PR DESCRIPTION
```
# NumSamples = 15106; Min = 0.09; Max = 994.07
# Mean = 40.201291; Variance = 12377.015830; SD = 111.252037; Median 8.773700
# each ∎ represents a count of 183
    0.0941 -    99.4913 [ 13759]: ∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎ (91.08%)
   99.4913 -   198.8885 [   484]: ∎∎ (3.20%)
  198.8885 -   298.2857 [   288]: ∎ (1.91%)
  298.2857 -   397.6829 [   124]:  (0.82%)
  397.6829 -   497.0801 [   134]:  (0.89%)
  497.0801 -   596.4772 [    97]:  (0.64%)
  596.4772 -   695.8744 [    99]:  (0.66%)
  695.8744 -   795.2716 [    81]:  (0.54%)
  795.2716 -   894.6688 [    12]:  (0.08%)
  894.6688 -   994.0660 [    28]:  (0.19%)
``