### PR TITLE
set GALAXY_MEMORY_MB to integer value and fix invalid arithmetic operator error

### DIFF
--- a/files/galaxy/tpv/tool_defaults.yml
+++ b/files/galaxy/tpv/tool_defaults.yml
@@ -8,7 +8,7 @@ tools:
     mem: cores * 3.8
     gpus: 0
     env:
-      GALAXY_MEMORY_MB: "{mem * 1024}" # set 5/2023 might be moved to runner or tool wrappers, related to Galaxy issue 15952
+      GALAXY_MEMORY_MB: "{int(mem * 1024)}" # set 5/2023 might be moved to runner or tool wrappers, related to Galaxy issue 15952
     params:
       metadata_strategy: 'extended'
       tmp_dir: true


### PR DESCRIPTION
We are seeing the following in a few error reports we received

```
galaxy_59863413.sh: line 59: 3891.2 / 1: syntax error: invalid arithmetic operator (error token is ".2 / 1")
```

Setting `GALAXY_MEMORY_MB`  to an integer value will fix this issue.