### PR TITLE
Add memory (10GB) for kraken2

### DIFF
--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -504,6 +504,10 @@ tools:
     inherits: basic_docker_tool
     cores: 1
     mem: 20
+    
+  toolshed.g2.bx.psu.edu/repos/iuc/kraken2/kraken2/.*:
+    cores: 2
+    mem: 10
 
   toolshed.g2.bx.psu.edu/repos/nml/metaspades/metaspades/.*:
     cores: 2


### PR DESCRIPTION
Kraken fails inconsistent with this error: `Loading database information...classify: Error reading in hash table` which seems to be memory related: https://github.com/DerrickWood/kraken2/issues/84  
I do not really have a good starting point of how much memory is required. Let's start with 10GB and check with the foodborn collection and increase if needed.