### PR TITLE
tried old configurations

### DIFF
--- a/group_vars/sn06.yml
+++ b/group_vars/sn06.yml
@@ -979,15 +979,23 @@ galaxy_jobconf:
     - id: pulsar_mira_tpv
       runner: pulsar_mira_runner
       env:
+        GALAXY_MEMORY_MB: "{MEMORY_MB}"
+        GALAXY_SLOTS: "{PARALLELISATION}"
         LC_ALL: C
+        SINGULARITY_CACHEDIR: /data/share/var/database/container_cache
       params:
         jobs_directory: /data/share/staging
         transport: curl
         remote_metadata: "false"
+        submit_request_cpus: "{PARALLELISATION}"
+        submit_request_memory: "{MEMORY}"
+        outputs_to_working_directory: "false"
         default_file_action: remote_transfer
-        dependency_resolution: remote
+        dependency_resolution: "none"
         rewrite_parameters: "true"
         persistence_directory: /data/share/persisted_data
+        singularity_enabled: true
+        singularity_default_container_id: "/cvmfs/singularity.galaxyproject.org/u/b/ubuntu:18.04"
     # TODO(hxr): check functionality
     #- id: 24cores_15G_BLAST
     #  runner: dynamic


### PR DESCRIPTION
From our Pulsar documentation
``
remote_cluster_mq_<custom-suffix>:
  limits:
    cores: <number-of-available-cpus-per-node>
    mem: <ram-available-per-node>
  env:
    GALAXY_MEMORY_MB: '{MEMORY_MB}'
    GALAXY_SLOTS: '{PARALLELISATION}'
    LC_ALL: C
    SINGULARITY_CACHEDIR: /data/share/var/database/container_cache
  params:
    priority: -{PRIORITY}
    submit_request_cpus: '{PARALLELISATION}'
    submit_request_memory: '{MEMORY}'
    jobs_directory: '/data/share/staging'
    default_file_action: 'remote_transfer'
    dependency_resolution: 'none'
    outputs_to_working_directory: False
    rewrite_parameters: True
    transport: 'curl'
    singularity_enabled: true
    singularity_default_container_id: '/cvmfs/singularity.galaxyproject.org/u/b/ubuntu:18.04'
```