### PR TITLE
Add genomic intervals tools to ecology

### DIFF
--- a/templates/galaxy/config/global_host_filters.py.j2
+++ b/templates/galaxy/config/global_host_filters.py.j2
@@ -55,7 +55,7 @@ DOMAIN_SECTIONS = {
     'hicexplorer': GENERAL_NGS_SECTIONS + ["hicexplorer", "graph_display_data", "peak_calling"],
     'virology': GENERAL_NGS_SECTIONS + ["assembly", "annotation", "phylogenetics"],
     'nanopore': GENERAL_NGS_SECTIONS + ["nanopore", "ncbi_blast", "fasta_fastq", "assembly", "graph_display_data", "metagenomic_analysis"],
-    'ecology': ["join__subtract_and_group", "statistics", "graph_display_data", "machine_learning",
+    'ecology': ["join__subtract_and_group", "operate_on_genomic_intervals", "statistics", "graph_display_data", "machine_learning",
         "ncbi_blast", "fasta_fastq", "fastq_quality_control", "assembly", "dna_metabarcoding", "metagenomic_analysis",
         "mothur", "qiime", "rad_seq", "animal_detection_on_acoustic_recordings","species_abundance",
         "gis_data_handling", "climate_analysis", "interactivetools"],


### PR DESCRIPTION
This will make it possible to move several gops tools into their native section without dropping them from the ecology subdomain.