### PR TITLE
Swap weight values between 'jwd04' and 'jwd05e'.

### DIFF
--- a/templates/galaxy/config/object_store_conf.xml.j2
+++ b/templates/galaxy/config/object_store_conf.xml.j2
@@ -152,11 +152,11 @@ The storage consists of 16 Gen6 type A200 storage nodes and 16 Gen5 type X410 no
             <files_dir path="/data/dnb08/galaxy_db/files"/>
             <extra_dir type="job_work" path="/data/jwd02f/main"/>
         </backend>
-        <backend id="files19" type="disk" weight="2" store_by="uuid">
+        <backend id="files19" type="disk" weight="1" store_by="uuid">
             <files_dir path="/data/dnb08/galaxy_db/files"/>
             <extra_dir type="job_work" path="/data/jwd04/main"/>
         </backend>
-        <backend id="files20" type="disk" weight="1" store_by="uuid">
+        <backend id="files20" type="disk" weight="2" store_by="uuid">
             <files_dir path="/data/dnb08/galaxy_db/files"/>
             <extra_dir type="job_work" path="/data/jwd05e/main"/>
         </backend>


### PR DESCRIPTION
Give `jwd05e` (backed by a dataset that is encrypted at the ZFS level) a higher weight than `jwd04`, to assess its I/O-performance under increased load.