### PR TITLE
outputs_to_working_directory should be true

### DIFF
--- a/files/galaxy/tpv/destinations.yml
+++ b/files/galaxy/tpv/destinations.yml
@@ -18,7 +18,7 @@ destinations:
       require_container: true
       submit_request_cpus: "{cores}"
       submit_request_memory: "{mem}G"
-      outputs_to_working_directory: false
+      outputs_to_working_directory: true
       container_monitor_result: callback
       submit_requirements: "GalaxyDockerHack == True"
 


### PR DESCRIPTION
Is there a reason why the Docker container have that set to false?