### PR TITLE
Emergency rebalance JWDs (jwd02f running full fast)

### DIFF
--- a/templates/galaxy/config/object_store_conf.xml.j2
+++ b/templates/galaxy/config/object_store_conf.xml.j2
@@ -128,11 +128,11 @@ The storage consists of 16 Gen6 type A200 storage nodes and 16 Gen5 type X410 no
             <extra_dir type="temp" path="/data/jwd/object_store_temp/dnb06"/>
             <extra_dir type="job_work" path="/data/jwd/main"/>
         </backend>
-        <backend id="files13" type="disk" weight="0" store_by="uuid">
+        <backend id="files13" type="disk" weight="4" store_by="uuid">
             <files_dir path="/data/dnb07/galaxy_db/files"/>
             <extra_dir type="job_work" path="/data/jwd01/main"/>
         </backend>
-        <backend id="files14" type="disk" weight="1" store_by="uuid">
+        <backend id="files14" type="disk" weight="0" store_by="uuid">
             <files_dir path="/data/dnb07/galaxy_db/files"/>
             <extra_dir type="job_work" path="/data/jwd02f/main"/>
         </backend>


### PR DESCRIPTION
`jwd02f` is running faster than I anticipated, I propose to throw most of the JWD traffic on the spinning-rust share `jwd01` for the time being and pulling `jwd02f` entirely back from the front line for now.