### PR TITLE
keras_train_and_eval: properly match tool id in tools.yml

### DIFF
--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -60,7 +60,7 @@ tools:
       # return the amount of memory needed
       value
 
-  keras_train_and_eval:
+  toolshed.g2.bx.psu.edu/repos/bgruening/keras_train_and_eval/keras_train_and_eval/.*:
     inherits: basic_gpu_resource_param_tool
 
   toolshed.g2.bx.psu.edu/repos/iuc/snippy/snippy/.*:


### PR DESCRIPTION
_The obvious is the easiest to go unnoticed._

This PR should make the job resource parameters selector for keras_train_and_eval actually do something. There were no asterisks before, so the tool id was not being matched.
