### PR TITLE
WIP: Update sn07 playbook and the requirements.yml file

### DIFF
--- a/files/galaxy/config/nginx_gunicorn_selinux.te
+++ b/files/galaxy/config/nginx_gunicorn_selinux.te
@@ -1,0 +1,17 @@
+module nginx_gunicorn_selinux 1.0;
+
+require {
+        type httpd_t;
+        type usr_t;
+        type unconfined_service_t;
+        type unconfined_t;
+        class unix_stream_socket connectto;
+        class sock_file { relabelto write };
+}
+
+#============= httpd_t ==============
+allow httpd_t unconfined_service_t:unix_stream_socket connectto;
+allow httpd_t usr_t:sock_file write;
+
+#============= unconfined_t ==============
+allow unconfined_t httpd_t:sock_file relabelto;

--- a/group_vars/sn07.yml
+++ b/group_vars/sn07.yml
@@ -78,8 +78,10 @@ fsm_cron_tasks:
     dow: "*"
     job: ". {{ galaxy_root }}/.bashrc && docker system prune -f > /dev/null"
     user: "{{ fsm_galaxy_user.username }}"
+  # 29.11.2022: We do not want to have the clean up task run on both the head nodes
+  # For now it will run only on sn06. So set "enable" to "false".
   gxadmin:
-    enable: true
+    enable: false
     name: "Gxadmin Galaxy clean up"
     minute: 0
     hour: "*/6"

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -17,7 +17,7 @@ collections:
     source: https://galaxy.ansible.com
     type: galaxy
   - name: devsec.hardening
-    version: 7.10.0
+    version: 8.3.0
     source: https://galaxy.ansible.com
     type: galaxy
   - name: usegalaxy_eu.handy

--- a/sn07.yml
+++ b/sn07.yml
@@ -240,7 +240,7 @@
     - usegalaxy-eu.fix-user-quotas # Automatically recalculate user quotas and attribute ELIXIR quota to ELIXIR AAI user on a regular basis
 
     # - dev-sec.os-hardening
-    - ssh_hardening
+    - ssh_hardening #dev-sec.hardening collection
 
     ## Setup docker
     - geerlingguy.docker

--- a/sn07.yml
+++ b/sn07.yml
@@ -58,7 +58,7 @@
   handlers:
     - name: Restart Galaxy
       shell: |
-        echo 'Manual web handler restart required' && cd /opt/galaxy/ && source /opt/galaxy/.bashrc  && sudo -u galaxy /usr/bin/galaxy-sync-to-nfs && systemctl restart galaxy-handler@* && systemctl restart galaxy-workflow-scheduler@*
+        echo 'Manual web handler restart required' && cd /opt/galaxy/ && source /opt/galaxy/.bashrc && systemctl restart galaxy-handler@* && systemctl restart galaxy-workflow-scheduler@*
   pre_tasks:
     - name: Install Dependencies
       package:
@@ -73,9 +73,6 @@
             "python3-devel",
           ]
       become: true
-    - name: Disable SELinux
-      selinux:
-        state: disabled
   post_tasks:
     - name: Append some users to the systemd-journal group
       user:
@@ -112,6 +109,49 @@
         - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC9itwmMTgcRCrwjO3RCke/NWJsRb3N5lUTF5fubw/V0PlSbFDuv7IMKp5hhFfhiOuVRMoXQBHnnOWWu1xd9jDqZKXmNGHg06JtnddQ/OVprZ6Dpu2g9pZ6uc4r1As94mvpICLVK9lNHPNA60sIwTsTRVFSb1VbXALI4iuLOxPLzIxhrZ1LouK19VWetJIQ/Uq8UalfTDr1KOyQQ/ZgjBeWdD5InSOl3sbPJZhGQLqSHIi0MVxH527CMnh1PQIxiD/vqX8SK7HaKvUZIHHzz5TFrUgrw7BkfRd04UIgr1OhnMf1E413yZdeQzJQV7C1CL9MbAThXX6Ruvs0Rg3ylazpYfwDifMWvqLeRoTCDUbGx94ySO/wzer/kcjpJ27iydNo+en/hImMYz7kktf6A3BzOYxFmOQvnQ9cChP+iuk7fTiQZS7Qtkz+axNIvwCkm7Hmgt7vYizHc+OAtKmzZFTHecozjxCXs9RwynnWpToheP3ZPYgOpKc7pkUngRSjXyc= bebatut@bebatut-ThinkPad-T14-Gen-1"
         - "ecdsa-sha2-nistp521 AAAAE2VjZHNhLXNoYTItbmlzdHA1MjEAAAAIbmlzdHA1MjEAAACFBADKblzzPBc3+dEfFvhJQHsHGkFFN6ORjfXo71P1OutwcKEMCIcNkZKJHhYkLLrfTDN5JJ5tK2L5AaSxdwETofwm4AG1xv3LuoYsXC6e3sjKi09BVmzef520pIMW+rvL+hESwSazZaUAC0wDcH4aNDTonZYcAY87rpMX7pNMkNPJvWilUA== mira"
         - "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFH54+qZEBeU5uwIeWWOViLcC509qxoRW6oN0VHRQr4r nate"
+
+    # Add SELinux policy for nginx to interact with the gunicorn socket
+    - name: Check if nginx-gunicorn selinux policy is installed
+      command: semodule --list=full | grep -q nginx_gunicorn_selinux
+      register: nginx_gunicorn_selinux_policy
+      failed_when: nginx_gunicorn_selinux_policy.rc > 1
+
+    - name: Add SELinux policy for nginx to interact with the gunicorn socket
+      when: nginx_gunicorn_selinux_policy.rc == 1
+      block:
+        - name: Copy nginx-gunicorn selinux type enforcement file
+          copy:
+            src: "files/galaxy/config/nginx_gunicorn_selinux.te"
+            dest: "/tmp/nginx_gunicorn_selinux.te"
+
+        - name: Compile nginx-gunicorn selinux module
+          command: "checkmodule -M -m -o /tmp/nginx_gunicorn_selinux.mod /tmp/nginx_gunicorn_selinux.te"
+
+        - name: Compile nginx-gunicorn selinux policy package
+          command: "semodule_package -o /tmp/nginx_gunicorn_selinux.pp -m /tmp/nginx_gunicorn_selinux.mod"
+
+        - name: Install nginx-gunicorn selinux policy package
+          command: "semodule -i /tmp/nginx_gunicorn_selinux.pp"
+
+        - name: Clean up nginx-gunicorn selinux policy files
+          file:
+            path: "{{ item }}"
+            state: absent
+          with_items:
+            - "/tmp/nginx_gunicorn_selinux.te"
+            - "/tmp/nginx_gunicorn_selinux.mod"
+            - "/tmp/nginx_gunicorn_selinux.pp"
+
+    # Add http and https to the current firewall zone
+    - name: Add http and https services to the current firewall zone
+      firewalld:
+        service: "{{ item }}"
+        immediate: true
+        permanent: true
+        state: enabled
+      with_items:
+        - http
+        - https
 
   roles:
     ## Starting configuration of the operating system

--- a/sn07.yml
+++ b/sn07.yml
@@ -53,6 +53,8 @@
     - secret_group_vars/file_sources.yml # file_sources_conf.yml creds
     - secret_group_vars/all.yml # All of the other assorted secrets...
     - templates/galaxy/config/job_conf.yml
+  collections:
+    - devsec.hardening
   handlers:
     - name: Restart Galaxy
       shell: |
@@ -189,7 +191,6 @@
     ## GALAXY
     - hxr.postgres-connection
     - galaxyproject.gxadmin
-    - galaxyproject.tiaas2
     - usegalaxy_eu.ansible_nginx_upload_module
     - usegalaxy-eu.nginx
     # TODO move under monitoring + telegraf.
@@ -208,6 +209,10 @@
         galaxy_fetch_dependencies: true
         galaxy_build_client: true
 
+    - role: galaxyproject.tiaas2
+      vars:
+        tiaas_virtualenv_command: "{{ galaxy_virtualenv_command }}"
+
     ## Extras!
     - usegalaxy-eu.fix-galaxy-server-dir # Fix details into the galaxy server dirs
     - hxr.install-to-venv # Some extra packages our site needs.
@@ -225,14 +230,17 @@
     - usegalaxy-eu.fix-stuck-handlers # Restart handlers to prevent several classes of issues
     - usegalaxy-eu.log-cleaner # do not retain journalctl logs, they are unnecessary/risky under GDPR
     - usegalaxy-eu.fix-ancient-ftp-data # Remove FTP data older than 3 months, create FTP user directories
+
+    # Some of our 'cleanups' also generate telegraf format so this goes at end.
+    # 25.11.2022: Moved here becuase the galaxy-procstat role fails
+    # as it is not able to find the /etc/telegraf/telegraf.d/ directory
+    - dj-wasabi.telegraf
     - usegalaxy-eu.galaxy-procstat # Some custom telegraf monitoring that's templated
     - usegalaxy-eu.fix-missing-api-keys # Workaround for IE users not have a key set.
     - usegalaxy-eu.fix-user-quotas # Automatically recalculate user quotas and attribute ELIXIR quota to ELIXIR AAI user on a regular basis
 
-    # Some of our 'cleanups' also generate telegraf format so this goes at end.
-    - dj-wasabi.telegraf
     # - dev-sec.os-hardening
-    - dev-sec.ssh-hardening
+    - ssh_hardening
 
     ## Setup docker
     - geerlingguy.docker

--- a/sn07.yml
+++ b/sn07.yml
@@ -153,6 +153,13 @@
         - http
         - https
 
+    - name: Change compliance.log file ownership to the galaxy user
+      file:
+        path: "{{ galaxy_server_dir }}/compliance.log"
+        owner: galaxy
+        group: root
+        mode: 0644
+
   roles:
     ## Starting configuration of the operating system
     - role: usegalaxy_eu.handy.os_setup

--- a/templates/galaxy/config/job_conf.yml.j2
+++ b/templates/galaxy/config/job_conf.yml.j2
@@ -44,11 +44,14 @@ handling:
 {% if galaxy_jobconf.handlers.ready_window_size is defined %}
   ready_window_size: {{ galaxy_jobconf.handlers.ready_window_size }}
 {% endif %}
-{% if galaxy_systemd_handlers is defined %}
+{% if galaxy_systemd_handlers is defined and galaxy_systemd_handlers > 0 %}
   processes:
 {% for n in range(galaxy_systemd_handlers) %}
     {{ galaxy_systemd_handler_prefix }}_{{ n }}:
 {% endfor %}
+{% elif galaxy_systemd_handlers is defined and galaxy_systemd_handlers == 0 %}
+  processes:
+    DUMMY_PLACEHOLDER_FOR_HANDLER:
 {% endif %}
 
 #


### PR DESCRIPTION
Final changes made to `sn07.yml` after testing the playbook manually against the `sn07` server.

**File sn07.yml:**
1. **galaxyproject.gxadmin**: Missing `make` dependency for `galaxyproject.gxadmin` role. So added it through a [PR](https://github.com/usegalaxy-eu/ansible-collection-handy/pull/8) to the `usegalaxy_eu.handy` role.
2. **galaxyproject.tiaas2:**
	1. This role should be moved after the second invocation of `galaxyproject.galaxy` role; only during the second invocation the variable `galaxy_manage_clone` is set to true and the tiaas2 role requires this cloned repo to accomplish the task `Copy Galaxy's stylesheet` otherwise ansible will fail, so the role was moved after the second invocation of the `galaxyproject.galaxy` role.
	2. Since we use the `virtualenv` from a conda environment we should add the variable `tiaas_virtualenv_command` directly under this role. Adding the variable to the `group_vars/sn07.yml` would not work due to variable precedence. Also, this variable should point to the `virtualenv` present in the conda `_galaxy_` environment. This environment is created by the `galaxyproject.miniconda` role. All virtual environments are created using the `virtualenv` command from this `_galaxy_` environment
3. **dj-wasabi.telegraf:** This role should run before the `usegalaxy-eu.galaxy-procstat` role else the role will fail because it cannot find the `/etc/telegraf/telegraf.d` directory (This directory will get created only after the installation of `telegraf` package).
4. **dev-sec.ssh-hardening:**  
	1. Is [not maintained anymore](https://github.com/dev-sec/ansible-ssh-hardening). Instead, we should use their [ansible-collection-hardening](https://github.com/dev-sec/ansible-collection-hardening/tree/master/roles/ssh_hardening) collection.  
	2. Rocky 9 uses OpenSSH version 8.7 and [does not support `sntrup4591761x25519-sha512@tinyssh.org`](https://github.com/dev-sec/ansible-collection-hardening/issues/433) KEX algorithm which has been fixed in the above-mentioned collection. 

**File requirements.yml:**
1. Updated the version of the collection `devsec.hardening` to `8.3.0` because an [SELinux task in the `ssh_hardening` role fails](https://github.com/dev-sec/ansible-collection-hardening/issues/585). The updated collection fixes that issue.

**Manual changes made on the server to make galaxy run:**
1. Change ownership of the file `/opt/galaxy/server/compliance.log` to the user `galaxy`
2. SELinux set to permissive mode and/or disable (just like in sn06)
3. Stop `firewalld` service and disable it (just like in sn06)
4. Setting the systemd variable `galaxy_systemd_handlers` to `0` in `group_vars/sn07.yml` results in a broken `Job_conf.yml` because the `processes` section in the `handling` block is empty and this leads to a `NoneType` error which stops galaxy from starting. So manually adding a dummy handler process name would allow the galaxy processes to start. _This is a non-persistent change and this file will be overwritten during the next Ansible run via Jenkins._

Attach this PR to: https://github.com/usegalaxy-eu/issues/issues/352