### PR TITLE
Try telegraf role 0.14.0

### DIFF
--- a/requirements.yaml
+++ b/requirements.yaml
@@ -31,8 +31,8 @@ roles:
     version: 9.7.0
   - name: devops.tomcat7
     version: 1.0.0
-    # - name: dj-wasabi.telegraf
-    #  version: 0.10.0
+  - name: dj-wasabi.telegraf
+    version: 0.14.0
   - name: galaxyproject.galaxy
     src: https://github.com/galaxyproject/ansible-galaxy
     version: 0.9.18


### PR DESCRIPTION
The role we saved seems to have an outdated GPG key

```bash
14:42:48 TASK [dj-wasabi.telegraf : Install telegraf package | RedHat] ******************
14:42:51 fatal: [beacon-import.galaxyproject.eu]: FAILED! => {"changed": false, "msg": "Failed to validate GPG signature for telegraf-1.7.3-1.x86_64"}
14:42:51 
```