### PR TITLE
Add permapol as a tab in apollo

### DIFF
--- a/group_vars/apollo.yml
+++ b/group_vars/apollo.yml
@@ -31,6 +31,7 @@ apollo_version: eu-2.6.4
 
 apollo_config_apollo: |
     extraTabs = [
+        ['title': 'Sharing', 'url': 'https://usegalaxy.eu/apollo-permapol/'],
         ['title': 'GGA', 'url': 'https://gitter.im/galaxy-genome-annotation/Lobby/~embed']
     ]
 


### PR DESCRIPTION
Looking at #295 I guess the url will be https://usegalaxy.eu/apollo-permapol/