### PR TITLE
disable singularity

### DIFF
--- a/files/galaxy/dynamic_rules/usegalaxy/total_perspective_vortex/destinations.yml
+++ b/files/galaxy/dynamic_rules/usegalaxy/total_perspective_vortex/destinations.yml
@@ -205,6 +205,8 @@ destinations:
     scheduling:
       prefer:
         - singularity
+      require:
+        - foo
 
   # Generic destination for tools that don't get any params
   # and no specified dependency resolution

--- a/files/galaxy/dynamic_rules/usegalaxy/total_perspective_vortex/destinations.yml
+++ b/files/galaxy/dynamic_rules/usegalaxy/total_perspective_vortex/destinations.yml
@@ -206,7 +206,7 @@ destinations:
       prefer:
         - singularity
       require:
-        - foo
+        - offline
 
   # Generic destination for tools that don't get any params
   # and no specified dependency resolution


### PR DESCRIPTION
Some nodes cannot read from CVMFS, disabling singularity would give us more time to debug the issue.