### PR TITLE
add the second gunicorn listen path

### DIFF
--- a/templates/nginx/galaxy-main.j2
+++ b/templates/nginx/galaxy-main.j2
@@ -5,6 +5,7 @@ map $http_upgrade $connection_upgrade {
 
 upstream galaxy {
     server unix:{{ galaxy_systemd_gunicorn_listen_path }};
+    server unix:{{ galaxy_systemd_gunicorn_listen_path_2 }};
 }
 
 server {


### PR DESCRIPTION
This can go hand-in-hand with https://github.com/usegalaxy-eu/ansible-galaxy-systemd/pull/7

It implements (maybe) version one of: 

![IMG_20221012_124814](https://user-images.githubusercontent.com/469983/195323798-aaeb004b-e9a3-40ca-bc98-c25c0fe6b97a.jpg)
