### PR TITLE
Redirect away from galaxyproject.eu

### DIFF
--- a/templates/nginx/galaxyproject.j2
+++ b/templates/nginx/galaxyproject.j2
@@ -4,7 +4,70 @@ server {
 
 	server_name galaxyproject.eu;
 
+	# Redirect homepages.
+	location = / {
+		return 301 https://galaxyproject.org/eu/;
+	}
+	location = /freiburg/ {
+		return 301 https://galaxyproject.org/freiburg/;
+	}
+	location = /erasmusmc/ {
+		return 301 https://galaxyproject.org/erasmusmc/;
+	}
+	location = /belgium/ {
+		return 301 https://galaxyproject.org/belgium/;
+	}
+	location = /pasteur/ {
+		return 301 https://galaxyproject.org/pasteur/;
+	}
+	location = /genouest/ {
+		return 301 https://galaxyproject.org/genouest/;
+	}
+	location = /elixir-it/ {
+		return 301 https://galaxyproject.org/elixir-it/;
+	}
+	location = /ifb/ {
+		return 301 https://galaxyproject.org/ifb/;
+	}
+
+	# EU-wide news/events feeds.
+	location ~ ^/news(\.html)?$ {
+		return 301 https://galaxyproject.org/eu/news/;
+	}
+	location ~ ^/events(\.html)?$ {
+		return 301 https://galaxyproject.org/eu/events/;
+	}
+
+	# Misc.
+	location = /widgets/news.html {
+		return 301 https://galaxyproject.org/bare/eu/latest/news/;
+	}
+	location = /widgets/events.html {
+		return 301 https://galaxyproject.org/bare/eu/latest/events/;
+	}
+	location = /galaxy/news.html {
+		return 301 https://galaxyproject.org/bare/eu/news/;
+	}
+	location = /galaxy/events.html {
+		return 301 https://galaxyproject.org/bare/eu/events/;
+	}
+
+	# Galaxy server middle pane homepages.
+	location = /galaxy/ {
+		return 301 https://galaxyproject.org/bare/eu/usegalaxy/main/;
+	}
+	location = /index-metabolomics.html {
+		return 301 https://galaxyproject.org/bare/eu/usegalaxy/metabolomics/;
+	}
+	location = /index-proteomics.html {
+		return 301 https://galaxyproject.org/bare/eu/usegalaxy/proteomics/;
+	}
+
 	location / {
+		# Subsite-specific news and events pages.
+		rewrite ^/([^/]+)/(news|events)(\.html)?$  https://galaxyproject.org/$1/$2/  permanent;
+
+		# The rest should be transparently proxied to github.io.
 		proxy_pass https://usegalaxy-eu.github.io/;
 		proxy_cache           STATIC;
 		proxy_cache_valid     200  5m;

--- a/templates/nginx/galaxyproject.j2
+++ b/templates/nginx/galaxyproject.j2
@@ -38,7 +38,7 @@ server {
 		return 301 https://galaxyproject.org/eu/events/;
 	}
 
-	# Misc.
+	# Redirect other pages used by Galaxy servers to .org
 	location = /widgets/news.html {
 		return 301 https://galaxyproject.org/bare/eu/latest/news/;
 	}
@@ -67,10 +67,7 @@ server {
 		# Subsite-specific news and events pages.
 		rewrite ^/([^/]+)/(news|events)(\.html)?$  https://galaxyproject.org/$1/$2/  permanent;
 
-		# The rest should be transparently proxied to github.io.
-		proxy_pass https://usegalaxy-eu.github.io/;
-		proxy_cache           STATIC;
-		proxy_cache_valid     200  5m;
-		proxy_cache_use_stale error timeout invalid_header updating http_500 http_502 http_503 http_504;
+		# The rest should continue to be served by the European website, but under the github.io domain.
+		return 301 https://usegalaxy-eu.github.io$request_uri;
 	}
 }


### PR DESCRIPTION
After #421 there was discussion at [EGD](https://galaxyproject.org/events/2022-10-egd/) about a different strategy. Instead, we decided to do a bulk move of .eu events and news posts to .org, then 301 to .org from all news/events feeds instead of keeping them accessible (but with warnings).

Now that the content is moved (galaxyproject/galaxy-hub#1707), we can do the redirects.