### PR TITLE
enable stats user to watch the journald logs

### DIFF
--- a/sn06.yml
+++ b/sn06.yml
@@ -77,6 +77,7 @@
       loop:
         - "{{ galaxy_user.name }}"
         - "telegraf"
+        - "stats" # special account to retrieve statistics from the server in read-only mode
     - name: Set authorized SSH key (galaxy user)
       ansible.posix.authorized_key:
         user: "{{ galaxy_user.name }}"


### PR DESCRIPTION
This will enable the stats user to see the journald logs. Might be helpful for debugging.