### PR TITLE
Increase memory BWA-MEM2

### DIFF
--- a/files/galaxy/dynamic_rules/usegalaxy/tool_destinations.yaml
+++ b/files/galaxy/dynamic_rules/usegalaxy/tool_destinations.yaml
@@ -657,7 +657,7 @@ blockclust: {mem: 10}
 bowtie2: {cores: 8, mem: 20}
 bwa: {cores: 8, mem: 20}
 bwa_mem: {cores: 8, mem: 30}
-bwa_mem2: {cores: 8, mem: 20}
+bwa_mem2: {cores: 8, mem: 30}
 bwa_mem_index_builder_data_manager: {cores: 12, mem: 48}
 bwameth_index_builder_data_manager: {cores: 12, mem: 48}
 kallisto_index_builder_data_manager: {cores: 12, mem: 92}


### PR DESCRIPTION

- CPU Time | 832 hours and 21 minutes
- Failed to allocate memory count | 2092589910
- Memory limit on cgroup (MEM) | 60.0 GB
- Max memory usage (MEM) | 70.1 GB
- Memory limit on cgroup (MEM+SWP) | 61.2 GB
- Max memory usage (MEM+SWP) | 70.1 GB
- OOM Control enabled | No
- Was OOM Killer active? | No
- Memory Allocated (MB) | 20480
- Job Start Time | 2022-02-26 13:00:49
- Job End Time | 2022-02-26 23:53:26
- Job Runtime (Wall Clock) | 10 hours and 52 minutes

