### PR TITLE
Many gunicorns

### DIFF
--- a/group_vars/galaxy-test.yml
+++ b/group_vars/galaxy-test.yml
@@ -274,7 +274,6 @@ galaxy_group:
 galaxy_config_perms: 0644
 
 galaxy_root: /opt/galaxy
-galaxy_systemd_handlers: 2
 galaxy_workflow_scheduler_count: "{{ galaxy_systemd_workflow_schedulers }}"
 galaxy_host_codename: "{{ codename }}"
 galaxy_home_dir: /opt/galaxy

--- a/group_vars/galaxy-test.yml
+++ b/group_vars/galaxy-test.yml
@@ -274,7 +274,7 @@ galaxy_group:
 galaxy_config_perms: 0644
 
 galaxy_root: /opt/galaxy
-galaxy_systemd_handlers: "{{ galaxy_systemd_handlers }}"
+galaxy_systemd_handlers: 2
 galaxy_workflow_scheduler_count: "{{ galaxy_systemd_workflow_schedulers }}"
 galaxy_host_codename: "{{ codename }}"
 galaxy_home_dir: /opt/galaxy

--- a/group_vars/galaxy-test.yml
+++ b/group_vars/galaxy-test.yml
@@ -274,7 +274,7 @@ galaxy_group:
 galaxy_config_perms: 0644
 
 galaxy_root: /opt/galaxy
-galaxy_handler_count: "{{ galaxy_systemd_handlers }}"
+galaxy_systemd_handlers: "{{ galaxy_systemd_handlers }}"
 galaxy_workflow_scheduler_count: "{{ galaxy_systemd_workflow_schedulers }}"
 galaxy_host_codename: "{{ codename }}"
 galaxy_home_dir: /opt/galaxy
@@ -335,7 +335,7 @@ galaxy_singularity_images_cvmfs_path: "/cvmfs/singularity.galaxyproject.org/all/
 galaxy_jobconf:
   plugin_workers: 8
   handlers:
-    count: "{{ galaxy_handler_count }}"
+    count: "{{ galaxy_systemd_handlers }}"
     assign_with: db-skip-locked
     max_grab: 4
   plugins:

--- a/group_vars/sn06.yml
+++ b/group_vars/sn06.yml
@@ -345,6 +345,7 @@ galaxy_cvmfs_server_urls:
 
 # SystemD
 galaxy_systemd_mode: "gunicorn"
+galaxy_systemd_gunicorns: 2
 galaxy_systemd_gunicorn_workers: 4
 galaxy_systemd_gunicorn_timeout: 600
 galaxy_systemd_handlers: 6
@@ -440,7 +441,6 @@ galaxy_user:
 galaxy_config_perms: 0644
 
 galaxy_root: /opt/galaxy
-galaxy_handler_count: "{{ galaxy_systemd_handlers }}"
 galaxy_workflow_scheduler_count: "{{ galaxy_systemd_workflow_schedulers }}"
 galaxy_host_codename: "{{ codename }}"
 galaxy_home_dir: /opt/galaxy

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -70,7 +70,7 @@ roles:
     src: https://github.com/usegalaxy-eu/ansible-certbot
     version: 0.1.5
   - name: usegalaxy_eu.galaxy_systemd
-    version: 0.2.1
+    version: 1.0.0
   - name: usegalaxy-eu.dynmotd
     src: https://github.com/usegalaxy-eu/ansible-dynmotd
     version: 0.0.1

--- a/roles/test/templates/job_conf.xml
+++ b/roles/test/templates/job_conf.xml
@@ -19,7 +19,7 @@
 {% endfor %}
 	</plugins>
 	<handlers{% if galaxy_jobconf.handlers.assign_with is defined %} assign_with="{{ galaxy_jobconf.handlers.assign_with }}"{% endif %}{% if galaxy_jobconf.handlers.default is defined %} default="{{ galaxy_jobconf.handlers.default }}"{% endif %}>
-{% for n in range(galaxy_handler_count) %}
+{% for n in range(galaxy_systemd_handlers) %}
 		<handler id="handler_{{ galaxy_instance_codename }}_{{ n }}"/>
 {% endfor %}
 	</handlers>
@@ -42,7 +42,7 @@
 		<tool id="{{ tool['id'] }}" destination="{{ tool['destination'] }}" />
 {% endfor %}
 		<!-- Per handler echos-->
-{% for n in range(galaxy_handler_count) %}
+{% for n in range(galaxy_systemd_handlers) %}
 		<tool id="echo_main_handler{{ n }}" destination="local" handler="handler{{ n }}"/>
 {% endfor %}
 	</tools>

--- a/templates/galaxy-test/config/job_conf.yml.j2
+++ b/templates/galaxy-test/config/job_conf.yml.j2
@@ -41,10 +41,10 @@ handling:
 {% if galaxy_jobconf.handlers.ready_window_size is defined %}
   ready_window_size: {{ galaxy_jobconf.handlers.ready_window_size }}
 {% endif %}
-{% if galaxy_handler_count is defined %}
+{% if galaxy_systemd_handlers is defined %}
   processes:
-{% for n in range(galaxy_handler_count) %}
-    handler_{{ galaxy_instance_codename }}_{{ n }}:
+{% for n in range galaxy_systemd_handlers) %}
+    {{ galaxy_systemd_handler_prefix }}_{{ n }}:
 {% endfor %}
 {% endif %}
 

--- a/templates/galaxy/config/job_conf.yml
+++ b/templates/galaxy/config/job_conf.yml
@@ -5,7 +5,7 @@
 galaxy_jobconf:
   plugin_workers: 8
   handlers:
-    count: "{{ galaxy_handler_count }}"
+    count: "{{ galaxy_systemd_handlers }}"
     assign_with: db-skip-locked
     max_grab: 16
     ready_window_size: 32

--- a/templates/galaxy/config/job_conf.yml.j2
+++ b/templates/galaxy/config/job_conf.yml.j2
@@ -44,10 +44,10 @@ handling:
 {% if galaxy_jobconf.handlers.ready_window_size is defined %}
   ready_window_size: {{ galaxy_jobconf.handlers.ready_window_size }}
 {% endif %}
-{% if galaxy_handler_count is defined %}
+{% if galaxy_systemd_handlers is defined %}
   processes:
-{% for n in range(galaxy_handler_count) %}
-    handler_{{ galaxy_instance_codename }}_{{ n }}:
+{% for n in range galaxy_systemd_handlers) %}
+    {{ galaxy_systemd_handler_prefix }}_{{ n }}:
 {% endfor %}
 {% endif %}
 

--- a/templates/nginx/galaxy-main.j2
+++ b/templates/nginx/galaxy-main.j2
@@ -4,8 +4,9 @@ map $http_upgrade $connection_upgrade {
 }
 
 upstream galaxy {
-    server unix:{{ galaxy_systemd_gunicorn_listen_path }};
-    server unix:{{ galaxy_systemd_gunicorn_listen_path_2 }};
+	{% for n in range(galaxy_systemd_gunicorns) %}
+    	server unix:{{ galaxy_mutable_data_dir }}/{{ galaxy_systemd_gunicorn_socket_name }}{{ n }}.sock;
+	{% endfor %}
 }
 
 server {


### PR DESCRIPTION
Reconfigued the Playbooks according to new [systemd role release](https://galaxy.ansible.com/usegalaxy_eu/galaxy_systemd):  
 - removed `galaxy_handler_count` var in favor of `galaxy_systemd_handlers`
 - changed socket name in nginx `galaxy-main` template
 - changed handler naming in the `job_conf.yml.j2` template