### PR TITLE
biosynteticSPAdes: increase memory

### DIFF
--- a/files/galaxy/dynamic_rules/usegalaxy/tool_destinations.yaml
+++ b/files/galaxy/dynamic_rules/usegalaxy/tool_destinations.yaml
@@ -1090,7 +1090,7 @@ spyboat: {cores: 8, mem: 4}
 sshmm: {mem: 16}
 structurefold: {mem: 12}
 rnaspades: {cores: 10, mem: 110}
-spades_biosyntheticspades: {cores: 10, mem: 200}
+spades_biosyntheticspades: {cores: 10, mem: 330}
 spades_coronaspades: {cores: 10, mem: 110}
 spades_metaplasmidspades: {cores: 10, mem: 110}
 spades_metaviralspades: {cores: 10, mem: 110}

--- a/files/galaxy/dynamic_rules/usegalaxy/tool_destinations.yaml
+++ b/files/galaxy/dynamic_rules/usegalaxy/tool_destinations.yaml
@@ -1090,7 +1090,11 @@ spyboat: {cores: 8, mem: 4}
 sshmm: {mem: 16}
 structurefold: {mem: 12}
 rnaspades: {cores: 10, mem: 110}
-spades_biosyntheticspades: {cores: 10, mem: 330}
+spades_biosyntheticspades:
+  cores: 10
+  mem: 110
+  env:
+    GALAXY_MEMORY_GB: 110
 spades_coronaspades: {cores: 10, mem: 110}
 spades_metaplasmidspades: {cores: 10, mem: 110}
 spades_metaviralspades: {cores: 10, mem: 110}


### PR DESCRIPTION
It failed again with the message: `Out of memory error: Out of memory error occurred`.

- CPU Time | 1 hour and 32 minutes
- Failed to allocate memory count | 0
- Memory limit on cgroup (MEM) | 300.0 GB
- Max memory usage (MEM) | 14.6 GB
- Memory limit on cgroup (MEM+SWP) | 301.0 GB
- Max memory usage (MEM+SWP) | 14.6 GB
