### PR TITLE
update sn05 playbook for Rocky 9 migration

### DIFF
--- a/sn05.yml
+++ b/sn05.yml
@@ -1,5 +1,5 @@
 ---
-- name: Galaxy DB server and HTCondor Central Manager
+- name: Galaxy DB server
   hosts: sn05
   become: true
   vars:

--- a/sn05.yml
+++ b/sn05.yml
@@ -1,5 +1,5 @@
 ---
-- name: HTCondor 8.8 Central Manager
+- name: Galaxy DB server and HTCondor Central Manager
   hosts: sn05
   become: true
   vars:
@@ -11,25 +11,21 @@
   pre_tasks:
     - name: Install Dependencies
       package:
-        name: ['python36', 'rsync']
+        name: ['python3', 'rsync', 'perl', 'glibc-langpack-en']
       become: true
-    - name: Set default version of Python
-      alternatives:
-        name: python
-        path: /usr/bin/python3
     - name: Disable firewalld service
       ansible.builtin.service:
         name: firewalld
         enabled: false
         state: stopped
   roles:
+    - geerlingguy.repo-epel
     - role: usegalaxy_eu.handy.os_setup
       vars:
         enable_hostname: true
         enable_powertools: true        # geerlingguy.repo-epel role doesn't enable PowerTools repository
         enable_install_software: true  # Some extra admin tools (*top, vim, etc)
     - usegalaxy-eu.dynmotd
-    - geerlingguy.repo-epel
     - influxdata.chrony
     - hxr.monitor-email
     - usegalaxy-eu.autoupdates  # keep all of our packages up to date


### PR DESCRIPTION
Issue: https://github.com/usegalaxy-eu/issues/issues/436

- [x] Testing of sn05 playbook on a Rocky 9 VM
- [x] Update required PostgreSQL changes to the [ansible-postgresql](https://github.com/usegalaxy-eu/ansible-postgresql) role. See [PR](https://github.com/usegalaxy-eu/ansible-postgresql/pull/2)
- [ ] Migrate HTCondor, central manager, from sn05 to sn06 and update the relevant DNS records [PRs: https://github.com/usegalaxy-eu/infrastructure-playbook/pull/783, https://github.com/usegalaxy-eu/infrastructure/pull/170]
