### PR TITLE
Update Materials Science category

### DIFF
--- a/templates/galaxy/config/global_host_filters.py.j2
+++ b/templates/galaxy/config/global_host_filters.py.j2
@@ -87,7 +87,7 @@ DOMAIN_SECTIONS = {
     'metabolomics': ['metabolomics'],
     'ml': ['machine_learning'],
     'annotation': GENERAL_NGS_SECTIONS + ['annotation', 'apollo', 'ncbi_blast', 'assembly', 'variant_calling', 'fetch_sequences___alignments', 'ontology', 'emboss', 'evolution', 'genome_diversity', 'multiple_alignments', 'graph_display_data'],
-    'materials': ['materials_science'],
+    'materials': ['muon_spectroscopy'],
     
 }
 

--- a/templates/galaxy/config/tool_conf.xml.j2
+++ b/templates/galaxy/config/tool_conf.xml.j2
@@ -371,7 +371,7 @@
     <tool file="chromatra/chromatrat.xml" />
     <tool file="plotting/foldchanges_heatmap.xml" />
   </section>
-  <section id="materials_science" name="Materials Science">
+  <section id="muon_spectroscopy" name="Muon Spectroscopy">
   </section>
 
   <label id="other_and_toolsuites_label" text="Miscellaneous Tools" />


### PR DESCRIPTION
Change "Materials Science" section to "Muon Spectroscopy" to match https://github.com/usegalaxy-eu/usegalaxy-eu-tools/pull/503 - since we hope to include more tools relating to X-ray or neutron spectroscopy later and it'll be good to have sections for each subdomain within materials science