### PR TITLE
change embedded to require

### DIFF
--- a/files/galaxy/dynamic_rules/usegalaxy/total_perspective_vortex/destinations.yml
+++ b/files/galaxy/dynamic_rules/usegalaxy/total_perspective_vortex/destinations.yml
@@ -62,7 +62,7 @@ destinations:
     max_accepted_cores: 24
     max_accepted_mem: 128
     scheduling:
-      prefer:
+      require:
         - docker
         - embedded-pulsar
 


### PR DESCRIPTION
so only tools that have the `embedded-pulsar` tag will go there