### PR TITLE
Fix rustus uploads

### DIFF
--- a/requirements.yaml
+++ b/requirements.yaml
@@ -99,7 +99,7 @@ roles:
   - name: usegalaxy_eu.fs_maintenance
     version: 0.0.5
   - name: usegalaxy_eu.rustus
-    version: 0.1.0
+    version: 0.2.0
   - name: usegalaxy_eu.rabbitmqserver
     version: 1.4.4
   - name: usegalaxy_eu.influxdbserver

--- a/upload.yml
+++ b/upload.yml
@@ -16,6 +16,9 @@
         user: "{{ user_name }}"
         # group that rustus will run as
         group: "{{ user_group_name }}"
+        # rustus will refuse to work if it cannot write to its current working directory,
+        # just provide a directory that rustus has write access to
+        working_directory: "{{ upload_dir_test }}"
         # args passed to rustus
         args:
           - --host "{{ inventory_hostname }}"
@@ -33,6 +36,9 @@
         user: "{{ user_name }}"
         # group that rustus will run as
         group: "{{ user_group_name }}"
+        # rustus will refuse to work if it cannot write to its current working directory,
+        # just provide a directory that rustus has write access to
+        working_directory: "{{ upload_dir_main }}"
         # args passed to rustus
         args:
           - --host "{{ inventory_hostname }}"


### PR DESCRIPTION
Use the new version of the [ansible-rustus](https://galaxy.ansible.com/usegalaxy_eu/rustus) role (0.2.0) that enforces setting a working directory for systemd units.

**DO NOT MERGE** until [PR #3 on usegalaxy-eu/ansible-rustus](https://github.com/usegalaxy-eu/ansible-rustus/pull/3/files) has been merged **AND** the new version of the role published.