### PR TITLE
Remove 'required' parameter from 'add_subparsers' function in the galaxy_jwd python script

### DIFF
--- a/roles/usegalaxy-eu.bashrc/files/galaxy_jwd.py
+++ b/roles/usegalaxy-eu.bashrc/files/galaxy_jwd.py
@@ -20,7 +20,6 @@ def main():
     parser = argparse.ArgumentParser()
     subparsers = parser.add_subparsers(
         dest="subcommand",
-        required=True,
         title="""
         Use one of the following subcommands:
             get_jwd: Get JWD path of a given Galaxy job id


### PR DESCRIPTION
To support python 3.6 this parameter should be removed . See [here](https://github.com/python/cpython/pull/3027)