### PR TITLE
Update for autofs-config (dnb-ds0{1,2})

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -161,6 +161,8 @@ autofs_conf_files:
     - dp01    -rw,hard,nosuid,nconnect=2      denbi.svm.bwsfs.uni-freiburg.de:/dataplant01
     - dnb01   -rw,hard,nosuid      ufr-dyn.isi1.public.ads.uni-freiburg.de:/ifs/isi1/ufr/bronze/nfs/denbi/&
     - dnb02   -rw,hard,nosuid      ufr-dyn.isi1.public.ads.uni-freiburg.de:/ifs/isi1/ufr/bronze/nfs/denbi/&
+    - dnb-ds01 -rw,hard,nosuid,nconnect=2      denbi.svm.bwsfs.uni-freiburg.de:/dnb01-legacy
+    - dnb-ds02 -rw,hard,nosuid,nconnect=2      denbi.svm.bwsfs.uni-freiburg.de:/dnb02-legacy
     - dnb03   -rw,hard,nosuid      ufr-dyn.isi1.public.ads.uni-freiburg.de:/ifs/isi1/ufr/bronze/nfs/denbi/&
     - dnb04   -rw,hard,nosuid      ufr-dyn.isi1.public.ads.uni-freiburg.de:/ifs/isi1/ufr/bronze/nfs/denbi/&
     - dnb05   -rw,hard,nosuid,nconnect=2      denbi.svm.bwsfs.uni-freiburg.de:/dnb01/&


### PR DESCRIPTION
This PR adds the new transition mountpoints for `dnb0{1,2}` (`/data/dnb-ds01` and `/data/dnb-ds02`).