### PR TITLE
set resources for CESM (climate tool)

### DIFF
--- a/files/galaxy/dynamic_rules/usegalaxy/tool_destinations.yaml
+++ b/files/galaxy/dynamic_rules/usegalaxy/tool_destinations.yaml
@@ -1084,6 +1084,8 @@ velveth:
   name: _velveth
 vsearch_search: {mem: 80}
 
+# Climate tool
+cesm: {cores: 16, mem: 128}
 
 # Some admin tools
 echo_main_env:


### PR DESCRIPTION
Set 16 cores and 128GB. 

I was not sure where to set it in the file. 