### PR TITLE
pulsar tag is not required

### DIFF
--- a/files/galaxy/tpv/destinations.yml.j2
+++ b/files/galaxy/tpv/destinations.yml.j2
@@ -126,9 +126,8 @@ destinations:
       docker_volumes: "$defaults,{{ cvmfs.data.path }}:{{ cvmfs.data.docker_perm }}"
       singularity_volumes: "$defaults,{{ cvmfs.data.path }}:{{ cvmfs.data.docker_perm }}"
     scheduling:
-      require:
-        - pulsar
       accept:
+        - pulsar
         - conda
         - singularity
         - docker

--- a/files/galaxy/tpv/destinations.yml.j2
+++ b/files/galaxy/tpv/destinations.yml.j2
@@ -104,7 +104,6 @@ destinations:
   #######################
 
   pulsar_default: # use for remote Pulsar nodes and ALWAYS overwrite the runner.
-    inherits: basic_singularity_destination
     abstract: true
     runner: pulsar_embedded
     env:
@@ -125,6 +124,8 @@ destinations:
       # $defaults expands to "$galaxy_root:ro,$tool_directory:ro,$job_directory:ro,$working_directory:rw,$default_file_path:rw"
       docker_volumes: "$defaults,{{ cvmfs.data.path }}:{{ cvmfs.data.docker_perm }}"
       singularity_volumes: "$defaults,{{ cvmfs.data.path }}:{{ cvmfs.data.docker_perm }}"
+      singularity_enabled: true
+      singularity_default_container_id: "{{ cvmfs.singularity.path }}/all/centos:8.3.2011"
     scheduling:
       accept:
         - pulsar


### PR DESCRIPTION
Because each pulsar endpoint will have it's own TPV tag, so normal jobs won't get there if they dont have a specific pulsar tag.