### PR TITLE
add Copernicus ADS user credentials on Galaxy

### DIFF
--- a/files/galaxy/config/user_preferences_extra_conf.yml
+++ b/files/galaxy/config/user_preferences_extra_conf.yml
@@ -119,3 +119,11 @@ preferences:
               label: C3S CDS API Key
               type: password
               required: False
+
+    cads_account:
+        description: Your Copernicus ADS API Key (Copernicus Atmosphere Data Store API Key)
+        inputs:
+            - name: cads_apikey
+              label: Copernicus ADS API Key
+              type: password
+              required: False


### PR DESCRIPTION
so user can retrieve data from Copernicus Atmosphere Monitoring data (forecasts for polluants, pollens, etc.) e.g. tool added in Galaxy Climate.