### PR TITLE
Ask for realistic resources for small viral genomes assembly

### DIFF
--- a/files/galaxy/dynamic_rules/usegalaxy/tool_destinations.yaml
+++ b/files/galaxy/dynamic_rules/usegalaxy/tool_destinations.yaml
@@ -1187,11 +1187,11 @@ sshmm: {mem: 16}
 structurefold: {mem: 12}
 rnaspades: {cores: 10, mem: 250}
 spades_biosyntheticspades: {cores: 10, mem: 450}
-spades_coronaspades: {cores: 10, mem: 250}
+spades_coronaspades: {cores: 10, mem: 8}
 spades_metaplasmidspades: {cores: 10, mem: 330}
 spades_metaviralspades: {cores: 10, mem: 250}
 spades_plasmidspades: {cores: 10, mem: 250}
-spades_rnaviralspades: {cores: 10, mem: 250}
+spades_rnaviralspades: {cores: 10, mem: 8}
 strelka_germline: {cores: 8, mem: 12}
 strelka_somatic: {cores: 8, mem: 12}
 stringtie: {mem: 25}


### PR DESCRIPTION
spades comes with specialized rnaviralspades and coronaspades submodules, and these do not require a lot of resources.