### PR TITLE
Update autofs tables (added 'jwd04'-share)

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -177,6 +177,7 @@ autofs_conf_files:
     - jwd01   -rw,hard,nosuid       zfs1.galaxyproject.eu:/export/&
     - jwd02f  -rw,hard,nosuid       zfs2f.galaxyproject.eu:/export/&
     - jwd03f  -rw,hard,nosuid,nconnect=2      denbi.svm.bwsfs.uni-freiburg.de:/ws02/&
+    - jwd04   -rw,hard,nosuid       zfs3f.galaxyproject.eu:/export/&
   discontinued:
     - 0       -rw,hard,nosuid      sn01.bi.uni-freiburg.de:/export/data3/galaxy/net/data/&
     - 1       -rw,hard,nosuid      sn03.bi.uni-freiburg.de:/export/galaxy1/data/&


### PR DESCRIPTION
An update for `auto.data` to include the shiny new `jwd04`-share, now available courtesy of Bernd. Yes the name is rly "jwd04", Bernd has decided to drop the 'f'-suffix for new *shares* backed by all-flash storage.