### PR TITLE
remove nginx rate limit

### DIFF
--- a/templates/nginx/galaxy-main.j2
+++ b/templates/nginx/galaxy-main.j2
@@ -88,7 +88,6 @@ server {
 
 	location /_upload {
 		upload_store {{ galaxy_config['galaxy']['nginx_upload_store'] }};
-		upload_limit_rate 32k;
 		upload_store_access user:rw group:rw all:rw;
 		upload_pass_form_field "";
 		upload_set_form_field "__${upload_field_name}__is_composite" "true";
@@ -112,7 +111,6 @@ server {
 				rewrite "" /api/jobs/$arg_job_id/files last;
 		}
 		upload_store {{ galaxy_config['galaxy']['nginx_upload_job_files_store'] }};
-		upload_limit_rate 32k;
 		upload_store_access user:rw group:rw all:rw;
 		upload_pass_form_field "";
 		upload_set_form_field "__${upload_field_name}_path" "$upload_tmp_path";


### PR DESCRIPTION
Remove "upload_limit_rate" for Nginx, this is needed to allow pulsar network endpoints to upload back job outputs.