### PR TITLE
Add `ansible.windows` collections to requirements.yaml

### DIFF
--- a/requirements.yaml
+++ b/requirements.yaml
@@ -23,6 +23,9 @@ collections:
   - name: usegalaxy_eu.handy
     version: 2.2.0
     source: https://galaxy.ansible.com
+  - name: ansible.windows
+    version: 1.14.0
+    source: https://galaxy.ansible.com
 
 roles:
   - name: dev-sec.os-hardening


### PR DESCRIPTION
The `ansible.windows` collection is required by the `dj-wasabi.telegraf` to run.