### PR TITLE
Added the possibility to have C3S API key in Galaxy (Climate)

### DIFF
--- a/files/galaxy/config/user_preferences_extra_conf.yml
+++ b/files/galaxy/config/user_preferences_extra_conf.yml
@@ -117,5 +117,5 @@ preferences:
         inputs:
             - name: c3s_cds_apikey
               label: C3S CDS API Key
-              type: text
+              type: password
               required: True

--- a/files/galaxy/config/user_preferences_extra_conf.yml
+++ b/files/galaxy/config/user_preferences_extra_conf.yml
@@ -111,3 +111,11 @@ preferences:
               label: Password
               type:  password
               required: False
+
+    c3s_account:
+        description: Your CDS API Key (Copernicus Climate Change Service API Key)
+        inputs:
+            - name: c3s_cds_apikey
+              label: C3S CDS API Key
+              type: text
+              required: True


### PR DESCRIPTION
- For accessing Copernicus Climate Change Services (C3S) and download data from https://cds.climate.copernicus.eu/ 
- I am not sure about `required`. I set it to `true` because C3S API key is required for c3s climate tool but of course users who are not interested in climate should not have to fill anything.
