### PR TITLE
mount tmp from netapp

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -206,4 +206,5 @@ autofs_conf_files:
   usrlocal:
     - /usr/local/tools   -rw,hard,nosuid,nconnect=2      denbi.svm.bwsfs.uni-freiburg.de:/dnb01/tools
   usrlocal_celerycluster:
+    - /tmp               -rw,hard,nosuid,nconnect=2      denbi.svm.bwsfs.uni-freiburg.de:/ws01/jwd/tmp
     - /opt/galaxy        -rw,hard,nosuid,nconnect=2      denbi.svm.bwsfs.uni-freiburg.de:/ws01/galaxy-sync/main


### PR DESCRIPTION
Celery's root disk is filled up frequently by large tmp files, e.g. history export zip archives.
We should put that on a real storage