### PR TITLE
Remove set default version of python task on sn07

### DIFF
--- a/sn07.yml
+++ b/sn07.yml
@@ -71,10 +71,6 @@
             "python3-devel",
           ]
       become: true
-    - name: Set default version of Python
-      alternatives:
-        name: python
-        path: /usr/bin/python3
     - name: Disable SELinux
       selinux:
         state: disabled


### PR DESCRIPTION
Remove `set default version of python task` on `sn07.yml` playbook. Rocky 9 on sn07 already has Python 3.9 as the default system version. Galaxy uses a conda env with python 3.8 to create all required envs. So this task is not needed.

Because of this task, the `sn07` build (build number `8`) also fails with the error message `Needed to install the alternative, but unable to do so as we are missing the link` (however, I think this task can be fixed by adding a `link`  parameter to the task).