### PR TITLE
Update galaxy_jwd python script to handle jwds of pulsar_embedded jobs

### DIFF
--- a/roles/usegalaxy-eu.bashrc/defaults/main.yml
+++ b/roles/usegalaxy-eu.bashrc/defaults/main.yml
@@ -3,3 +3,5 @@ bashrc_users:
   - uname: "{{ galaxy_user.name }}"
     uhome: "{{ galaxy_user.home }}"
     gname: "{{ galaxy_group.name }}"
+
+galaxy_pulsar_app_conf: "{{ galaxy_config_dir }}/pulsar_app.yml"

--- a/roles/usegalaxy-eu.bashrc/tasks/bashrc_tasks.yml
+++ b/roles/usegalaxy-eu.bashrc/tasks/bashrc_tasks.yml
@@ -108,13 +108,14 @@
         path: "{{ item.uhome }}/.bashrc"
         line: "{{ task_item }}"
       loop:
-        # ENV's for gxadmin
+        # ENV's for gxadmin and the galaxy_jwd python script
         - "export GALAXY_CONFIG_DIR={{ galaxy_config_dir }}"
         - "export GALAXY_CONFIG_FILE={{ galaxy_config_file }}"
         - "export GALAXY_LOG_DIR={{ galaxy_log_dir }}"
         - "export GALAXY_MUTABLE_CONFIG_DIR={{ galaxy_mutable_config_dir }}"
         - "export GALAXY_ROOT={{ galaxy_server_dir }}"
         - "export VIRTUAL_ENV={{ galaxy_venv_dir }}"
+        - "export GALAXY_PULSAR_APP_CONF={{ galaxy_pulsar_app_conf }}"
       loop_control:
         loop_var: task_item
 


### PR DESCRIPTION
`pulsar_embedded` jobs use _staging directory_ as the JWD base so for such jobs the usual construction of the JWD path does not apply. This PR adds the required functionality to handle such jobs.

1. Update the `galaxy_jwd` script
2. Add a new environment variable (for `pulsar_app.yml`)