### PR TITLE
Enable VGCN monitoring role on sn06

### DIFF
--- a/group_vars/sn06.yml
+++ b/group_vars/sn06.yml
@@ -243,6 +243,10 @@ pip_install_dependencies:
   - WeasyPrint
   - nbconvert
   - gitlab-arc-fs
+  # Needed for usegalaxy-eu.vgcn-monitoring Telegraf role
+  - pyyaml
+  - GitPython
+  - python-openstackclient
 
 yum_exclude_repos:
   - condor*

--- a/sn06.yml
+++ b/sn06.yml
@@ -231,3 +231,4 @@
     - dj-wasabi.telegraf
     # - dev-sec.os-hardening
     - dev-sec.ssh-hardening
+    - usegalaxy-eu.vgcn-monitoring


### PR DESCRIPTION
With this, we can proceed with the building of the Grafana dashboard.

Wait for this PR to be merged: https://github.com/usegalaxy-eu/infrastructure-playbook/pull/667