### PR TITLE
Bump `devsec.hardening` collection to 8.7.0

### DIFF
--- a/requirements.yaml
+++ b/requirements.yaml
@@ -17,7 +17,7 @@ collections:
     source: https://galaxy.ansible.com
     type: galaxy
   - name: devsec.hardening
-    version: 8.3.0
+    version: 8.7.0
     source: https://galaxy.ansible.com
     type: galaxy
   - name: usegalaxy_eu.handy


### PR DESCRIPTION
Bump `devsec.hardening` collection to version 8.7.0. The current version (8.3.0) fails when used together with `ansible-core >= 2.14` because deprecated `warn` parameter is used in the `cmd` module.