### PR TITLE
Fix fix-stop-ITs role

### DIFF
--- a/roles/usegalaxy-eu.fix-stop-ITs/tasks/main.yml
+++ b/roles/usegalaxy-eu.fix-stop-ITs/tasks/main.yml
@@ -7,19 +7,26 @@
     group: root
     mode: 0755
 
-- name: Create logfile
+- name: Create cron log directory
   file:
     state: directory
+    path: /var/log/cron
+    mode: 0755
+    owner: root
+    group: root
+
+- name: Create logfile
+  file:
+    state: touch
     path: /var/log/cron/stop-ITs.log
     mode: 0664
     owner: "{{ galaxy_user.name }}"
     group: "{{ galaxy_group.name }}"
-    state: touch
 
 - name: Setup logrotate
   copy:
     content: |
-      /var/log/stop-ITs.log
+      /var/log/cron/stop-ITs.log
       {
           rotate 6
           daily


### PR DESCRIPTION
Adds exclusive create directory task
Removes redundant state in the create logfile task (parameters should be used only once)
Fixes the path of the logfile in the logrotate task