### PR TITLE
Fix dry_run parsing in the JWD clean up script

### DIFF
--- a/roles/usegalaxy-eu.bashrc/files/galaxy_jwd.py
+++ b/roles/usegalaxy-eu.bashrc/files/galaxy_jwd.py
@@ -35,24 +35,40 @@ def main():
             <pg_host>:5432:*:<pg_user>:<pg_password>
 
         Example:
-            python galaxy_jwd.py get_jwd 12345678
-            python galaxy_jwd.py clean_jwds --dry_run True --days 30
+            get_jwd:
+                python galaxy_jwd.py get_jwd 12345678
+            clean_jwds:
+                Dry run: python galaxy_jwd.py clean_jwds --dry_run --days 5
+                No dry run: python galaxy_jwd.py clean_jwds --no_dry_run --days 5
         """,
     )
 
     # Parser for the get_jwd subcommand
-    get_jwd_parser = subparsers.add_parser("get_jwd", help="Get JWD path of a given Galaxy job id")
+    get_jwd_parser = subparsers.add_parser(
+        "get_jwd", help="Get JWD path of a given Galaxy job id"
+    )
     get_jwd_parser.add_argument(
         "job_id",
         help="Galaxy job id",
     )
 
     # Parser for the clean_jwds subcommand
-    clean_jwds_parser = subparsers.add_parser("clean_jwds", help="Clean JWD's of jobs failed within last X days")
-    clean_jwds_parser.add_argument(
+    clean_jwds_parser = subparsers.add_parser(
+        "clean_jwds", help="Clean JWD's of jobs failed within last X days"
+    )
+    dry_run_group = clean_jwds_parser.add_mutually_exclusive_group()
+    dry_run_group.add_argument(
         "--dry_run",
-        help="If True, do NOT delete JWD's; only print them (default: True)",
+        help="Dry run (default: True)",
+        dest="dry_run",
         default=True,
+        action="store_true",
+    )
+    dry_run_group.add_argument(
+        "--no_dry_run",
+        help="No dry run",
+        dest="dry_run",
+        action="store_false",
     )
     clean_jwds_parser.add_argument(
         "--days",
@@ -75,12 +91,19 @@ def main():
         raise ValueError("Please set ENV PGHOST")
 
     # Check if ~/.pgpass file exists and is not empty
-    if not os.path.isfile(os.path.expanduser("~/.pgpass")) or os.stat(os.path.expanduser("~/.pgpass")).st_size == 0:
-        raise ValueError("Please create a ~/.pgpass file in format: <pg_host>:5432:*:<pg_user>:<pg_password>")
+    if (
+        not os.path.isfile(os.path.expanduser("~/.pgpass"))
+        or os.stat(os.path.expanduser("~/.pgpass")).st_size == 0
+    ):
+        raise ValueError(
+            "Please create a ~/.pgpass file in format: <pg_host>:5432:*:<pg_user>:<pg_password>"
+        )
 
     # Check if the given galaxy.yml file exists
     if not os.path.isfile(os.environ.get("GALAXY_CONFIG_FILE")):
-        raise ValueError(f"The given galaxy.yml file {os.environ.get('GALAXY_CONFIG_FILE')} does not exist")
+        raise ValueError(
+            f"The given galaxy.yml file {os.environ.get('GALAXY_CONFIG_FILE')} does not exist"
+        )
 
     # Set variables
     galaxy_config_file = os.environ.get("GALAXY_CONFIG_FILE").strip()
@@ -88,7 +111,9 @@ def main():
     db_name = os.environ.get("PGDATABASE").strip()
     db_user = os.environ.get("PGUSER").strip()
     db_host = os.environ.get("PGHOST").strip()
-    db_password = extract_password_from_pgpass(pgpass_file=os.path.expanduser("~/.pgpass"))
+    db_password = extract_password_from_pgpass(
+        pgpass_file=os.path.expanduser("~/.pgpass")
+    )
     object_store_conf = get_object_store_conf_path(galaxy_config_file)
     backends = parse_object_store(object_store_conf)
 
@@ -117,12 +142,14 @@ def main():
     if args.subcommand == "clean_jwds":
         # Check if the given Galaxy log directory exists
         if not os.path.isdir(galaxy_log_dir):
-            raise ValueError(f"The given Galaxy log directory {galaxy_log_dir} does not exist")
+            raise ValueError(
+                f"The given Galaxy log directory {galaxy_log_dir} does not exist"
+            )
 
         # Set variables
         dry_run = args.dry_run
         days = args.days
-        jwd_cleanup_log = f"{galaxy_log_dir}/jwd_cleanup" f"_{datetime.now().strftime('%d_%m_%Y-%I_%M_%S')}.log"
+        jwd_cleanup_log = f"{galaxy_log_dir}/jwd_cleanup_{datetime.now().strftime('%d_%m_%Y-%I_%M_%S')}.log"
         failed_jobs = db.get_failed_jobs(days=days)
 
         # Delete JWD folders if dry_run is False
@@ -137,8 +164,8 @@ def main():
                     # Delete JWD folders older than X days
                     jwd_path = decode_path(job_id, metadata, backends)
                     if jwd_path:
-                        jwd_log.write(f"{job_id}: {jwd_path}")
                         delete_jwd(jwd_path)
+                        jwd_log.write(f"{job_id}: {jwd_path}")
         else:
             # Print JWD folders older than X days
             for job_id, metadata in failed_jobs.items():
@@ -228,7 +255,9 @@ def decode_path(job_id, metadata, backends_dict):
 
     # Check if object_store_id exists in our object store config
     if metadata[0] not in backends_dict.keys():
-        raise ValueError(f"Object store id '{metadata[0]}' does not exist in the object_store_conf.xml file")
+        raise ValueError(
+            f"Object store id '{metadata[0]}' does not exist in the object_store_conf.xml file"
+        )
 
     jwd_path = f"{backends_dict[metadata[0]]}/0{job_id[0:2]}/{job_id[2:5]}/{job_id}"
 
@@ -256,6 +285,7 @@ def delete_jwd(jwd_path):
         jwd_path (str): Path to the JWD folder
     """
     try:
+        print(f"Deleting JWD: {jwd_path}\n")
         shutil.rmtree(jwd_path)
     except OSError as e:
         print(f"Error deleting JWD: {jwd_path} : {e.strerror}")
@@ -273,7 +303,9 @@ class Database:
 
     def __init__(self, dbname, dbuser, dbhost, dbpassword):
         try:
-            self.conn = psycopg2.connect(dbname=dbname, user=dbuser, host=dbhost, password=dbpassword)
+            self.conn = psycopg2.connect(
+                dbname=dbname, user=dbuser, host=dbhost, password=dbpassword
+            )
         except psycopg2.OperationalError as e:
             print(f"Unable to connect to database: {e}")
 


### PR DESCRIPTION
dry_run user argument was parsed as a Python string instead of a boolean. Now, this commit introduces dry_run and no_dry_run mutual exclusive groups and defaults to dry_run.