### PR TITLE
Migrate HTCondor manager from sn05 to sn06

### DIFF
--- a/group_vars/sn05.yml
+++ b/group_vars/sn05.yml
@@ -18,23 +18,23 @@ software_groups_to_install:
   - utils
 
 # HTCondor
-condor_host: "condor-cm.galaxyproject.eu"
-condor_allow_write: "10.5.68.0/24, 132.230.223.0/24, 132.230.153.0/28"
-condor_daemons:
-  - COLLECTOR
-  - MASTER
-  - NEGOTIATOR
-condor_allow_negotiator: $(ALLOW_WRITE)
-condor_allow_administrator: "$(ALLOW_NEGOTIATOR)"
-condor_network_interface: ens802f0.2368
-condor_extra: |
-  MASTER_UPDATE_INTERVAL = 150
-  CLASSAD_LIFETIME = 300
-  NEGOTIATOR_INTERVAL = 15
-  NEGOTIATOR_UPDATE_INTERVAL = 100
-  JOB_START_COUNT = 250
-  JOB_START_DELAY = 0
-  NEGOTIATOR_POST_JOB_RANK = isUndefined(RemoteOwner) * (10000 - TotalLoadAvg)
+# condor_host: "condor-cm.galaxyproject.eu"
+# condor_allow_write: "10.5.68.0/24, 132.230.223.0/24, 132.230.153.0/28"
+# condor_daemons:
+#   - COLLECTOR
+#   - MASTER
+#   - NEGOTIATOR
+# condor_allow_negotiator: $(ALLOW_WRITE)
+# condor_allow_administrator: "$(ALLOW_NEGOTIATOR)"
+# condor_network_interface: ens802f0.2368
+# condor_extra: |
+#   MASTER_UPDATE_INTERVAL = 150
+#   CLASSAD_LIFETIME = 300
+#   NEGOTIATOR_INTERVAL = 15
+#   NEGOTIATOR_UPDATE_INTERVAL = 100
+#   JOB_START_COUNT = 250
+#   JOB_START_DELAY = 0
+#   NEGOTIATOR_POST_JOB_RANK = isUndefined(RemoteOwner) * (10000 - TotalLoadAvg)
 
 # PostgreSQL
 postgresql_conf:

--- a/group_vars/sn06.yml
+++ b/group_vars/sn06.yml
@@ -369,22 +369,28 @@ galaxy_systemd_memory_limit_workflow: 15
 condor_host: "condor-cm.galaxyproject.eu"
 condor_fs_domain: bi.uni-freiburg.de
 condor_uid_domain: bi.uni-freiburg.de
-condor_allow_write: "10.5.68.0/24, 132.230.223.0/24"
+condor_allow_write: "10.5.68.0/24, 132.230.223.0/24,132.230.153.0/28"
 condor_daemons:
+  - COLLECTOR
+  - NEGOTIATOR
   - MASTER
   - SCHEDD
-condor_allow_negotiator: "132.230.223.239,$(CONDOR_HOST)"
+condor_allow_negotiator: "132.230.223.239,$(CONDOR_HOST),$(ALLOW_WRITE)"
 condor_allow_administrator: "$(ALLOW_NEGOTIATOR)"
 
-condor_system_periodic_hold: "{{ 30 * 24 * 60 * 60}}"
-condor_system_periodic_remove: "{{ 2 * 24 * 60 * 60}}"
+condor_system_periodic_hold: "{{ 30 * 24 * 60 * 60 }}"
+condor_system_periodic_remove: "{{ 2 * 24 * 60 * 60 }}"
 condor_network_interface: ens802f0.223
 condor_extra: |
   MASTER_UPDATE_INTERVAL = 150
+  CLASSAD_LIFETIME = 300
+  NEGOTIATOR_INTERVAL = 15
+  NEGOTIATOR_UPDATE_INTERVAL = 100
   SCHEDD_INTERVAL = 60
   JOB_START_COUNT = 250
   JOB_START_DELAY = 0
   CLAIM_WORKLIFE = 120
+  NEGOTIATOR_POST_JOB_RANK = isUndefined(RemoteOwner) * (10000 - TotalLoadAvg)
 
 # gie_proxy
 gie_proxy_dir: "{{ galaxy_root }}/gie-proxy/proxy"

--- a/sn05.yml
+++ b/sn05.yml
@@ -36,7 +36,7 @@
     - usegalaxy-eu.autofs
     - ssh-host-sign
     # Applications
-    - usegalaxy_eu.htcondor
+    # - usegalaxy_eu.htcondor
     - usegalaxy-eu.ansible-postgresql
     # End Applications
     - dj-wasabi.telegraf


### PR DESCRIPTION
Since sn05 will be upgraded to Rocky 9.0 we cannot use the old version of HTCondor anymore. So, we migrate the central manager from sn05 to sn06 until the cloud is also updated to Rocky 9.0. after which we can roll out HTCondor 10 and set up HTCondor manager on sn05 and retire it on sn06.

DNS update PR: https://github.com/usegalaxy-eu/infrastructure/pull/170
DB server migration issue: https://github.com/usegalaxy-eu/issues/issues/436