### PR TITLE
Re-balance JWD weights

### DIFF
--- a/templates/galaxy/config/object_store_conf.xml.j2
+++ b/templates/galaxy/config/object_store_conf.xml.j2
@@ -140,7 +140,7 @@ The storage consists of 16 Gen6 type A200 storage nodes and 16 Gen5 type X410 no
             <files_dir path="/data/dnb07/galaxy_db/files"/>
             <extra_dir type="job_work" path="/data/jwd03f/main"/>
         </backend>
-        <backend id="files16" type="disk" weight="1" store_by="uuid">
+        <backend id="files16" type="disk" weight="2" store_by="uuid">
             <files_dir path="/data/dnb07/galaxy_db/files"/>
             <extra_dir type="job_work" path="/data/jwd04/main"/>
         </backend>


### PR DESCRIPTION
`jwd04` has approx. twice the storage space available that `jwd02f` has; giving `jwd04` a weight twice that of `jwd02f` should help balance the block usage on both shares.