### PR TITLE
Add condition to check if the JWD exists for a JID

### DIFF
--- a/roles/usegalaxy-eu.bashrc/tasks/bashrc_tasks.yml
+++ b/roles/usegalaxy-eu.bashrc/tasks/bashrc_tasks.yml
@@ -77,6 +77,13 @@
 
           JID=$1
           JWD=$(python /usr/local/bin/galaxy_jwd get_jwd $JID)
+
+          # Check the return code and whether the job working directory exists
+          if [[ $? -ne 0 || ! -d $JWD ]]; then
+              echo "INFO: Could not find the job working directory for job $JID"
+              return 1
+          fi
+
           cd $JWD
           }
 


### PR DESCRIPTION
    
This checks both the return code and whether the folder exists, to avoid `bash: cd: too many arguments` errors