### PR TITLE
Bump rustus to v0.7.4 in upload playbook

### DIFF
--- a/upload.yml
+++ b/upload.yml
@@ -10,7 +10,7 @@
   vars:
     upload_dir_test: /data/jwd04/tus_upload/test
     upload_dir_main: /data/jwd04/tus_upload/main
-    rustus_version: "0.7.3"
+    rustus_version: "0.7.4"
     rustus_instances:
       - name: test_uploads
         # user that rustus will run as


### PR DESCRIPTION
Bump rustus to the latest version ([v0.7.4](https://github.com/s3rius/rustus/releases/tag/0.7.4)).

Should work out of the box, it went just through a minor change and [Ansible Molecule tests for this version](https://github.com/usegalaxy-eu/ansible-rustus/actions/runs/5441783283/jobs/9896148700?pr=5) passed just a few minutes ago.