### PR TITLE
Pin rustus to version 0.7.3

### DIFF
--- a/upload.yml
+++ b/upload.yml
@@ -10,6 +10,7 @@
   vars:
     upload_dir_test: /data/jwd04/tus_upload/test
     upload_dir_main: /data/jwd04/tus_upload/main
+    rustus_version: "0.7.3"
     rustus_instances:
       - name: test_uploads
         # user that rustus will run as


### PR DESCRIPTION
Given that rustus is still making 0.x.x releases, it seems irresponsible to me not to pin the version.

If we want to bump the version we can do it "quickly" (if things can go wrong, they will go wrong though, no matter how much do you test) since I [included a GitHub workflow](https://github.com/usegalaxy-eu/ansible-rustus/actions/workflows/molecule-latest.yml) in the [role](https://github.com/usegalaxy-eu/ansible-rustus) that tests the latest version every week.