### PR TITLE
Add x-clacks-overhead

### DIFF
--- a/templates/nginx/galaxy-main.j2
+++ b/templates/nginx/galaxy-main.j2
@@ -59,6 +59,8 @@ server {
 		#location /history/export_archive {
 		#	return 302 https://usegalaxy.eu;
 		#}
+
+		add_header X-Clacks-Overhead 'GNU James Taylor (@jxtx) Simon Gladman (@slugger70)';
 	}
 	location ~ ^/api/dataset_collections/([^/]+)/download/?$ {
 		proxy_buffering off;


### PR DESCRIPTION
This adds a non-standard header, that was inspired by the Discworld series. There a series of towers are used to constantly re-transmit the memory of a lost son, throughout a network. Inspired by this many servers serve a similar header with memories of lost comrades (including Sir Terry Pratchett, the author).

Here I propose adding Simon and James to the clacks-overhead served by EU, a small way to remember them.

> In Sir Terry's novel "Going Postal", the story explains that the
> inventor of the Clacks - a man named Robert Dearheart, lost his only son
> in a suspicious workplace accident, and in order to keep the memory of
> his son alive, he transmitted his son's name as a special operational
> signal through the Clacks to forever preserve his memory:

https://xclacksoverhead.org/home/about

(Feel free to reject this, it only increases response size in a very small way, and I was a big fan of discworld, as was simon.)