### PR TITLE
Metaspades: increase memory

### DIFF
--- a/files/galaxy/dynamic_rules/usegalaxy/tool_destinations.yaml
+++ b/files/galaxy/dynamic_rules/usegalaxy/tool_destinations.yaml
@@ -1132,7 +1132,11 @@ spyboat: {cores: 8, mem: 4}
 sshmm: {mem: 16}
 structurefold: {mem: 12}
 rnaspades: {cores: 10, mem: 110}
-spades_biosyntheticspades: {cores: 10, mem: 400}
+spades_biosyntheticspades:
+  cores: 10
+  mem: 400
+  env:
+    GALAXY_MEMORY_GB: 400
 spades_coronaspades: {cores: 10, mem: 110}
 spades_metaplasmidspades: {cores: 10, mem: 330}
 spades_metaviralspades: {cores: 10, mem: 110}

--- a/files/galaxy/dynamic_rules/usegalaxy/tool_destinations.yaml
+++ b/files/galaxy/dynamic_rules/usegalaxy/tool_destinations.yaml
@@ -678,7 +678,7 @@ mass_spectrometry_imaging_preprocessing: {mem: 110}
 mass_spectrometry_imaging_ion_images: {mem: 20}
 mass_spectrometry_imaging_qc: {mem: 110}
 mass_spectrometry_imaging_filtering: {mem: 20}
-metaspades: {cores: 10, mem: 200}
+metaspades: {cores: 10, mem: 250}
 megahit: {cores: 10, mem: 80}
 charts: {mem: 10}
 circgraph: {mem: 10}
@@ -1132,11 +1132,7 @@ spyboat: {cores: 8, mem: 4}
 sshmm: {mem: 16}
 structurefold: {mem: 12}
 rnaspades: {cores: 10, mem: 110}
-spades_biosyntheticspades:
-  cores: 10
-  mem: 400
-  env:
-    GALAXY_MEMORY_GB: 400
+spades_biosyntheticspades: {cores: 10, mem: 400}
 spades_coronaspades: {cores: 10, mem: 110}
 spades_metaplasmidspades: {cores: 10, mem: 330}
 spades_metaviralspades: {cores: 10, mem: 110}


### PR DESCRIPTION
This PR increases the memory up to 250 GB, which is the recommended default value according to [SPAdes documentation](http://cab.spbu.ru/files/release3.12.0/manual.html#:~:text=The%20default%20value%20is%2016.&text=Set%20memory%20limit%20in%20Gb,default%20value%20is%20250%20Gb.).