### PR TITLE
Increase resources bbtools_callvariants

### DIFF
--- a/files/galaxy/dynamic_rules/usegalaxy/tool_destinations.yaml
+++ b/files/galaxy/dynamic_rules/usegalaxy/tool_destinations.yaml
@@ -1030,6 +1030,7 @@ prokka:
   mem: 20
   cores: 8
 bbtools_callvariants:
+  mem: 15
   env:
     _JAVA_OPTIONS: -XX:MaxPermSize=2G -Xmx15G -Xms1G -Djava.io.tmpdir=/data/2/galaxy_db/tmp
 proteomics_search_msgfplus_1: {mem: 10}

--- a/files/galaxy/dynamic_rules/usegalaxy/tool_destinations.yaml
+++ b/files/galaxy/dynamic_rules/usegalaxy/tool_destinations.yaml
@@ -1029,6 +1029,9 @@ prokka:
     _JAVA_OPTIONS: -XX:MaxPermSize=2G -Xmx15G -Xms1G -Djava.io.tmpdir=/data/2/galaxy_db/tmp
   mem: 20
   cores: 8
+bbtools_callvariants:
+  env:
+    _JAVA_OPTIONS: -XX:MaxPermSize=2G -Xmx15G -Xms1G -Djava.io.tmpdir=/data/2/galaxy_db/tmp
 proteomics_search_msgfplus_1: {mem: 10}
 pyprophet_score: {mem: 400, cores: 1}
 pureclip: {mem: 32, cores: 2}


### PR DESCRIPTION
Related to error:

```
Note: Coverage capped at 65535; please use the flag 32bit for higher values.
java.lang.OutOfMemoryError: Java heap space
	at java.base/java.util.Arrays.copyOfRange(Arrays.java:4030)
	at shared.KillSwitch.copyOfRange(KillSwitch.java:472)
	at fileIO.ByteFile1.nextLine(ByteFile1.java:173)
	at fileIO.ByteFile2$BF1Thread.run(ByteFile2.java:274)

This program ran out of memory.
Try increasing the -Xmx flag and using tool-specific memory-related parameters.
```