### PR TITLE
Revert "run deeptools in Singularity"

### DIFF
--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -24,11 +24,6 @@ tools:
   toolshed.g2.bx.psu.edu/repos/chemteam/gmx_sim/gmx_sim/.*:
     inherits: basic_gpu_resource_param_tool
 
-  toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_.*/deeptools_.*/.*:
-    scheduling:
-      require:
-        - singularity
-
   toolshed.g2.bx.psu.edu/repos/bgruening/hifiasm/hifiasm/.*:
     rules:
       - id: hifiasm_memory


### PR DESCRIPTION
Reverts usegalaxy-eu/infrastructure-playbook#809

Sorry but we have to revert this and think twice. As I feared the dependency resolver is not smart enough (or simply the containers need to be published to match the tool versions and not the GitHub tags). 

See for example this job launched by me:

```
galaxy@sn06:/data/jwd01/main/060/861/60861503$ gxadmin report job-info 60861503
# Galaxy Job 60861503

Property | Value
-------- | -----
Tool | toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_compute_matrix/deeptools_compute_matrix/2.2.2.0
State | error
Handler | handler_sn06_3
Created | 2023-06-19 15:57:16.71551+02
Job Runner/ID | condor / 44290107
Owner | jdm (id=*****)

## Destination Parameters

Key | Value
--- | ---
+Group | `""`
accounting_group_user | `*****`
description | `deeptools_compute_matrix`
docker_memory | `3.8G`
metadata_strategy | `extended`
request_cpus | `1`
request_memory | `3.8G`
requirements | `(GalaxyGroup  ==  "compute")`
singularity_default_container_id | `/cvmfs/singularity.galaxyproject.org/all/centos:8.3.2011`
singularity_enabled | `true`
singularity_volumes | `$_CONDOR_SCRATCH_DIR:rw,  $job_directory:rw,  $tool_directory:ro,  $job_directory/outputs:rw,  $working_directory:rw,  /data/dp01/galaxy_db/:rw,  /data/0/galaxy_db/:ro,  /data/1/galaxy_db/:ro,  /data/2/galaxy_db/:ro,  /data/3/galaxy_db/:ro,  /data/4/galaxy_db/:ro,  /data/6/galaxy_db/:ro,  /data/7/galaxy_db/:ro,  /data/dnb01/galaxy_db/:ro,  /data/dnb02/galaxy_db/:ro,  /data/dnb03/galaxy_db/:ro,  /data/dnb05/galaxy_db/:ro,  /data/dnb06/galaxy_db/:rw,  /data/dnb07/galaxy_db/:rw,  /data/dnb08/galaxy_db/:rw,  /data/dnb09/galaxy_db/:ro,  /data/5/galaxy_import/galaxy_user_data/:ro,  /data/db/:ro,  /usr/local/tools/:ro`
submit_request_cpus | `1`
submit_request_gpus | `0`
submit_request_memory | `3.8G`
tmp_dir | `true`
## Dependencies

Name | Version | Dependency Type | Cacheable | Exact | Environment Path | Model Class
---- | ------- | --------------- | --------- | ----- | ---------------- | -----------


## Tool Parameters

Name | Settings
----- | ------------
regionsFiles | [{__index__: 0, regionsFile: {values: [{id: 139727340, src: hda}]}}]
scoreFileName | {values: [{id: 139727384, src: hda}]}
mode | {__current_case__: 1, afterRegionStartLength: 10, beforeRegionStartLength: 10, mode_select: reference-point, nanAfterEnd: false, referencePoint: TSS}
output | {__current_case__: 0, showOutputSettings: no}
advancedOpt | {__current_case__: 1, averageTypeBins: sum, binSize: 10, maxThreshold: , minThreshold: , missingDataAsZero: false, scale: , showAdvancedOpt: yes, skipZeros: false, sortRegions: descend, sortUsing: sum}
chromInfo | /opt/galaxy/tool-data/shared/ucsc/chrom/?.len
dbkey | ?
__input_ext | bed

## Inputs


Job ID | Name | Extension | hda-id | hda-state | hda-deleted | hda-purged | ds-id | ds-state | ds-deleted | ds-purged | Size
---- | ---- | ---- | ---- | ---- | ---- | ---- | ---- | ---- | ---- | ---- | ----
49736065 | computeMatrix1.bed | bed | 139727340 |  | f | f | 113723596 | ok | f | f | 207 bytes
49736112 | bamCoverage_result4.bw | bigwig | 139727384 |  | f | f | 113723643 | ok | f | f | 3353 bytes
49736112 | bamCoverage_result4.bw | bigwig | 139727384 |  | f | f | 113723643 | ok | f | f | 3353 bytes

## Outputs

Name | Extension | hda-id | hda-state | hda-deleted | hda-purged | ds-id | ds-state | ds-deleted | ds-purged | Size
---- | ---- | ---- | ---- | ---- | ---- | ---- | ---- | ---- | ---- | ----
computeMatrix on data 76 and data 34: Matrix | deeptools_compute_matrix_archive | 139727561 |  | f | f | 113723817 | error | f | f | 0 bytes
```

The singularity container that exists is 

```shell
galaxy@sn06:/data/jwd01/main/060/861/60861503$ ls -lah /cvmfs/singularity.galaxyproject.org/d/e/deeptools* | awk '{print $9}' | grep 2.2.2
/cvmfs/singularity.galaxyproject.org/d/e/deeptools:2.2.2--py27_0
```
Which results in the default singularity image, `/cvmfs/singularity.galaxyproject.org/all/centos:8.3.2011` being used.

```shell
galaxy@sn06:/data/jwd01/main/060/861/60861503$ tail -n9 galaxy_60861503.sh 
    rm -rf working/ outputs/ configs/; cp -R _working working; cp -R _outputs outputs; cp -R _configs configs
else
    cp -R working _working; cp -R outputs _outputs; cp -R configs _configs
fi
cd working; SINGULARITYENV_GALAXY_SLOTS=$GALAXY_SLOTS SINGULARITYENV_GALAXY_MEMORY_MB=$GALAXY_MEMORY_MB SINGULARITYENV_GALAXY_MEMORY_MB_PER_SLOT=$GALAXY_MEMORY_MB_PER_SLOT SINGULARITYENV_HOME=$HOME SINGULARITYENV__GALAXY_JOB_HOME_DIR=$_GALAXY_JOB_HOME_DIR SINGULARITYENV__GALAXY_JOB_TMP_DIR=$_GALAXY_JOB_TMP_DIR SINGULARITYENV_TMPDIR=$TMPDIR SINGULARITYENV_TMP=$TMP SINGULARITYENV_TEMP=$TEMP singularity -s exec --cleanenv -B "$_CONDOR_SCRATCH_DIR:$_CONDOR_SCRATCH_DIR" -B /data/jwd01/main/060/861/60861503:/data/jwd01/main/060/861/60861503 -B /opt/galaxy/shed_tools/toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_compute_matrix/98d2e2ad3c82/deeptools_compute_matrix:/opt/galaxy/shed_tools/toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_compute_matrix/98d2e2ad3c82/deeptools_compute_matrix:ro -B /data/jwd01/main/060/861/60861503/outputs:/data/jwd01/main/060/861/60861503/outputs -B /data/jwd01/main/060/861/60861503/working:/data/jwd01/main/060/861/60861503/working -B /data/dp01/galaxy_db/:/data/dp01/galaxy_db/ -B /data/0/galaxy_db/:/data/0/galaxy_db/:ro -B /data/1/galaxy_db/:/data/1/galaxy_db/:ro -B /data/2/galaxy_db/:/data/2/galaxy_db/:ro -B /data/3/galaxy_db/:/data/3/galaxy_db/:ro -B /data/4/galaxy_db/:/data/4/galaxy_db/:ro -B /data/6/galaxy_db/:/data/6/galaxy_db/:ro -B /data/7/galaxy_db/:/data/7/galaxy_db/:ro -B /data/dnb01/galaxy_db/:/data/dnb01/galaxy_db/:ro -B /data/dnb02/galaxy_db/:/data/dnb02/galaxy_db/:ro -B /data/dnb03/galaxy_db/:/data/dnb03/galaxy_db/:ro -B /data/dnb05/galaxy_db/:/data/dnb05/galaxy_db/:ro -B /data/dnb06/galaxy_db/:/data/dnb06/galaxy_db/ -B /data/dnb07/galaxy_db/:/data/dnb07/galaxy_db/ -B /data/dnb08/galaxy_db/:/data/dnb08/galaxy_db/ -B /data/dnb09/galaxy_db/:/data/dnb09/galaxy_db/:ro -B /data/5/galaxy_import/galaxy_user_data/:/data/5/galaxy_import/galaxy_user_data/:ro -B /data/db/:/data/db/:ro -B /usr/local/tools/:/usr/local/tools/:ro --home $HOME:$HOME /cvmfs/singularity.galaxyproject.org/all/centos:8.3.2011 /bin/sh /data/jwd01/main/060/861/60861503/tool_script.sh > '../outputs/tool_stdout' 2> '../outputs/tool_stderr'; return_code=$?; echo $return_code > /data/jwd01/main/060/861/60861503/galaxy_60861503.ec; cd '/data/jwd01/main/060/861/60861503'; 
[ "$GALAXY_VIRTUAL_ENV" = "None" ] && GALAXY_VIRTUAL_ENV="$_GALAXY_VIRTUAL_ENV"; _galaxy_setup_environment True; python metadata/set.py; sh -c "exit $return_code"
date +"%s" > /data/jwd01/main/060/861/60861503/__instrument_core_epoch_end
if [ -e "/proc/$$/cgroup" -a -d "/sys/fs/cgroup" ]; then     cgroup_path=$(cat "/proc/$$/cgroup" | awk -F':' '($2=="cpuacct,cpu") || ($2=="cpu,cpuacct") {print $3}');     if [ ! -e "/sys/fs/cgroup/cpu$cgroup_path/cpuacct.usage" ]; then         cgroup_path="";     fi;     for f in /sys/fs/cgroup/{cpu\,cpuacct,cpuacct\,cpu}$cgroup_path/{cpu,cpuacct}.*; do         if [ -f "$f" ]; then             echo "__$(basename $f)__" >> /data/jwd01/main/060/861/60861503/__instrument_cgroup__metrics; cat "$f" >> /data/jwd01/main/060/861/60861503/__instrument_cgroup__metrics 2>/dev/null;         fi;     done; fi
if [ -e "/proc/$$/cgroup" -a -d "/sys/fs/cgroup" ]; then     cgroup_path=$(cat "/proc/$$/cgroup" | awk -F':' '$2=="memory"{print $3}');     if [ ! -e "/sys/fs/cgroup/memory$cgroup_path/memory.max_usage_in_bytes" ]; then         cgroup_path="";     fi;     for f in /sys/fs/cgroup/memory$cgroup_path/memory.*; do         echo "__$(basename $f)__" >> /data/jwd01/main/060/861/60861503/__instrument_cgroup__metrics; cat "$f" >> /data/jwd01/main/060/861/60861503/__instrument_cgroup__metrics 2>/dev/null;     done; fi
```
