### PR TITLE
fix repeatmasker

### DIFF
--- a/files/galaxy/dynamic_rules/usegalaxy/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_rules/usegalaxy/total_perspective_vortex/tools.yml
@@ -708,7 +708,8 @@ tools:
   toolshed.g2.bx.psu.edu/repos/bgruening/repeat_masker/repeatmasker_wrapper/.*:
     env:
       RM_LIB_PATH: "/data/db/databases/dfam/3.4/"
-
+  toolshed.g2.bx.psu.edu/repos/bgruening/repeat_masker/repeatmasker_wrapper/4.1.5+galaxy0:
+    cores: 4
   toolshed.g2.bx.psu.edu/repos/galaxyp/reactome_pathwaymatcher/reactome_pathwaymatcher/.*:
     env:
       _JAVA_OPTIONS: -XX:MaxPermSize=2G -Xmx17G -Xms1G -Djava.io.tmpdir=/data/2/galaxy_db/tmp


### PR DESCRIPTION
tool versions bigger then 4.1.5+galaxy0 should not use the env ... how do we do this effectively in TPV?