### PR TITLE
Add docker GPU destination

### DIFF
--- a/files/galaxy/tpv/destinations.yml.j2
+++ b/files/galaxy/tpv/destinations.yml.j2
@@ -313,3 +313,19 @@ destinations:
       GPU_AVAILABLE: 1
     params:
       requirements: 'GalaxyGroup == "compute_gpu"'
+
+  condor_docker_gpu:
+    inherits: basic_docker_destination
+    # shorter than inheriting from condor_gpu
+    runner: condor
+    max_accepted_cores: 8
+    max_accepted_mem: 16
+    min_accepted_gpus: 1
+    max_accepted_gpus: 1
+    scheduling:
+      require:
+        - docker
+    env:
+      GPU_AVAILABLE: 1
+    params:
+      requirements: 'GalaxyGroup == "compute_gpu"'


### PR DESCRIPTION
Currently there is no possibility to run dockerized tools in a GPU machine. This PR adds a docker GPU destination.

Such a destination is required, for example, to run [instagraal](https://github.com/usegalaxy-eu/infrastructure-playbook/blob/8a9eb8f3c39d44eb32dde09596776b368bed9f45/files/galaxy/tpv/tools.yml#L176-L177).

Whether the containers will actually be using the GPU is a different matter...