### PR TITLE
temporarily rolled back to sorting hat

### DIFF
--- a/templates/galaxy/config/job_conf.yml
+++ b/templates/galaxy/config/job_conf.yml
@@ -529,24 +529,24 @@ galaxy_jobconf:
       destination: tpv_dispatcher
     - id: "htseq-clip"
       destination: tpv_dispatcher
-    - id: "metaspades"
-      destination: tpv_dispatcher
-    - id: spades
-      destination: tpv_dispatcher
-    - id: spades_rnaviralspades
-      destination: tpv_dispatcher
-    - id: rnaspades
-      destination: tpv_dispatcher
-    - id: spades_plasmidspades
-      destination: tpv_dispatcher
-    - id: spades_metaviralspades
-      destination: tpv_dispatcher
-    - id: spades_metaplasmidspades
-      destination: tpv_dispatcher
-    - id: spades_coronaspades
-      destination: tpv_dispatcher
-    - id: spades_biosyntheticspades
-      destination: tpv_dispatcher
+   # - id: "metaspades"
+   #   destination: tpv_dispatcher
+   # - id: spades
+   #   destination: tpv_dispatcher
+   # - id: spades_rnaviralspades
+   #   destination: tpv_dispatcher
+   # - id: rnaspades
+   #   destination: tpv_dispatcher
+   # - id: spades_plasmidspades
+   #   destination: tpv_dispatcher
+   # - id: spades_metaviralspades
+   #   destination: tpv_dispatcher
+   # - id: spades_metaplasmidspades
+   #   destination: tpv_dispatcher
+   # - id: spades_coronaspades
+   #   destination: tpv_dispatcher
+   # - id: spades_biosyntheticspades
+   #   destination: tpv_dispatcher
     - id: snippy
       destination: tpv_dispatcher
     - id: fasta-stats


### PR DESCRIPTION
Because of frequently wrongly assigned memory, I suggest to roll it back to sorting hat until we fixed TPV.
Otherwise we are getting to many mrror-messages.