### PR TITLE
Update sn05.yml

### DIFF
--- a/group_vars/sn05.yml
+++ b/group_vars/sn05.yml
@@ -76,7 +76,7 @@ postgresql_conf:
   - log_min_duration_statement: 100
 postgresql_pg_hba_conf:
   - "host    postgres        galaxy          132.230.223.239/32      md5"
-  - "host    postgres        galaxy-test     132.230.223.239/32      md5"
+  - "host    postgres        galaxy-test     10.5.68.0/24            md5"
   - "host    galaxy          galaxy          132.230.223.239/32      md5"
   - "host    galaxy          galaxy-readonly 132.230.223.239/32      md5"
   - "host    tiaas           tiaas           132.230.223.239/32      md5"

--- a/group_vars/sn05.yml
+++ b/group_vars/sn05.yml
@@ -76,7 +76,7 @@ postgresql_conf:
   - log_min_duration_statement: 100
 postgresql_pg_hba_conf:
   - "host    postgres        galaxy          132.230.223.239/32      md5"
-  - "host    postgres        galaxy-test     10.5.68.0/24            md5"
+  - "host    postgres        galaxy-test     10.5.68.154/32          md5"
   - "host    galaxy          galaxy          132.230.223.239/32      md5"
   - "host    galaxy          galaxy-readonly 132.230.223.239/32      md5"
   - "host    tiaas           tiaas           132.230.223.239/32      md5"


### PR DESCRIPTION
The new release 22.05 seems to need to access postgres db as well.

```
Jul 26 13:15:45 test.internal.usegalaxy.eu python[288420]: sqlalchemy.exc.OperationalError: (psycopg2.OperationalError) FATAL:  no pg_hba.conf entry for host "10.5.68.154", user "galaxy-test", database "postgres", SSL off

```