### PR TITLE
Mq cert fix

### DIFF
--- a/group_vars/mq.yml
+++ b/group_vars/mq.yml
@@ -32,6 +32,8 @@ certbot_well_known_root: /srv/nginx/_well-known_root
 
 # NGINX
 nginx_enable_default_server: false
+nginx_servers:
+  - redirect-ssl
 nginx_ssl_servers:
   - mq-ssl
 nginx_remove_default_vhost: true

--- a/group_vars/mq.yml
+++ b/group_vars/mq.yml
@@ -17,7 +17,7 @@ certbot_auto_renew_hour: "{{ 23 |random(seed=inventory_hostname)  }}"
 certbot_auto_renew_minute: "{{ 59 |random(seed=inventory_hostname)  }}"
 certbot_domains:
   - "{{ hostname }}"
-certbot_environment: "staging"    # change to production when ready to go
+certbot_environment: "production"    # change to production when ready to go
 certbot_install_method: virtualenv
 certbot_share_key_users:
   - nginx


### PR DESCRIPTION
For the Certbot webroot option the
```
nginx_servers:
   - redirect-ssl
```
was missing.