### PR TITLE
Fix file ownership of the compliance log

### DIFF
--- a/roles/usegalaxy-eu.fix-galaxy-server-dir/tasks/main.yml
+++ b/roles/usegalaxy-eu.fix-galaxy-server-dir/tasks/main.yml
@@ -22,5 +22,8 @@
 - name: Create the compliance.log file, if it doesnt exist already
   file:
     path: "{{ galaxy_server_dir }}/compliance.log"
+    owner: galaxy
+    group: root
+    mode: 0644
     state: touch
   when: not compliance_log_stat_result.stat.exists


### PR DESCRIPTION
With this fix we can remove the task to change the file ownership of the compliance log on the headnodes (for now its on sn07.yml playbook)