### PR TITLE
Add new 'galaxy-sync' NFS share to autofs config

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -180,6 +180,7 @@ autofs_conf_files:
     - gxtst   -rw,hard,nosuid,nconnect=2      denbi.svm.bwsfs.uni-freiburg.de:/ws01/galaxy-sync/test
   gxkey:
     - gxkey   -rw,hard,nosuid,nconnect=2      denbi.svm.bwsfs.uni-freiburg.de:/ws01/galaxy-sync/main
+    - galaxy-sync -rw,hard,nosuid,nconnect=2  denbi.svm.bwsfs.uni-freiburg.de:/galaxy-sync
   jwd:
     - jwd     -rw,hard,nosuid,nconnect=2      denbi.svm.bwsfs.uni-freiburg.de:/ws01/&
     - jwd01   -rw,hard,nosuid       zfs1.galaxyproject.eu:/export/&


### PR DESCRIPTION
The maintenance node will rsync the galaxy codebase to this share and then this share can be mounted as read-only in celery and worker nodes as `/opt/galaxy` in the future after the initial testing. So at the moment, we do not need to add this to the VGCN infrastructure. I will also update the [storage.md](https://github.com/usegalaxy-eu/operations/blob/main/storage.md) document accordingly.