### PR TITLE
handy os setup update

### DIFF
--- a/requirements.yaml
+++ b/requirements.yaml
@@ -21,7 +21,7 @@ collections:
     source: https://galaxy.ansible.com
     type: galaxy
   - name: usegalaxy_eu.handy
-    version: 2.9.0
+    version: 2.10.0
     source: https://galaxy.ansible.com
 
 roles:


### PR DESCRIPTION
Version 2.9.0 → 2.10.0
to include make in utils software group