### PR TITLE
BiosyntheticSPAdes: Increase memory

### DIFF
--- a/files/galaxy/dynamic_rules/usegalaxy/tool_destinations.yaml
+++ b/files/galaxy/dynamic_rules/usegalaxy/tool_destinations.yaml
@@ -1088,7 +1088,7 @@ structurefold: {mem: 12}
 rnaspades: {cores: 10, mem: 110}
 spades_biosyntheticspades:
   cores: 10
-  mem: 330
+  mem: 400
   env:
     GALAXY_MEMORY_GB: 330
 spades_coronaspades: {cores: 10, mem: 110}

--- a/files/galaxy/dynamic_rules/usegalaxy/tool_destinations.yaml
+++ b/files/galaxy/dynamic_rules/usegalaxy/tool_destinations.yaml
@@ -1090,7 +1090,7 @@ spades_biosyntheticspades:
   cores: 10
   mem: 400
   env:
-    GALAXY_MEMORY_GB: 330
+    GALAXY_MEMORY_GB: 400
 spades_coronaspades: {cores: 10, mem: 110}
 spades_metaplasmidspades: {cores: 10, mem: 330}
 spades_metaviralspades: {cores: 10, mem: 110}


### PR DESCRIPTION
It failed again with the message: `The reads contain too many k-mers to fit into available memory. You need approx. 333.69GB of free RAM to assemble your dataset`.

Memory limit on cgroup (MEM) | 327.1 GB
Max memory usage (MEM) | 321.4 GB
Memory limit on cgroup (MEM+SWP) | 327.1 GB
Max memory usage (MEM+SWP) | 321.4 GB

