### PR TITLE
Remove environment/destination from the job_conf

### DIFF
--- a/templates/galaxy/config/job_conf.yml.j2
+++ b/templates/galaxy/config/job_conf.yml.j2
@@ -111,11 +111,7 @@ tools:
 {% for tool in galaxy_jobconf['tools'] %}
 {% if 'resources' in tool %}
   - id: {{ tool['id'] }}
-    environment: {{ tool['destination'] }}
     resources: {{ tool['resources'] }}
-{% else %}
-  - id: {{ tool['id'] }}
-    environment: {{ tool['destination'] }}
 {% endif %}
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
... template for tools section as we switched to TPV

The build fails with the error 

```
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ansible.errors.AnsibleUndefinedVariable: 'dict object' has no attribute 'destination'. 'dict object' has no attribute 'destination'
00:37:44 
failed: [sn06.galaxyproject.eu] (item={'src': 'templates/galaxy/config/job_conf.yml.j2', 'dest': '/opt/galaxy/config/job_conf.yml'}) => {"ansible_loop_var": "item", "changed": false, "item": {"dest": "/opt/galaxy/config/job_conf.yml", "src": "templates/galaxy/config/job_conf.yml.j2"}, "msg": "AnsibleUndefinedVariable: 'dict object' has no attribute 'destination'. 'dict object' has no attribute 'destination'"}
```

Removing the environment/destination from the template will fix the issue or adding an additional `if` block will fix it. Since the default environment/destination is set to `tpv_dispatcher`, this is no longer needed.