### PR TITLE
Fix double slash in `main` welcome URL.

### DIFF
--- a/roles/usegalaxy-eu.subdomain-themes/tasks/main.yml
+++ b/roles/usegalaxy-eu.subdomain-themes/tasks/main.yml
@@ -14,7 +14,7 @@
     dest: "{{ multisite_dir }}/usegalaxy.eu.html"
     mode: 0644
   with_items:
-    - index: "/main/"
+    - index: "main/"
 
 - name: "Template out welcome pages"
   template:


### PR DESCRIPTION
I noticed the welcome is route is resolving to something like `https://galaxyproject.org/bare/eu/usegalaxy//main/?nonce=2801095`, note the double slash.  This doesn't play nicely with some of the expected page resolution on the hub, causing in-page components to fail (in my case https://galaxyproject.org/bare/eu/usegalaxy//main/, vs the correct https://galaxyproject.org/bare/eu/usegalaxy/main/)

xref https://github.com/usegalaxy-eu/infrastructure-playbook/pull/466/files; this index gets plugged into a string that has a slash before the item index, like `'https://galaxyproject.org/bare/eu/usegalaxy/{{ item.index }}?nonce='`