### PR TITLE
Fix TPV linting

### DIFF
--- a/.github/workflows/tpv.py
+++ b/.github/workflows/tpv.py
@@ -1,0 +1,168 @@
+"""Collection of functions to generate Ansible playbooks that template files.
+
+Given an Ansible playbook, this file helps you modify it in order to produce
+another playbook with the sole purpose of templating files.
+"""
+
+import glob
+import os
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Iterable
+
+import yaml
+from jinja2 import Environment, FileSystemLoader, meta
+
+# Keys from plays to be kept in the generated playbooks
+KEEP_KEYS = {
+    "name",
+    "hosts",
+    "vars",
+    "vars_files",
+}
+
+# Set the default editor to "true" create empty Ansible vaults easily
+os.environ["EDITOR"] = "true"
+
+
+# Tasks to execute in each play.
+def templating_task(
+    src: str | Path,
+    dest: str | Path,
+) -> dict:
+    """Generate an ansible templating task.
+
+    Args:
+        src: Template file.
+        dest: Templated file.
+
+    Returns:
+        Ansible templating task (in the form of a dictionary).
+    """
+    return {
+        "name": f"Template {src}",
+        "template": {
+            "src": str(src),
+            "dest": str(dest),
+        },
+    }
+
+
+def get_variables(path: str | Path) -> set[str]:
+    """Get names of the variables used in a Jinja template.
+
+    Args:
+        path: Path of the Jinja template.
+
+    Returns:
+        Set of variables used in the Jinja template.
+    """
+    path = Path(path)
+    dirname = path.parent
+
+    env = Environment(
+        loader=FileSystemLoader(dirname),
+        extensions=["jinja2_ansible_filters.AnsibleCoreFiltersExtension"],
+    )
+    source = open(path, "r").read()
+    parsed_content = env.parse(source)
+    variables = set(meta.find_undeclared_variables(parsed_content))
+
+    return variables
+
+
+def make_playbook(
+    model: str | Path,
+    templates: Iterable[tuple[str | Path, str | Path]],
+) -> Path:
+    """Generate a playbook from a model.
+
+    Takes a playbook as reference, keeps the skeleton of the playbook (e.g.
+    variables, and variable files) and replaces the existing tasks with
+    templating tasks.
+
+    The working directory of the model playbook will be copied to a temporary
+    directory and in such directory, the newly generated playbook will replace
+    the model playbook. The function returns the absolute path of the newly
+    generated playbook.
+
+    Args:
+        model: Playbook to be taken as reference. The skeleton of the playbook
+            is kept (keys from KEEP_KEYS, for example the vars and
+            vars_files), while the existing tasks are stripped out.
+        templates: Files to be templated, given as tuples where the first
+            element is the path of the template and the second element the
+            path of the templated file.
+
+    Returns:
+        The absolute path of the newly generated playbook.
+    """
+    playbook = Path(model)
+    dirname = playbook.parent
+    basename = playbook.name
+
+    # copy working directory to the temporary directory and chdir into it
+    directory = Path(tempfile.mkdtemp()) / "ansible"
+    shutil.copytree(dirname, directory)
+    playbook = directory / basename
+    dirname = directory
+
+    playbook = yaml.safe_load(open(playbook))
+    for i, play in enumerate(playbook):
+        # filter keys
+        play = {key: value for key, value in play.items() if key in KEEP_KEYS}
+
+        # replace vaults with empty vaults
+        vault_string = "$ANSIBLE_VAULT"
+        for filename in play.get("vars_files", []):
+            try:
+                with open(filename, "r") as file:
+                    is_vault = file.read(14) == vault_string
+            except FileNotFoundError:
+                is_vault = False
+            if is_vault:
+                os.remove(directory / filename)
+                subprocess.run(
+                    ["ansible-vault", "create", directory / filename]
+                )
+
+        # generate a file with dummy variables
+        dummy_vars = {}
+        # - determinate what is already defined in group variables
+        group_vars = set()
+        for file_path in glob.glob(str(directory / "group_vars" / "*")):
+            contents = yaml.safe_load(open(file_path))
+            group_vars |= set(contents)
+        # - for vars files
+        dummy_vars |= {
+            var: "undefined"
+            for vars_file in play.get("vars_files", [])
+            for var in get_variables(vars_file)
+            if var not in group_vars
+        }
+        # - for templates
+        dummy_vars |= {
+            var: "undefined"
+            for src, _ in templates
+            for var in get_variables(src)
+            if var not in group_vars
+        }
+        # - save generated file
+        with open(directory / "dummy_vars_file.yml", "w") as file:
+            yaml.dump(dummy_vars, file)
+
+        # insert file with dummy variables at the top of the vars_files list
+        play["vars_files"] = play.get("vars_files", [])
+        play["vars_files"].insert(0, "dummy_vars_file.yml")
+
+        play["tasks"] = [templating_task(src, dest) for src, dest in templates]
+
+        playbook[i] = play
+
+    playbook_path = (directory / basename).absolute()
+    with open(playbook_path, "w") as file:
+        yaml.dump(playbook, file)
+
+    return playbook_path

--- a/.github/workflows/tpv.yml
+++ b/.github/workflows/tpv.yml
@@ -22,6 +22,11 @@ jobs:
         with:
           path: 'infrastructure-playbook'
 
+      - name: Update git submodules.
+        working-directory: 'infrastructure-playbook'
+        run: |
+          git submodule update --init --recursive --remote --checkout
+
       - name: Set up Python 3.
         uses: actions/setup-python@v2
         with:
@@ -105,10 +110,62 @@ jobs:
           TPV_REQ=$(perl -pe 's/\\\n/ /' lib/galaxy/dependencies/conditional-requirements.txt | grep total-perspective-vortex)
           pip3 install --upgrade "$TPV_REQ"
 
+      - name: Install port of Ansible filters for Jinja (required for the next step).
+        run: |
+          pip3 install jinja2-ansible-filters
+
+      - name: Create mounts vars file.
+        working-directory: 'infrastructure-playbook/mounts'
+        run: |
+          make dest/all.yml
+
+      - name: Create a playbook to template the TPV files.
+        shell: python -u {0}
+        working-directory: 'infrastructure-playbook'
+        run: |
+          import glob
+          import importlib
+          import sys
+
+          # import tpv.py
+          spec = importlib.util.spec_from_file_location('tpv_ci', '.github/workflows/tpv.py')
+          module = importlib.util.module_from_spec(spec)
+          spec.loader.exec_module(module)
+          make_playbook = module.make_playbook
+
+          tpv_path = "files/galaxy/tpv/"
+          templates = tuple(
+              (file, '.'.join(file.split('.')[:-1]))  # remove j2 extension
+              for file in glob.glob(f"{tpv_path}/*.yaml.j2") + glob.glob(f"{tpv_path}/*.yml.j2")
+          )
+
+          playbook = make_playbook('sn06.yml', templates=templates)
+          with open('../playbook_path', 'w') as file:
+            file.write(str(playbook))
+
+      - name: Render TPV configuration files.
+        run: |
+          PLAYBOOK="$(cat playbook_path)"
+          BASENAME="$(basename $PLAYBOOK)"
+          DIRNAME="$(dirname $PLAYBOOK)"
+          cd "$DIRNAME"
+
+          shopt -s nullglob
+
+          ansible-playbook --connection=local "$BASENAME"
+
       - name: Run Total Perspective Vortex linter.
         run: |
           export PYTHONPATH=$(realpath ./galaxy/lib)
-          for file in $(ls infrastructure-playbook/files/galaxy/tpv/*.{yml,yaml}); do
+
+          PLAYBOOK="$(cat playbook_path)"
+          BASENAME="$(basename $PLAYBOOK)"
+          DIRNAME="$(dirname $PLAYBOOK)"
+          cd "$DIRNAME"
+
+          shopt -s nullglob
+
+          for file in files/galaxy/tpv/*.{yml,yaml}; do
             echo Running TPV linter on "$file"...
             tpv lint $file || exit 1
           done

--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -856,8 +856,8 @@ tools:
     cores: 16
     mem: 90
     env:
-      _JAVA_OPTIONS: -XX:MaxPermSize=2G -Xmx6G -Xms1G -Djava.io.tmpdir=/data/2/galaxy_db/tmp -Duser.home=/data/2/galaxy_db/tmp
       TERM: vt100
+      _JAVA_OPTIONS: -XX:MaxPermSize=2G -Xmx6G -Xms1G -Djava.io.tmpdir=/data/2/galaxy_db/tmp -Duser.home=/data/2/galaxy_db/tmp
 
   toolshed.g2.bx.psu.edu/repos/imgteam/unzip/unzip/.*:
     scheduling:


### PR DESCRIPTION
Does TPV linting also on Jinja templates (e.g. destinations.yml.j2).

It is done in such a complicated way (with the extra Python module) because in this way things can be reused to also have `tpv dry-run` :tada: in GitHub actions (the job_conf.yml can finally be templated). I bet though that this will break soon :laughing:.

A PR for `tpv dry-run` is coming soon.