### PR TITLE
rotate audit logs

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -33,6 +33,11 @@ chrony_keyfile: '/etc/chrony.keys'
 # Telegraf var
 dc: ufr-rz
 
+# OS Hardening
+os_auditd_max_log_file_action: rotate
+os_auditd_space_left: 500
+os_auditd_space_left_action: suspend
+
 # Telegraf
 telegraf_agent_package_state: latest
 telegraf_agent_output:


### PR DESCRIPTION
OS hardening sets audit.conf's `max_log_file_action` to `keep_logs` which can lead to full disks.
setting it to `rotate` and the `space_left` parameter to 500, will rotate the logs and suspend the Daemon from writing if the available disk space is <500 MB