### PR TITLE
Allow maintenance node to communicate to galaxy DB

### DIFF
--- a/group_vars/sn05.yml
+++ b/group_vars/sn05.yml
@@ -56,6 +56,7 @@ postgresql_conf:
 postgresql_pg_hba_conf:
   - "host    postgres        galaxy          132.230.223.239/32      md5"
   - "host    postgres        galaxy          10.5.68.237/32          md5"
+  - "host    galaxy          galaxy          10.5.68.118/32          md5"
   - "host    postgres        galaxy-test     10.5.68.154/32          md5"
   - "host    galaxy          galaxy          132.230.223.239/32      md5"
   - "host    galaxy          galaxy          10.5.68.237/32          md5"
@@ -63,6 +64,7 @@ postgresql_pg_hba_conf:
   - "host    galaxy          galaxy          100.118.169.22/32       md5"
   - "host    galaxy          galaxy-readonly 132.230.223.239/32      md5"
   - "host    galaxy          galaxy-readonly 10.5.68.237/32          md5"
+  - "host    galaxy          galaxy-readonly 10.5.68.118/32          md5"
   - "host    tiaas           tiaas           132.230.223.239/32      md5"
   - "host    tiaas           tiaas           10.5.68.237/32          md5"
   - "host    galaxy-test     galaxy-test     132.230.223.239/32      md5"


### PR DESCRIPTION
The galaxy will be installed in the maintenance node and synced to NFS (not at the moment, but in the future). Also, the maintenance node will run cron jobs that use galaxy DB user. So maintenance node needs to communicate with the galaxy database.