### PR TITLE
Add GISAID login details

### DIFF
--- a/files/galaxy/config/user_preferences_extra_conf.yml
+++ b/files/galaxy/config/user_preferences_extra_conf.yml
@@ -146,3 +146,15 @@ preferences:
               label: Copernicus ADS API Key
               type: password
               required: False
+
+    gisaid_account:
+        description: Your GISAID account details
+        inputs:
+            - name: username
+              label: GISAID username
+              type: text
+              required: False
+            - name: password
+              label: GISAID password
+              type: text
+              required: False


### PR DESCRIPTION
This adds GISAID username and password fields to the Manage Information section. This is necessary for a (future) GISAID upload tool.