### PR TITLE
decrease STAR mem to 50 and add scran destination with 900G mem

### DIFF
--- a/files/galaxy/dynamic_rules/usegalaxy/tool_destinations.yaml
+++ b/files/galaxy/dynamic_rules/usegalaxy/tool_destinations.yaml
@@ -374,7 +374,7 @@ fastp: {cores: 4}
 gmx_sim: {cores: 8, mem: 8, gpus: 1, runner: remote_cluster_mq_uk01}
 gmx_em: {cores: 16, mem: 8}
 gmx_fep: {cores: 16, mem: 8}
-gsc_scran_normalize: {cores:1: mem:900}
+gsc_scran_normalize: {cores:1: mem:20}
 
 # gmx_md: {runner: remote_cluster_mq_de02}
 # gmx_merge_topology_files: {runner: remote_cluster_mq_de02}

--- a/files/galaxy/dynamic_rules/usegalaxy/tool_destinations.yaml
+++ b/files/galaxy/dynamic_rules/usegalaxy/tool_destinations.yaml
@@ -374,6 +374,7 @@ fastp: {cores: 4}
 gmx_sim: {cores: 8, mem: 8, gpus: 1, runner: remote_cluster_mq_uk01}
 gmx_em: {cores: 16, mem: 8}
 gmx_fep: {cores: 16, mem: 8}
+gsc_scran_normalize: {cores:1: mem:900}
 
 # gmx_md: {runner: remote_cluster_mq_de02}
 # gmx_merge_topology_files: {runner: remote_cluster_mq_de02}
@@ -1047,7 +1048,7 @@ rgPicardMarkDups:
   env:
     _JAVA_OPTIONS: -Xmx12G -Xms1G
 rm_spurious_events.py: {mem: 4}
-rna_star: {cores: 10, mem: 90}
+rna_star: {cores: 10, mem: 50}
 rna_starsolo: {cores: 4, mem: 40}
 rna_star_index_builder_data_manager:
   cores: 10


### PR DESCRIPTION
Note that 900G for `gsc_scran_normalize` is temporary and will be used for a specific dataset. Although it consumes high memory in general, at the moment, we don't have enough data to set a dynamic destination. Once this run particular run is finished, I will set it to 20G.