### PR TITLE
Add gateway for keras_train_eval tool for choosing CPU or GPU

### DIFF
--- a/files/galaxy/dynamic_rules/usegalaxy/sorting_hat.py
+++ b/files/galaxy/dynamic_rules/usegalaxy/sorting_hat.py
@@ -595,24 +595,27 @@ def gateway_for_keras_train_eval(app, job, tool, user, next_dest=None):
         email = ''
         user_id = -1
 
+    # get default job destination parameters
     try:
         env, params, runner, spec, tags = _gateway(tool_id, user_preferences, user_roles, user_id, email)
     except Exception as e:
         return JobMappingException(str(e))
 
+    # set up to resubmit job in case of failure
     resubmit = []
     if next_dest:
         resubmit = [{
             'condition': 'any_failure and attempt <= 3',
             'destination': next_dest
         }]
-
     name = name_it(spec)
 
+    # assign dynamic runner based on user's input from tool wrapper
     if 'gpu' in param_dict:
         if param_dict['gpu'] == '1':
             runner = "condor_docker_ie_interactive_gpu"
 
+    # create dynamic destination rule
     return JobDestination(
         id=name,
         tags=tags,

--- a/files/galaxy/dynamic_rules/usegalaxy/sorting_hat.py
+++ b/files/galaxy/dynamic_rules/usegalaxy/sorting_hat.py
@@ -613,7 +613,8 @@ def gateway_for_keras_train_eval(app, job, tool, user, next_dest=None):
     # assign dynamic runner based on user's input from tool wrapper
     if 'gpu' in param_dict:
         if param_dict['gpu'] == '1':
-            runner = "condor_docker_ie_interactive_gpu"
+            params['requirements'] = 'GalaxyGroup == "compute_gpu"'
+            params['request_gpus'] = 1
 
     # create dynamic destination rule
     return JobDestination(

--- a/group_vars/sn06.yml
+++ b/group_vars/sn06.yml
@@ -720,6 +720,11 @@ galaxy_jobconf:
       params:
         type: python
         function: gateway_for_hifiasm
+    - id: gateway_for_keras_train_eval
+      runner: dynamic
+      params:
+        type: python
+        function: gateway_for_keras_train_eval
     # Pulsar MQs
     - id: remote_cluster_mq_cz
       runner: pulsar_eu_cz


### PR DESCRIPTION
This PR creates a gateway for dynamically choosing the compute resource (tu run on CPUs by default or GPU) to run `keras_train_eval` tool based on user's input from its wrapper. It is inspired from `gateway_for_hifiasm` method for `Hifiasm` tool that updates memory the tool requires based on user's input.

ping @gmauro 