### PR TITLE
Meryl: increase memory

### DIFF
--- a/files/galaxy/dynamic_rules/usegalaxy/tool_destinations.yaml
+++ b/files/galaxy/dynamic_rules/usegalaxy/tool_destinations.yaml
@@ -407,7 +407,7 @@ MzTabExporter: {cores: 4, mem: 8}
 QCCalculator: {mem: 8}
 OpenSwathWorkflow: {mem: 156}
 mira_assembler: {mem: 24}
-meryl: {cores: 24, mem: 110}
+meryl: {cores: 24, mem: 150}
 mothur_align_check: {cores: 1, mem: 20, env: {TERM: vt100}}
 mothur_align_seqs: {cores: 2, mem: 100, env: {TERM: vt100}}
 mothur_amova: {cores: 1, mem: 20, env: {TERM: vt100}}

--- a/files/galaxy/dynamic_rules/usegalaxy/tool_destinations.yaml
+++ b/files/galaxy/dynamic_rules/usegalaxy/tool_destinations.yaml
@@ -407,7 +407,7 @@ MzTabExporter: {cores: 4, mem: 8}
 QCCalculator: {mem: 8}
 OpenSwathWorkflow: {mem: 156}
 mira_assembler: {mem: 24}
-meryl: {cores: 24, mem: 150}
+meryl: {cores: 24, mem: 130}
 mothur_align_check: {cores: 1, mem: 20, env: {TERM: vt100}}
 mothur_align_seqs: {cores: 2, mem: 100, env: {TERM: vt100}}
 mothur_amova: {cores: 1, mem: 20, env: {TERM: vt100}}


### PR DESCRIPTION
It seems that 110 is currently a bottleneck when using > 20GB input FASTQ.

Dataset size: 29.9 GB
- CPU Time	47 hours and 54 minutes
- Failed to allocate memory count	5337065
- Memory limit on cgroup (MEM)	110.0 GB
- Max memory usage (MEM)	110.0 GB
-Memory limit on cgroup (MEM+SWP)	8.0 EB
- Max memory usage (MEM+SWP)	110.0 GB

Dataset size: 20.1 GB
- CPU Time	16 hours and 41 minutes
- Failed to allocate memory count	0
- Memory limit on cgroup (MEM)	110.0 GB
- Max memory usage (MEM)	107.0 GB
- Memory limit on cgroup (MEM+SWP)	8.0 EB
- Max memory usage (MEM+SWP)	107.0 GB