### PR TITLE
CZ PULSAR: set the needed variables directly

### DIFF
--- a/files/galaxy/dynamic_rules/usegalaxy/destination_specifications.yaml
+++ b/files/galaxy/dynamic_rules/usegalaxy/destination_specifications.yaml
@@ -660,7 +660,10 @@ remote_cluster_mq_cz01:
     GALAXY_SLOTS: '{PARALLELISATION}'
     LC_ALL: C
     SINGULARITY_CACHEDIR: /storage/praha5-elixir/home/marten/pulsar/files/singularity_cache
-    file: /storage/praha5-elixir/home/marten/.galaxyrc.sh
+    SINGULARITY_TMPDIR: $SCRATCHDIR
+    TMPDIR: $SCRATCHDIR
+    TMP: $SCRATCHDIR
+    TEMP: $SCRATCHDIR
   params:
     priority: -{PRIORITY}
     submit_request_cpus: '{PARALLELISATION}'


### PR DESCRIPTION
the file-sourcing syntax does not seem to be supported here (or at least not like this) -- it ends up generating like so:
```sh
SINGULARITY_CACHEDIR="/storage/praha5-elixir/home/marten/pulsar/files/singularity_cache"; export SINGULARITY_CACHEDIR
file="/storage/praha5-elixir/home/marten/.galaxyrc.sh"; export file
```