### PR TITLE
Migrate to rustus

### DIFF
--- a/group_vars/upload.yml
+++ b/group_vars/upload.yml
@@ -2,7 +2,7 @@
 # create_user task
 user_name: galaxy
 user_uid: 999
-user_comment: Tusd Service-Acct
+user_comment: rustus Service-Acct
 user_group_name: galaxy
 user_gid: 999
 

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -98,8 +98,8 @@ roles:
     version: 1.0.0
   - name: usegalaxy_eu.fs_maintenance
     version: 0.0.5
-  - name: galaxyproject.tusd
-    version: 0.0.1
+  - name: usegalaxy_eu.rustus
+    version: 0.1.0
   - name: usegalaxy_eu.rabbitmqserver
     version: 1.4.4
   - name: usegalaxy_eu.influxdbserver

--- a/templates/nginx/galaxy-main.j2
+++ b/templates/nginx/galaxy-main.j2
@@ -140,7 +140,7 @@ server {
 		proxy_set_header         Upgrade $http_upgrade;
 		proxy_set_header         Connection "upgrade";
 		client_max_body_size     0;
-		proxy_pass http://upload.galaxyproject.eu:1081/files;
+		proxy_pass http://upload.galaxyproject.eu:1081/api/upload/resumable_upload;
 	}
 
 	location /phinch {

--- a/templates/nginx/galaxy-test.j2
+++ b/templates/nginx/galaxy-test.j2
@@ -79,7 +79,7 @@ server {
 		proxy_set_header         Upgrade $http_upgrade;
 		proxy_set_header         Connection "upgrade";
 		client_max_body_size     0;
-		proxy_pass http://upload.galaxyproject.eu:1080/files;
+		proxy_pass http://upload.galaxyproject.eu:1080/api/upload/resumable_upload;
 	}
 
 	location /phinch {

--- a/upload.yml
+++ b/upload.yml
@@ -22,7 +22,7 @@
           - --hooks "pre-create"
           - --hooks-format tusd
           - --url "/api/upload/resumable_upload"
-          - --max-body-size 10000000
+          - --max-body-size 20000000
       - name: main_uploads
         # user that rustus will run as
         user: "{{ user_name }}"
@@ -38,7 +38,7 @@
           - --hooks "pre-create"
           - --hooks-format tusd
           - --url "/api/upload/resumable_upload"
-          - --max-body-size 10000000
+          - --max-body-size 20000000
   pre_tasks:
     - ansible.posix.firewalld:
         zone: public

--- a/upload.yml
+++ b/upload.yml
@@ -3,6 +3,8 @@
   hosts: upload
   become: true
   become_user: root
+  vars_files:
+    - secret_group_vars/sentry.yml
   vars:
     upload_dir_test: /data/jwd04/tus_upload/test
     upload_dir_main: /data/jwd04/tus_upload/main
@@ -23,6 +25,7 @@
           - --hooks-format tusd
           - --url "/api/upload/resumable_upload"
           - --max-body-size 20000000
+          - "--sentry-dsn {{ sentry_dsn.test }} --sentry-sample-rate 1.0"
       - name: main_uploads
         # user that rustus will run as
         user: "{{ user_name }}"
@@ -39,6 +42,7 @@
           - --hooks-format tusd
           - --url "/api/upload/resumable_upload"
           - --max-body-size 20000000
+          - "--sentry-dsn {{ sentry_dsn.main }} --sentry-sample-rate 1.0"
   pre_tasks:
     - ansible.posix.firewalld:
         zone: public

--- a/upload.yml
+++ b/upload.yml
@@ -1,36 +1,44 @@
 ---
-- name: Install and configure tusd
+- name: Install and configure rustus
   hosts: upload
   become: true
   become_user: root
   vars:
     upload_dir_test: /data/jwd04/tus_upload/test
     upload_dir_main: /data/jwd04/tus_upload/main
-    tusd_instances:
+    rustus_instances:
       - name: test_uploads
-        # user that tusd will run as
+        # user that rustus will run as
         user: "{{ user_name }}"
-        # group that tusd will run as
+        # group that rustus will run as
         group: "{{ user_group_name }}"
-        # args passed to tusd
+        # args passed to rustus
         args:
-          - -host={{ inventory_hostname }}
-          - -port=1080
-          - "-upload-dir={{ upload_dir_test }}"
-          - -hooks-http=https://test.usegalaxy.eu/api/upload/hooks
-          - -hooks-http-forward-headers=X-Api-Key,Cookie
+          - --host "{{ inventory_hostname }}"
+          - --port 1080
+          - "--data-dir {{ upload_dir_test }}"
+          - --hooks-http-urls "https://test.usegalaxy.eu/api/upload/hooks"
+          - --hooks-http-proxy-headers "X-Api-Key,Cookie"
+          - --hooks "pre-create"
+          - --hooks-format tusd
+          - --url "/api/upload/resumable_upload"
+          - --max-body-size 10000000
       - name: main_uploads
-        # user that tusd will run as
+        # user that rustus will run as
         user: "{{ user_name }}"
-        # group that tusd will run as
+        # group that rustus will run as
         group: "{{ user_group_name }}"
-        # args passed to tusd
+        # args passed to rustus
         args:
-          - -host={{ inventory_hostname }}
-          - -port=1081
-          - "-upload-dir={{ upload_dir_main }}"
-          - -hooks-http=https://usegalaxy.eu/api/upload/hooks
-          - -hooks-http-forward-headers=X-Api-Key,Cookie
+          - --host "{{ inventory_hostname }}"
+          - --port 1081
+          - "--data-dir {{ upload_dir_main }}"
+          - --hooks-http-urls "https://usegalaxy.eu/api/upload/hooks"
+          - --hooks-http-proxy-headers "X-Api-Key,Cookie"
+          - --hooks "pre-create"
+          - --hooks-format tusd
+          - --url "/api/upload/resumable_upload"
+          - --max-body-size 10000000
   pre_tasks:
     - ansible.posix.firewalld:
         zone: public
@@ -49,4 +57,4 @@
     ## Filesystems
     - usegalaxy-eu.autofs     # Setup the mount points which will be needed later
 
-    - galaxyproject.tusd
+    - usegalaxy_eu.rustus


### PR DESCRIPTION
Migrate to rustus from tusd.

The changes have been tested to work on one of the GAT machines.

-----

Details to be included in the merge commit message:

```
- When you create an upload, rustus tells you that it is available in the URL that you set in proxy_pass (nginx), rather than the URL that you provided.
- rustus needs some extra command-line arguments:
  - The hooks that should be enabled.
  - The format of the JSON responses. Fortunately, this can be set to "tusd" for compatibility with upstream Galaxy.
  - The base URL for all requests.
  - The maximum body size for uploads. Uploads to Galaxy are split into multiple PATCH requests  with a body size of length up to 10000000. The default for rustus seems to be lower, and needs to be fixed to a higher value via the command-line.
```