### PR TITLE
Rstudio poweruser

### DIFF
--- a/files/galaxy/tpv/destinations.yml.j2
+++ b/files/galaxy/tpv/destinations.yml.j2
@@ -78,6 +78,14 @@ destinations:
     params:
       requirements: 'GalaxyGroup == "compute_gpu"'
 
+  interactive_pulsar_rstudio_poweruser:
+    inherits: interactive_pulsar
+    min_accepted_gpus: 0
+    max_accepted_gpus: 0
+    scheduling:
+      require:
+        - rstudio-poweruser
+
   embedded_pulsar_docker:
     inherits: basic_docker_destination
     runner: pulsar_embedded

--- a/files/galaxy/tpv/roles.yml
+++ b/files/galaxy/tpv/roles.yml
@@ -11,7 +11,7 @@ roles:
     rules:
       - id: rstudio_poweruser
         if: |
-          'rstudio' in tool.id
+          'rstudio' in tool.id and 'interactive' in tool.id
         scheduling:
           require:
             - docker

--- a/files/galaxy/tpv/roles.yml
+++ b/files/galaxy/tpv/roles.yml
@@ -6,3 +6,16 @@ roles:
   storage-test*:
     params:
       object_store_id: "s3_netapp01"
+
+  rstudio-poweruser:
+    rules:
+      - id: rstudio_poweruser
+        if: |
+          'rstudio' in tool.id
+        scheduling:
+          require:
+            - docker
+            - interactive
+            - rstudio-poweruser
+        mem: 100
+        cores: 2

--- a/files/galaxy/tpv/roles.yml
+++ b/files/galaxy/tpv/roles.yml
@@ -7,7 +7,7 @@ roles:
     params:
       object_store_id: "s3_netapp01"
 
-  rstudio-poweruser:
+  rstudio-poweruser*:
     rules:
       - id: rstudio_poweruser
         if: |

--- a/files/galaxy/tpv/roles.yml
+++ b/files/galaxy/tpv/roles.yml
@@ -11,7 +11,7 @@ roles:
     rules:
       - id: rstudio_poweruser
         if: |
-          'rstudio' in tool.id and 'interactive' in tool.id
+          'interactive_tool_rstudio' in tool.id
         scheduling:
           require:
             - docker


### PR DESCRIPTION
This would schedule `Rstudio` jobs for users with role `rstudio-poweruser` to a dedicated destination and give them 100G mem.
The IT-stopper script can check jobs for that destination and stop them after a specific time for that destination.
This allows us to run RStudio interactive tool longer for specific users.