### PR TITLE
HiCexplorer hicpca: increse memory

### DIFF
--- a/files/galaxy/dynamic_rules/usegalaxy/tool_destinations.yaml
+++ b/files/galaxy/dynamic_rules/usegalaxy/tool_destinations.yaml
@@ -827,7 +827,7 @@ hicexplorer_hicfindtads: {mem: 20}
 hicexplorer_hicplotmatrix: {mem: 64}
 hicexplorer_hicplottads: {mem: 64}
 hicexplorer_hicsummatrices: {mem: 64}
-hicexplorer_hicpca: {cores: 10, mem: 60}
+hicexplorer_hicpca: {cores: 10, mem: 150}
 hicexplorer_hicmergematrixbins: {mem: 80}
 hicexplorer_hictransform: {cores: 10, mem: 60}
 hicexplorer_hicplotviewpoint: {mem: 12}


### PR DESCRIPTION
This PR increases the allocated memory up to 150 Gb. It was requested by a user through an error report.