### PR TITLE
Active Users in Telegraf

### DIFF
--- a/files/galaxy/gxadmin/gxadmin-local.sh
+++ b/files/galaxy/gxadmin/gxadmin-local.sh
@@ -1,0 +1,8 @@
+local_cu() { ## : Shows active users in last 10 minutes
+        handle_help "$@" <<-EOF
+                cu unique sorts the IP adresses from gunicorns log, using "GET /history/current_history_json"
+                and prints it in influx line format
+        EOF
+
+        echo "active_users,timespan=last_10_min users=$(journalctl -u galaxy-gunicorn@*.service --since "10 minutes ago" | grep "/history/current_history_json"  | awk "{print \$11}" | sort -u | wc -l)"
+}

--- a/group_vars/sn06.yml
+++ b/group_vars/sn06.yml
@@ -204,7 +204,7 @@ telegraf_plugins_extra:
   galaxy_active_users:
     plugin: "exec"
     config:
-      - commands = ["{{ custom_telegraf_env }} /usr/bin/gxadmin uwsgi active-users"]
+      - commands = ["/usr/bin/gxadmin local cu"]
       - timeout = "15s"
       - data_format = "influx"
       - interval = "1m"


### PR DESCRIPTION
I created a local gxadmin function that prints the active users in influxDB line format.
It should be copied automatically and is executable with `gxadmin local cu`