### PR TITLE
Job resource parameters selector for `keras_train_and_eval` and `gmx_sim`: match tools using short tool ids in job configuration

### DIFF
--- a/templates/galaxy/config/job_conf.yml
+++ b/templates/galaxy/config/job_conf.yml
@@ -465,9 +465,9 @@ galaxy_jobconf:
   tools:
     # TODO(hxr): implement validation that checks that every destination
     # used here is defined above.
-    - id: "toolshed.g2.bx.psu.edu/repos/bgruening/keras_train_and_eval/keras_train_and_eval"
+    - id: keras_train_and_eval
       resources: usegpu
-    - id: "toolshed.g2.bx.psu.edu/repos/chemteam/gmx_sim/gmx_sim"
+    - id: gmx_sim
       resources: usegpu
   resources:
     - id: usegpu


### PR DESCRIPTION
Matching tools in the job configuration file does not seem to work as [the documentation claims](https://docs.galaxyproject.org/en/master/admin/jobs.html#static-destination-mapping).

> **id**
> `id` attribute of a Galaxy tool. Valid forms include the short `id` as found in the Tool’s XML configuration, a full Tool Shed GUID, or a Tool Shed GUID without the version component (for example `id="toolshed.example.org/repos/nate/filter_tool_repo/filter_tool/1.0.0"` or `id="toolshed.example.org/repos/nate/filter_tool_repo/filter_tool"` or `id="filter_tool"`).

I found out about it using both the short and long tool ids for `keras_train_and_eval` in the GAT 2023 VM and checking whether the job resource parameters selector shows up or not.

Therefore, this PR matches `keras_train_and_eval` and `gmx_sim` using their short tool ids. 