### PR TITLE
restrict resubmission to only 2 rounds

### DIFF
--- a/roles/usegalaxy-eu.htcondor_release/tasks/main.yml
+++ b/roles/usegalaxy-eu.htcondor_release/tasks/main.yml
@@ -15,7 +15,7 @@
 
         for j in $(condor_q -hold -autoformat ClusterId HoldReasonCode| awk '(($2-34) == 0){print $1}'| paste -s -d ' ')
         do
-          NUMBER_OF_TIMES_SUBMITTED=$(grep "$j" "$LOG" | wc -l)
+          NUMBER_OF_TIMES_SUBMITTED=$(grep -c "$j" "$LOG")
           if [ $NUMBER_OF_TIMES_SUBMITTED -gt $RESUBMIT_CAP ]; then
             condor_rm -reason "This job was resubmitted $RESUBMIT_CAP times. Most likely because of running out of memory." "$j"
             continue

--- a/roles/usegalaxy-eu.htcondor_release/tasks/main.yml
+++ b/roles/usegalaxy-eu.htcondor_release/tasks/main.yml
@@ -4,6 +4,7 @@
     content: |
         #!/bin/bash
         CAP=524288 # 512GB
+        RESUBMIT_CAP=2 # only N resubmission is allowed
         MULTIPLIER=3
         LOG=/data/dnb01/maintenance/condor_rerun_held_jobs.log
 
@@ -14,6 +15,11 @@
 
         for j in $(condor_q -hold -autoformat ClusterId HoldReasonCode| awk '(($2-34) == 0){print $1}'| paste -s -d ' ')
         do
+          NUMBER_OF_TIMES_SUBMITTED=$(grep "$j" "$LOG" | wc -l)
+          if [ $NUMBER_OF_TIMES_SUBMITTED -gt $RESUBMIT_CAP ]; then
+            condor_rm -reason "This job was resubmitted $RESUBMIT_CAP times. Most likely because of running out of memory." "$j"
+            continue
+          fi
           JOB_DESCRIPTION=$(condor_q "$j" -autoformat JobDescription)
           MEMORY_PROVISIONED=$(condor_q "$j" -autoformat MemoryProvisioned)          
           if [ $(($MEMORY_PROVISIONED * $MULTIPLIER)) -gt $CAP ]; then


### PR DESCRIPTION
Not tested, but something along these lines is needed.

Otherwise we will end up with something like

```
galaxy@sn06:/data/jwd01/main/052/131/52131849$ cat galaxy_52131849.condor.log 
000 (36707199.000.000) 11/11 06:16:40 Job submitted from host: <132.230.223.239:9618?addrs=132.230.223.239-9618&noUDP&sock=3240940_d941_90>
...
001 (36707199.000.000) 11/11 06:16:58 Job executing on host: <10.5.68.79:9618?addrs=10.5.68.79-9618&noUDP&sock=1622_22b4_3>
...
006 (36707199.000.000) 11/11 06:17:07 Image size of job updated: 668700
	651  -  MemoryUsage of job (MB)
	666448  -  ResidentSetSize of job (KB)
...
006 (36707199.000.000) 11/11 06:17:44 Image size of job updated: 4254280
	4088  -  MemoryUsage of job (MB)
	4185388  -  ResidentSetSize of job (KB)
...
007 (36707199.000.000) 11/11 06:17:44 Shadow exception!
	Error from slot1_9@vgcnbwc-worker-c36m100-0574.novalocal: Job has gone over memory limit of 4096 megabytes. Peak usage: 4088 megabytes.
	0  -  Run Bytes Sent By Job
	0  -  Run Bytes Received By Job
...
012 (36707199.000.000) 11/11 06:17:45 Job was held.
	Error from slot1_9@vgcnbwc-worker-c36m100-0574.novalocal: Job has gone over memory limit of 4096 megabytes. Peak usage: 4088 megabytes.
	Code 34 Subcode 0
...
013 (36707199.000.000) 11/11 06:30:37 Job was released.
	via condor_release (by user galaxy)
...
001 (36707199.000.000) 11/11 06:30:57 Job executing on host: <10.5.68.40:9618?addrs=10.5.68.40-9618&noUDP&sock=3080977_892a_23>
...
006 (36707199.000.000) 11/11 06:32:28 Image size of job updated: 12475232
	12183  -  MemoryUsage of job (MB)
	12475232  -  ResidentSetSize of job (KB)
...
007 (36707199.000.000) 11/11 06:32:28 Shadow exception!
	Error from slot1_9@vgcnbwc-worker-c36m225-5302.novalocal: Job has gone over memory limit of 12288 megabytes. Peak usage: 12183 megabytes.
	0  -  Run Bytes Sent By Job
	0  -  Run Bytes Received By Job
...
012 (36707199.000.000) 11/11 06:32:29 Job was held.
	Error from slot1_9@vgcnbwc-worker-c36m225-5302.novalocal: Job has gone over memory limit of 12288 megabytes. Peak usage: 12183 megabytes.
	Code 34 Subcode 0
...
013 (36707199.000.000) 11/11 06:45:05 Job was released.
	via condor_release (by user galaxy)
...
001 (36707199.000.000) 11/11 06:45:24 Job executing on host: <10.5.68.90:9618?addrs=10.5.68.90-9618&noUDP&sock=2701_3d64_3>
...
006 (36707199.000.000) 11/11 06:48:58 Image size of job updated: 37765700
	36789  -  MemoryUsage of job (MB)
	37671120  -  ResidentSetSize of job (KB)
...
007 (36707199.000.000) 11/11 06:48:58 Shadow exception!
	Error from slot1_2@vgcnbwc-worker-c125m425-5897.novalocal: Job has gone over memory limit of 36864 megabytes. Peak usage: 36789 megabytes.
	0  -  Run Bytes Sent By Job
	0  -  Run Bytes Received By Job
...
012 (36707199.000.000) 11/11 06:48:58 Job was held.
	Error from slot1_2@vgcnbwc-worker-c125m425-5897.novalocal: Job has gone over memory limit of 36864 megabytes. Peak usage: 36789 megabytes.
	Code 34 Subcode 0
...
013 (36707199.000.000) 11/11 07:00:02 Job was released.
	via condor_release (by user galaxy)
...
001 (36707199.000.000) 11/11 07:12:25 Job executing on host: <10.5.68.123:9618?addrs=10.5.68.123-9618&noUDP&sock=229016_8178_27>
...
006 (36707199.000.000) 11/11 07:17:34 Image size of job updated: 101482808
	99105  -  MemoryUsage of job (MB)
	101482636  -  ResidentSetSize of job (KB)
...
006 (36707199.000.000) 11/11 07:18:10 Image size of job updated: 110416760
	107829  -  MemoryUsage of job (MB)
	110416760  -  ResidentSetSize of job (KB)
...
007 (36707199.000.000) 11/11 07:18:10 Shadow exception!
	Error from slot1_8@vgcnbwc-worker-c36m975-1622.novalocal: Job has gone over memory limit of 110592 megabytes. Peak usage: 107829 megabytes.
	0  -  Run Bytes Sent By Job
	0  -  Run Bytes Received By Job
...
012 (36707199.000.000) 11/11 07:18:10 Job was held.
	Error from slot1_8@vgcnbwc-worker-c36m975-1622.novalocal: Job has gone over memory limit of 110592 megabytes. Peak usage: 107829 megabytes.
	Code 34 Subcode 0
...
013 (36707199.000.000) 11/11 07:30:38 Job was released.
	via condor_release (by user galaxy)
...
001 (36707199.000.000) 11/20 15:57:10 Job executing on host: <10.5.68.55:9618?addrs=10.5.68.55-9618&noUDP&sock=144606_4444_5>
...
006 (36707199.000.000) 11/20 16:07:20 Image size of job updated: 125891984
	122800  -  MemoryUsage of job (MB)
	125746996  -  ResidentSetSize of job (KB)
...
006 (36707199.000.000) 11/20 16:12:21 Image size of job updated: 164575292
	160629  -  MemoryUsage of job (MB)
	164483560  -  ResidentSetSize of job (KB)
...
006 (36707199.000.000) 11/20 16:17:22 Image size of job updated: 208111152
	203232  -  MemoryUsage of job (MB)
	208109372  -  ResidentSetSize of job (KB)
...
006 (36707199.000.000) 11/20 16:22:22 Image size of job updated: 246937268
	241040  -  MemoryUsage of job (MB)
	246824748  -  ResidentSetSize of job (KB)
...
006 (36707199.000.000) 11/20 16:27:23 Image size of job updated: 279285500
	272600  -  MemoryUsage of job (MB)
	279141848  -  ResidentSetSize of job (KB)
...
006 (36707199.000.000) 11/20 16:32:23 Image size of job updated: 317084216
	309651  -  MemoryUsage of job (MB)
	317082436  -  ResidentSetSize of job (KB)
...
006 (36707199.000.000) 11/20 16:33:58 Image size of job updated: 331125104
	323365  -  MemoryUsage of job (MB)
	331125104  -  ResidentSetSize of job (KB)
...
007 (36707199.000.000) 11/20 16:33:58 Shadow exception!
	Error from slot1_1@vgcnbwc-worker-c36m975-3911.novalocal: Job has gone over memory limit of 331776 megabytes. Peak usage: 323365 megabytes.
	0  -  Run Bytes Sent By Job
	0  -  Run Bytes Received By Job
...
012 (36707199.000.000) 11/20 16:33:59 Job was held.
	Error from slot1_1@vgcnbwc-worker-c36m975-3911.novalocal: Job has gone over memory limit of 331776 megabytes. Peak usage: 323365 megabytes.
	Code 34 Subcode 0
...
013 (36707199.000.000) 11/20 16:45:01 Job was released.
	via condor_release (by user galaxy)
...
022 (36707199.000.000) 11/24 15:33:12 Job disconnected, attempting to reconnect
    Socket between submit and execute hosts closed unexpectedly
    Trying to reconnect to slot1_3@vgcnbwc-worker-c64m2-1465.novalocal <10.5.68.200:9618?addrs=10.5.68.200-9618&noUDP&sock=479534_043c_4>
...
024 (36707199.000.000) 11/24 15:33:20 Job reconnection failed
    Job not found at execution machine
    Can not reconnect to slot1_3@vgcnbwc-worker-c64m2-1465.novalocal, rescheduling job
...