### PR TITLE
Disable the last currently active JWD on the A400

### DIFF
--- a/templates/galaxy/config/object_store_conf.xml.j2
+++ b/templates/galaxy/config/object_store_conf.xml.j2
@@ -136,7 +136,7 @@ The storage consists of 16 Gen6 type A200 storage nodes and 16 Gen5 type X410 no
             <files_dir path="/data/dnb07/galaxy_db/files"/>
             <extra_dir type="job_work" path="/data/jwd02f/main"/>
         </backend>
-        <backend id="files15" type="disk" weight="1" store_by="uuid">
+        <backend id="files15" type="disk" weight="0" store_by="uuid">
             <files_dir path="/data/dnb07/galaxy_db/files"/>
             <extra_dir type="job_work" path="/data/jwd03f/main"/>
         </backend>


### PR DESCRIPTION
This PR assigns `weight="0"` to `files15`; this data space has the last currently active JWD that resides on the A44 (`jwd03f`).