### PR TITLE
Remove fix-missing-api-keys role and cron job on headnode

### DIFF
--- a/sn06.yml
+++ b/sn06.yml
@@ -224,7 +224,6 @@
     - usegalaxy-eu.log-cleaner # do not retain journalctl logs, they are unnecessary/risky under GDPR
     - usegalaxy-eu.fix-ancient-ftp-data # Remove FTP data older than 3 months, create FTP user directories
     - usegalaxy-eu.galaxy-procstat # Some custom telegraf monitoring that's templated
-    - usegalaxy-eu.fix-missing-api-keys # Workaround for IE users not have a key set.
     - usegalaxy-eu.fix-user-quotas # Automatically recalculate user quotas and attribute ELIXIR quota to ELIXIR AAI user on a regular basis
     - usegalaxy-eu.fix-stop-ITs # remove IT jobs after 24h from queue
     - usegalaxy_eu.tpv_auto_lint


### PR DESCRIPTION
Ref: https://github.com/usegalaxy-eu/issues/issues/410

Also, it's been disabled in the crontab file.
