### PR TITLE
Temporarily disable jwd04, it's running full fast

### DIFF
--- a/templates/galaxy/config/object_store_conf.xml.j2
+++ b/templates/galaxy/config/object_store_conf.xml.j2
@@ -140,7 +140,7 @@ The storage consists of 16 Gen6 type A200 storage nodes and 16 Gen5 type X410 no
             <files_dir path="/data/dnb07/galaxy_db/files"/>
             <extra_dir type="job_work" path="/data/jwd03f/main"/>
         </backend>
-        <backend id="files16" type="disk" weight="2" store_by="uuid">
+        <backend id="files16" type="disk" weight="0" store_by="uuid">
             <files_dir path="/data/dnb07/galaxy_db/files"/>
             <extra_dir type="job_work" path="/data/jwd04/main"/>
         </backend>


### PR DESCRIPTION
If we extrapolate the trend for `jwd04`, this share too will *probably* run full during the weekend. This PR completely closes `jwd04` for business (for *new* business at least). To be merged when needed, but I wouldn't wait much longer...