### PR TITLE
sn07: fix ansible recursive loop in template issue

### DIFF
--- a/group_vars/sn07.yml
+++ b/group_vars/sn07.yml
@@ -26,7 +26,7 @@ autofs_mount_points:
   - usrlocal
 
 # Miniconda role variables (galaxyproject.miniconda)
-miniconda_prefix: /opt/miniconda
+conda_prefix: /opt/miniconda
 
 # fs-maintenance
 fsm_maintenance_dir: "/data/dnb01/maintenance"
@@ -456,7 +456,7 @@ galaxy_venv_dir: "{{ galaxy_root }}/venv"
 galaxy_job_working_directory: "{{ galaxy_config['galaxy']['job_working_directory'] }}"
 ucsc_build_sites:
 
-galaxy_virtualenv_command: "{{ miniconda_prefix }}/envs/_galaxy_/bin/virtualenv"
+galaxy_virtualenv_command: "{{ conda_prefix }}/envs/_galaxy_/bin/virtualenv"
 galaxy_nonrepro_tools: "{{ galaxy_root }}/custom-tools"
 galaxy_nonrepro_commit: master
 

--- a/sn07.yml
+++ b/sn07.yml
@@ -128,7 +128,7 @@
     ## galaxy_virtualenv_command) in the group_vars/sn07.yml
     - role: galaxyproject.miniconda
       vars:
-        miniconda_prefix: "{{ miniconda_prefix }}"
+        miniconda_prefix: "{{ conda_prefix }}"
         galaxy_conda_create_env: true
         galaxy_conda_env_packages:
           - python=3.8


### PR DESCRIPTION
Build number 9 failed because of a recursive variable definition.

To not have these types of issues again, I ran ansible-lint on the playbook locally and found no such issues.