### PR TITLE
Changing Ownership of Config and Codebase to 'galaxy' user

### DIFF
--- a/group_vars/sn06.yml
+++ b/group_vars/sn06.yml
@@ -464,6 +464,7 @@ galaxy_instance_codename: "{{ codename }}"
 galaxy_log_dir: "/var/log/galaxy"
 galaxy_layout: root-dir
 galaxy_separate_privileges: true
+galaxy_privsep_user: "{{ galaxy_user.name }}"
 galaxy_manage_paths: true
 galaxy_build_client: false
 galaxy_restart_handler_name: Restart Galaxy


### PR DESCRIPTION
I found [this Line](https://github.com/galaxyproject/ansible-galaxy/blob/b1f10d4db7d6d6f39713345579d62b4bc6f60bc6/defaults/main.yml#L79) in the galaxy ansible role defaults.
It says that, if `galaxy_privilege_separation: true` (like in our case), the `galaxy_privsep_user` will get the ownership of codebase, configs and virtualenv.
It defaults to root, which is why I believe that our configs are owned by root user.
**We need to think carefully if this could break something before merge.**