### PR TITLE
Removed obsolete network 132.230.68.0/25 from Condor permit-write list

### DIFF
--- a/group_vars/galaxy-test.yml
+++ b/group_vars/galaxy-test.yml
@@ -236,7 +236,7 @@ galaxy_systemd_zergling_uwsgi_config_file: "{{ galaxy_config_dir }}/uwsgi.ini"
 
 # HTCondor
 condor_host: "condor-cm.galaxyproject.eu"
-condor_allow_write: "10.5.68.0/24, 132.230.68.0/24, 132.230.223.0/24, *.bi.uni-freiburg.de"
+condor_allow_write: "10.5.68.0/24, 132.230.223.0/24
 condor_daemons:
   - MASTER
   - SCHEDD

--- a/group_vars/sn05.yml
+++ b/group_vars/sn05.yml
@@ -39,7 +39,7 @@ software_groups_to_install:
 
 # HTCondor
 condor_host: "condor-cm.galaxyproject.eu"
-condor_allow_write: "10.5.68.0/24, 132.230.68.0/24, 132.230.223.0/24, 132.230.153.0/28, *.bi.uni-freiburg.de"
+condor_allow_write: "10.5.68.0/24, 132.230.223.0/24, 132.230.153.0/28
 condor_daemons:
   - COLLECTOR
   - MASTER

--- a/group_vars/sn06.yml
+++ b/group_vars/sn06.yml
@@ -406,7 +406,7 @@ galaxy_systemd_zergling_uwsgi_config_file: "{{ galaxy_config_dir }}/uwsgi.ini"
 
 # HTCondor
 condor_host: "condor-cm.galaxyproject.eu"
-condor_allow_write: "10.5.68.0/24, 132.230.68.0/24, 132.230.223.0/24, *.bi.uni-freiburg.de"
+condor_allow_write: "10.5.68.0/24, 132.230.223.0/24
 condor_daemons:
   - MASTER
   - SCHEDD


### PR DESCRIPTION
The network 132.230.68.0/25 is obsolete, as is its associated DNS domain 'bi.uni-freiburg.de' (yes, the network was rly /25, the /24 access grant had been too wide all the time).