### PR TITLE
fix vgcn-monitoring script

### DIFF
--- a/roles/usegalaxy-eu.vgcn-monitoring/templates/vgcn_monitoring.py.j2
+++ b/roles/usegalaxy-eu.vgcn-monitoring/templates/vgcn_monitoring.py.j2
@@ -123,7 +123,8 @@ def query_htcondor_status():
         print(f"Error while querying HTCondor status: {err}")
         sys.exit(1)
 
-    return output.stdout.decode("utf-8").splitlines()
+    # Remove domain name from the machine names
+    return [node.rsplit('.')[0] for node in output.stdout.decode("utf-8").splitlines()]
 
 
 def check_openstack_cmd():


### PR DESCRIPTION
Remove the domain name from the machine names (removes duplicate entries when pushing data to influxdb) of htcondor output.

The dashboard is here: https://stats.galaxyproject.eu/d/Zn2z0NYVk/vgcn-monitoring