### PR TITLE
Work around unresponsive Isilon share for PG dumps

### DIFF
--- a/group_vars/sn05.yml
+++ b/group_vars/sn05.yml
@@ -76,4 +76,4 @@ postgresql_pg_hba_conf:
   - "host    apollo          apollo          10.5.68.0/24            md5"
   - "host    chado           apollo          10.5.68.0/24            md5"
   - "host    grt             grt             10.5.68.0/24            md5"
-postgresql_pgdump_dir: "/var/lib/pgsql/pgdump"
+postgresql_pgdump_dir: "/var/lib/pgsql/pgdump2"


### PR DESCRIPTION
I currently cannot mount the Isilon share we normally use for `pg_dump(1)`, it is completely unresponsive. Since Raphael is atm on holiday I don't rly think we can get this fixed today, so as a temporary workaround I created a share on our "spare ZFS server" (`zfs0f:/export/pgdump2`) and mounted that under `/var/lib/pgsql/pgdump2`. This PR activates that directory as PG dump dir.

The reason why I created  new directory is that I don't want to cause early deletions of old dump files in the TSM backup of `/var/lib/pgsql/pgdump` that would be unavoidable if the new share were mounted there.