### PR TITLE
Add condor scratch to mounts

### DIFF
--- a/files/galaxy/dynamic_rules/usegalaxy/total_perspective_vortex/destinations.yml
+++ b/files/galaxy/dynamic_rules/usegalaxy/total_perspective_vortex/destinations.yml
@@ -13,6 +13,7 @@ destinations:
       docker_net: bridge
       docker_auto_rm: true
       docker_set_user: ""
+      docker_volumes: "$_CONDOR_SCRATCH_DIR:rw,$default,$job_directory:rw,$tool_directory:ro,/cvmfs/data.galaxyproject.org:ro"
       require_container: true
       submit_request_cpus: "{cores}"
       submit_request_memory: "{mem}G"


### PR DESCRIPTION
I think this will fix:

```
[36mError: cannot create temp directory /var/lib/condor/execute/dir_3780267.
[0m
```

From @wm75. However, we need to clean those volume paths. 