### PR TITLE
migrate pulsar staging from dnb01 to jwd04

### DIFF
--- a/templates/galaxy/config/pulsar_app.yml
+++ b/templates/galaxy/config/pulsar_app.yml
@@ -1,5 +1,5 @@
 private_token: {{ pulsar_private_token }}
-staging_directory: /data/dnb01/galaxy_db/pulsar_staging/
+staging_directory: /data/jwd04/galaxy_db/pulsar_staging/
 tool_dependency_dir: /data/dnb01/galaxy_db/pulsar_dependencies/
 
 managers:

--- a/templates/galaxy/config/pulsar_app.yml
+++ b/templates/galaxy/config/pulsar_app.yml
@@ -1,5 +1,5 @@
 private_token: {{ pulsar_private_token }}
-staging_directory: /data/jwd04/galaxy_db/pulsar_staging/
+staging_directory: /data/jwd04/pulsar_staging/
 tool_dependency_dir: /data/dnb01/galaxy_db/pulsar_dependencies/
 
 managers:


### PR DESCRIPTION
See issue: https://github.com/usegalaxy-eu/issues/issues/381

@bgruening Do we have to create the path `galaxy_db/pulsar_staging/` in `/data/jwd04` or will galaxy/pulsar take care of it?