### PR TITLE
fixed gunicorn sock in nginx

### DIFF
--- a/templates/nginx/galaxy-test.j2
+++ b/templates/nginx/galaxy-test.j2
@@ -1,5 +1,5 @@
 upstream galaxy {
-    server unix:{{ galaxy_systemd_gunicorn_listen_path }};
+    server unix:{{ galaxy_mutable_data_dir }}/{{ galaxy_systemd_gunicorn_socket_name }}.sock;
 }
 
 server {


### PR DESCRIPTION
this should at least fix the 404 and bring Galaxy test back.
Still we need to update a lot