### PR TITLE
Spades: increase memory in tools

### DIFF
--- a/files/galaxy/dynamic_rules/usegalaxy/tool_destinations.yaml
+++ b/files/galaxy/dynamic_rules/usegalaxy/tool_destinations.yaml
@@ -1142,7 +1142,7 @@ spades_biosyntheticspades:
     GALAXY_MEMORY_GB: 400
 spades_coronaspades: {cores: 10, mem: 250}
 spades_metaplasmidspades: {cores: 10, mem: 330}
-spades_metaviralspades: {cores: 10, mem: 2500}
+spades_metaviralspades: {cores: 10, mem: 250}
 spades_plasmidspades: {cores: 10, mem: 250}
 spades_rnaviralspades: {cores: 10, mem: 250}
 strelka_germline: {cores: 8, mem: 12}

--- a/files/galaxy/dynamic_rules/usegalaxy/tool_destinations.yaml
+++ b/files/galaxy/dynamic_rules/usegalaxy/tool_destinations.yaml
@@ -1134,17 +1134,17 @@ spades: {cores: 20, mem: 330}
 spyboat: {cores: 8, mem: 4}
 sshmm: {mem: 16}
 structurefold: {mem: 12}
-rnaspades: {cores: 10, mem: 110}
+rnaspades: {cores: 10, mem: 250}
 spades_biosyntheticspades:
   cores: 10
-  mem: 400
+  mem: 450
   env:
     GALAXY_MEMORY_GB: 400
-spades_coronaspades: {cores: 10, mem: 110}
+spades_coronaspades: {cores: 10, mem: 250}
 spades_metaplasmidspades: {cores: 10, mem: 330}
-spades_metaviralspades: {cores: 10, mem: 110}
-spades_plasmidspades: {cores: 10, mem: 110}
-spades_rnaviralspades: {cores: 10, mem: 110}
+spades_metaviralspades: {cores: 10, mem: 2500}
+spades_plasmidspades: {cores: 10, mem: 250}
+spades_rnaviralspades: {cores: 10, mem: 250}
 strelka_germline: {cores: 8, mem: 12}
 strelka_somatic: {cores: 8, mem: 12}
 stringtie: {mem: 25}

--- a/files/galaxy/dynamic_rules/usegalaxy/tool_destinations.yaml
+++ b/files/galaxy/dynamic_rules/usegalaxy/tool_destinations.yaml
@@ -1135,11 +1135,7 @@ spyboat: {cores: 8, mem: 4}
 sshmm: {mem: 16}
 structurefold: {mem: 12}
 rnaspades: {cores: 10, mem: 250}
-spades_biosyntheticspades:
-  cores: 10
-  mem: 450
-  env:
-    GALAXY_MEMORY_GB: 400
+spades_biosyntheticspades: {cores: 10, mem: 450}
 spades_coronaspades: {cores: 10, mem: 250}
 spades_metaplasmidspades: {cores: 10, mem: 330}
 spades_metaviralspades: {cores: 10, mem: 250}


### PR DESCRIPTION
This PR increases the memory of all SPAdes tools to 250 GB, which is the [default recommended value](https://github.com/ablab/spades#advanced-options). It is motivated by a recent error report from Saskia Hiltermann:

`Ran plasmidSPAdes on a relatively small dataset, but ran out of memory, misconfiguration, or assigned too small a node?`

In addition, it increases the memory of BiosyntheticSpades up to 450 GB, since 400 seems to be not enough for [this analysis](https://usegalaxy.eu/u/gallardoalba/h/cloud-aerosol-data).

Finally, it removes an unnecessary environment variable, since the original problem was fixed in https://github.com/galaxyproject/tools-iuc/pull/4388