### PR TITLE
remove the uwsgi monitoring role from sn07 playbook

### DIFF
--- a/sn07.yml
+++ b/sn07.yml
@@ -149,7 +149,6 @@
     ## Monitoring
     - hxr.monitor-cluster
     - hxr.monitor-email
-    - hxr.monitor-uwsgi
     - hxr.monitor-galaxy-journalctl
     # - usegalaxy-eu.monitor-disk-access-time
     - usegalaxy-eu.monitoring


### PR DESCRIPTION
Role was removed in db3986933a8555cfe46b62bcce6cc7321b3ea369