### PR TITLE
unified tags to use '-'

### DIFF
--- a/files/galaxy/dynamic_rules/usegalaxy/total_perspective_vortex/destinations.yml
+++ b/files/galaxy/dynamic_rules/usegalaxy/total_perspective_vortex/destinations.yml
@@ -1,4 +1,5 @@
 ---
+# ALL tags must be with dashes (-) instead of underscores (_)
 destinations:
   interactive_pulsar:
     runner: pulsar_embedded
@@ -59,14 +60,14 @@ destinations:
     mem: 1000
     scheduling:
       accept:
-        - condor_tpv
+        - condor-tpv
 
   pulsar_mira_tpv:
     cores: 2
     mem: 4
     scheduling:
       require:
-        - mira_pulsar
+        - mira-pulsar
         - docker
 
   pulsar_it_tpv:
@@ -88,4 +89,4 @@ destinations:
     mem: 1000
     scheduling:
       require:
-        - condor_singularity_with_conda_python2
+        - condor-singularity-with-conda-python2

--- a/files/galaxy/dynamic_rules/usegalaxy/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_rules/usegalaxy/total_perspective_vortex/tools.yml
@@ -1,10 +1,11 @@
 ---
+# ALL tags must be with dashes (-) instead of underscores (_)
 tools:
   toolshed.g2.bx.psu.edu/repos/iuc/snippy/snippy/.*:
     cores: 2
-    #scheduling:
-    #  accept:
-    #    - pulsar
+    scheduling:
+      require:
+        - condor-tpv
     rules:
       - if: input_size >= 0.015
         cores: 14
@@ -12,7 +13,7 @@ tools:
   toolshed.g2.bx.psu.edu/repos/iuc/enasearch_search_data/enasearch_search_data/.*:
     scheduling:
       require:
-        - condor_singularity_with_conda_python2
+        - condor-singularity-with-conda-python2
 
   toolshed.g2.bx.psu.edu/repos/rnateam/dewseq/dewseq/.*:
     cores: 2
@@ -116,7 +117,7 @@ tools:
     cores: 8
     scheduling:
       prefer:
-        - condor_tpv
+        - condor-tpv
     rules:
       - if: 0.1 <= input_size < 1
         cores: 20


### PR DESCRIPTION
We should try to use uniform separators, I chose dash here, because it was already used by most tags.
I think it would be good to set up a operations md where we collect rules and conventions for our TPV config