### PR TITLE
new flower version

### DIFF
--- a/group_vars/celerycluster.yml
+++ b/group_vars/celerycluster.yml
@@ -70,7 +70,7 @@ flower_python_path: server/lib
 flower_venv_dir: /opt/galaxy/venv
 flower_app_name: galaxy.celery
 
-flower_persistent: "True"
+flower_persistent: True
 
-flower_broker_api: "https://flower:{{ rabbitmq_password_flower }}@{{ rabbitmq_url }}/api"
+flower_broker_api: "https://flower:{{ rabbitmq_password_flower }}@{{ rabbitmq_url }}/api/"
 flower_broker_url: "amqp://flower:{{ rabbitmq_password_flower }}@{{ rabbitmq_url }}:5671/galaxy?ssl=true"

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -100,4 +100,4 @@ roles:
   - name: usegalaxy_eu.influxdbserver
     version: 1.1.1
   - name: usegalaxy_eu.flower
-    version: 0.2.0-alpha
+    version: 0.3.0-alpha


### PR DESCRIPTION
I changed it so that the flower_venv_dir variable actually is used to install flower there.
This would be /opt/galaxy/venv - so please review carefully. I tested it and it didn't affect the venv otherwise but it's better to be careful, I guess.
see the [ReadMe](https://galaxy.ansible.com/usegalaxy_eu/flower) for more details.
