### PR TITLE
disable database_engine_option_server_side_cursors

### DIFF
--- a/group_vars/gxconfig.yml
+++ b/group_vars/gxconfig.yml
@@ -52,7 +52,7 @@ base_app_main: &BASE_APP_MAIN
   # issues in the Galaxy process, leave the result on the server
   # instead.  This option is only available for PostgreSQL and is highly
   # recommended.
-  database_engine_option_server_side_cursors: "True"
+  # database_engine_option_server_side_cursors: "False"
 
   # Log all database transactions, can be useful for debugging and
   # performance profiling.  Logging is done via Python's 'logging'


### PR DESCRIPTION
This seems to fix our slow tool form builds.

fixes: https://github.com/galaxyproject/galaxy/issues/14151