### PR TITLE
try to fix "no space left on device bug"

### DIFF
--- a/files/galaxy/dynamic_rules/usegalaxy/tool_destinations.yaml
+++ b/files/galaxy/dynamic_rules/usegalaxy/tool_destinations.yaml
@@ -138,7 +138,9 @@ shasta: {cores: 10, mem: 12}
 msconvert: {runner: condor_docker}
 ## should be dynamically set, or lowered back to 250
 lumpy_sv: {mem: 8}
-lumpy_prep: {mem: 8}
+lumpy_prep:
+  runner: condor_singularity_with_conda
+  mem: 8
 
 pharmcat:
   runner: condor_docker


### PR DESCRIPTION
This tool is running `samtools collate` and this tool is writing to `/tmp/` and fails with `no space left on device`.

The idea here is to run this tool in a container. The Galaxy job-working-dir is then mounted into the container under `/tmp` and we can avoid this error. At least this is the idea.

@gallardoalba is trying to solve this on a tool level, but not clear if this is possible yet.

@gmauro what do you think?