### PR TITLE
Fix permission denied error with msconvert tool

### DIFF
--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -886,3 +886,10 @@ tools:
 
   toolshed.g2.bx.psu.edu/repos/iuc/semibin/semibin/.*:
     mem: 8
+
+  toolshed.g2.bx.psu.edu/repos/galaxyp/msconvert/msconvert/.*:
+    params:
+      docker_run_extra_arguments: --user 999
+    scheduling:
+      require:
+        - docker

--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -890,6 +890,3 @@ tools:
   toolshed.g2.bx.psu.edu/repos/galaxyp/msconvert/msconvert/.*:
     params:
       docker_run_extra_arguments: --user 999
-    scheduling:
-      require:
-        - docker


### PR DESCRIPTION
We received the following error report from a user:

job_id: `11ac94870d0bb33a297ea1b2a8e6fc89`
too_id: `toolshed.g2.bx.psu.edu/repos/galaxyp/msconvert/msconvert/3.0.20287.2`

```
stderr:
mv: inter-device move failed: 'outputs/20230427_PX_Silvana_E06_R05_P08b.mzML' to '/data/dnb08/galaxy_db/files/8/2/4/dataset_824dc3a0-22ad-41b8-8e59-9cf4f91865e8.dat'; unable to remove target: Permission denied
```

This tool requires docker to run and it's config is from the [TPV shared DB](https://github.com/galaxyproject/tpv-shared-database/blob/main/tools.yml#L631-L634). To fix the permission denied issue (based on similar issues we have seen in the past) I have added this tool to our TPV config and added the `param` to add the `docker_run_extra_arguments`. 