### PR TITLE
Update object_store_conf.xml.j2 to rebalance use of JWDs

### DIFF
--- a/templates/galaxy/config/object_store_conf.xml.j2
+++ b/templates/galaxy/config/object_store_conf.xml.j2
@@ -174,7 +174,7 @@ The storage consists of 16 Gen6 type A200 storage nodes and 16 Gen5 type X410 no
             <files_dir path="/data/dnb09/galaxy_db/files"/>
             <extra_dir type="job_work" path="/data/jwd02f/main"/>
         </backend>
-        <backend id="files24" type="disk" weight="0" store_by="uuid">
+        <backend id="files24" type="disk" weight="1" store_by="uuid">
             <files_dir path="/data/dnb09/galaxy_db/files"/>
             <extra_dir type="job_work" path="/data/jwd05e/main"/>
         </backend>


### PR DESCRIPTION
If we want to avoid using jwd01 for a bigger share of jobs (as far as I know it is backed by spinning disks) then I believe we should make use of jwd05e too. Since we did the cleanup of old JWDs we have more than double the free space on jwd05e than on jwd02f.

This is of course just a complement to the change of policy in the JWD script.

![grafik](https://github.com/usegalaxy-eu/infrastructure-playbook/assets/43052541/f57fd94b-58dc-411d-b74b-84c896da7f01)

![grafik](https://github.com/usegalaxy-eu/infrastructure-playbook/assets/43052541/94ea99c0-0ac3-4f56-83a9-c33a45579462)
