### PR TITLE
Revert "Fix permission denied error with msconvert tool"

### DIFF
--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -894,7 +894,3 @@ tools:
     scheduling:
       require:
         - singularity
-
-  toolshed.g2.bx.psu.edu/repos/galaxyp/msconvert/msconvert/.*:
-    params:
-      docker_run_extra_arguments: --user 999


### PR DESCRIPTION
Reverts usegalaxy-eu/infrastructure-playbook#789

The issue that #789 solved is now handled at the NFS export policy level. We no longer need such changes.