### PR TITLE
Fix typo for `picard_MarkDuplicates` and remove duplicate

### DIFF
--- a/files/galaxy/dynamic_rules/usegalaxy/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_rules/usegalaxy/total_perspective_vortex/tools.yml
@@ -621,7 +621,7 @@ tools:
     cores: 1
     mem: 6
 
-  toolshed.g2.bx.psu.edu/repos/devteam/picard/picard_MarkDuplicates/*:
+  toolshed.g2.bx.psu.edu/repos/devteam/picard/picard_MarkDuplicates/.*:
     cores: 8
     mem: 20
     inherits: basic_docker_tool
@@ -725,10 +725,6 @@ tools:
   toolshed.g2.bx.psu.edu/repos/devteam/picard/picard_SortSam/.*:
     env:
       _JAVA_OPTIONS: -Xmx4G -Xms1G -Djava.io.tmpdir=/data/2/galaxy_db/tmp
-
-  toolshed.g2.bx.psu.edu/repos/devteam/picard/picard_MarkDuplicates/.*:
-    env:
-      _JAVA_OPTIONS: -Xmx12G -Xms1G -Djava.io.tmpdir=/data/2/galaxy_db/tmp
 
   toolshed.g2.bx.psu.edu/repos/galaxyp/peptideshaker/peptide_shaker/.*:
     env:


### PR DESCRIPTION
Note that this alone will still not solve the issue below. #702 is also required to solve the issue.

> galaxy.eu/
> Error Localization
> Dataset	110595382 (4838ba20a6d8676537c328e408d62f12)
> History	1435779 (57b8758b73c6e907)
> Failed Job	32: MarkDuplicates on data 29: tabular (4838ba20a6d867659dffc5088526f95e)
> User Provided Information
> The user redacted (user: 67490) provided the following information:
>
> I get this messege when trying to run the app:
> No destinations are available to fulfill request: toolshed.g2.bx.psu.edu/repos/devteam/picard/picard_MarkDuplicates/.*, Rule: toolshed.g2.bx.psu.edu/repos/devteam/picard/picard_MarkDuplicates/.*
>
> Detailed Job Information
> Job environment and execution information is available at the job info page.
> Job ID	59507306 (11ac94870d0bb33a87659e88df640dd6)
> Tool ID	toolshed.g2.bx.psu.edu/repos/devteam/picard/picard_MarkDuplicates/2.18.2.4
> Tool Version	2.18.2.4
> Job PID or DRM id	None
> Job Tool Version	None
