### PR TITLE
Megan tools: add JAVA memory

### DIFF
--- a/files/galaxy/dynamic_rules/usegalaxy/tool_destinations.yaml
+++ b/files/galaxy/dynamic_rules/usegalaxy/tool_destinations.yaml
@@ -701,6 +701,15 @@ mass_spectrometry_imaging_qc: {mem: 110}
 mass_spectrometry_imaging_filtering: {mem: 20}
 metaspades: {cores: 10, mem: 250}
 megahit: {cores: 10, mem: 80}
+megan_daa_meganizer:
+  env:
+    _JAVA_OPTIONS: -XX:MaxPermSize=2G -Xmx8G -Xms1G -Djava.io.tmpdir=/data/2/galaxy_db/tmp
+megan_daa2rma:
+  env:
+    _JAVA_OPTIONS: -XX:MaxPermSize=2G -Xmx8G -Xms1G -Djava.io.tmpdir=/data/2/galaxy_db/tmp
+megan_sam2rma:
+  env:
+    _JAVA_OPTIONS: -XX:MaxPermSize=2G -Xmx8G -Xms1G -Djava.io.tmpdir=/data/2/galaxy_db/tmp
 maxbin2: {cores: 10, mem: 48}
 metabat2: {cores: 10, mem: 48}
 concoct: {cores: 10, mem: 48}

--- a/files/galaxy/dynamic_rules/usegalaxy/tool_destinations.yaml
+++ b/files/galaxy/dynamic_rules/usegalaxy/tool_destinations.yaml
@@ -702,12 +702,15 @@ mass_spectrometry_imaging_filtering: {mem: 20}
 metaspades: {cores: 10, mem: 250}
 megahit: {cores: 10, mem: 80}
 megan_daa_meganizer:
+  mem: 40
   env:
     _JAVA_OPTIONS: -XX:MaxPermSize=2G -Xmx40G -Xms1G -Djava.io.tmpdir=/data/2/galaxy_db/tmp
 megan_daa2rma:
+  mem: 40
   env:
     _JAVA_OPTIONS: -XX:MaxPermSize=2G -Xmx40G -Xms1G -Djava.io.tmpdir=/data/2/galaxy_db/tmp
 megan_sam2rma:
+  mem: 40
   env:
     _JAVA_OPTIONS: -XX:MaxPermSize=2G -Xmx40G -Xms1G -Djava.io.tmpdir=/data/2/galaxy_db/tmp
 maxbin2: {cores: 10, mem: 48}

--- a/files/galaxy/dynamic_rules/usegalaxy/tool_destinations.yaml
+++ b/files/galaxy/dynamic_rules/usegalaxy/tool_destinations.yaml
@@ -703,13 +703,13 @@ metaspades: {cores: 10, mem: 250}
 megahit: {cores: 10, mem: 80}
 megan_daa_meganizer:
   env:
-    _JAVA_OPTIONS: -XX:MaxPermSize=2G -Xmx8G -Xms1G -Djava.io.tmpdir=/data/2/galaxy_db/tmp
+    _JAVA_OPTIONS: -XX:MaxPermSize=2G -Xmx40G -Xms1G -Djava.io.tmpdir=/data/2/galaxy_db/tmp
 megan_daa2rma:
   env:
-    _JAVA_OPTIONS: -XX:MaxPermSize=2G -Xmx8G -Xms1G -Djava.io.tmpdir=/data/2/galaxy_db/tmp
+    _JAVA_OPTIONS: -XX:MaxPermSize=2G -Xmx40G -Xms1G -Djava.io.tmpdir=/data/2/galaxy_db/tmp
 megan_sam2rma:
   env:
-    _JAVA_OPTIONS: -XX:MaxPermSize=2G -Xmx8G -Xms1G -Djava.io.tmpdir=/data/2/galaxy_db/tmp
+    _JAVA_OPTIONS: -XX:MaxPermSize=2G -Xmx40G -Xms1G -Djava.io.tmpdir=/data/2/galaxy_db/tmp
 maxbin2: {cores: 10, mem: 48}
 metabat2: {cores: 10, mem: 48}
 concoct: {cores: 10, mem: 48}


### PR DESCRIPTION
Reported error:

`Exception in thread "main" java.lang.OutOfMemoryError: Java heap space at java.base/java.lang.AbstractStringBuilder.<init>(AbstractStringBuilder.java:87) at java.base/java.lang.StringBuilder.<init>(StringBuilder.java:100) at megan/megan.daa.io.InputReaderLittleEndian.readNullTerminatedBytes(InputReaderLittleEndian.java:168) at megan/megan.daa.io.DAAHeader.loadReferences(DAAHeader.java:222) at megan/megan.daa.DAAReferencesAnnotator.apply(DAAReferencesAnnotator.java:59) at megan/megan.daa.Meganize.apply(Meganize.java:73) at megan/megan.tools.DAAMeganizer.run(DAAMeganizer.java:269) at megan/megan.tools.DAAMeganizer.main(DAAMeganizer.java:65)`