### PR TITLE
Change the behavior of galaxy_jwd.py so that it deletes old failed jobs rather than recently failed jobs

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -7,7 +7,6 @@ exclude =
     roles/hxr.monitor-squid
     roles/hxr.simple-nagios    
     roles/jasonroyle.rabbitmq
-    roles/usegalaxy-eu.bashrc
     templates/encoder/yaml_converter.py
 ignore = 
     E203,

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,15 @@
+[flake8]
+exclude =
+    .venv
+    collections
+    roles/htcondor
+    roles/hxr.monitor-galaxy
+    roles/hxr.monitor-squid
+    roles/hxr.simple-nagios    
+    roles/jasonroyle.rabbitmq
+    roles/usegalaxy-eu.bashrc
+    templates/encoder/yaml_converter.py
+ignore = 
+    E203,
+    W503
+docstring-convention = google

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,6 @@
+# Run isort on galaxy_jwd.py
+c573ecd02e0f1ce97e74c21b753faf2467e9a227
+# Run black on galaxy_jwd.py
+e44dc2711a3bb70e62848049f09b449667b13ad1
+# Run flake8 on galaxy_jwd.py
+40095d807803bcc8faa49278ee9904c079313439

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,0 +1,31 @@
+---
+name: Python formatting
+
+"on": pull_request
+
+jobs:
+  PEP8:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - run: pip install --upgrade pip
+
+      - id: pip_install
+        run: pip install --upgrade isort~=5.0 flake8~=6.0 flake8-docstrings~=1.0
+
+      - name: isort
+        run: isort . --check --diff
+        if: (success() || failure()) && steps.pip_install.conclusion == 'success'
+
+      - name: Black
+        uses: psf/black@stable
+        with:
+          version: "~=23.0"
+          options: "--check --diff"
+          src: "."
+        if: (success() || failure()) && steps.pip_install.conclusion == 'success'
+
+      - name: Flake8
+        run: flake8 .
+        if: (success() || failure()) && steps.pip_install.conclusion == 'success'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,27 @@
+[tool.isort]
+profile = "black"
+line_length = 79
+extend_skip = [
+    "collections",
+    "roles/htcondor",
+    "roles/hxr.monitor-galaxy",
+    "roles/hxr.monitor-squid",
+    "roles/hxr.simple-nagios",
+    "roles/jasonroyle.rabbitmq",    
+    "roles/usegalaxy-eu.bashrc",
+    "templates/encoder/yaml_converter.py",
+]
+
+[tool.black]
+line-length = 79
+target-version = ['py39']
+extend-exclude = """
+    collections|\
+    roles/htcondor|\
+    roles/hxr.monitor-galaxy|\
+    roles/hxr.monitor-squid|\
+    roles/hxr.simple-nagios|\
+    roles/jasonroyle.rabbitmq|\
+    roles/usegalaxy-eu.bashrc|\
+    templates/encoder/yaml_converter.py\
+"""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,8 +7,7 @@ extend_skip = [
     "roles/hxr.monitor-galaxy",
     "roles/hxr.monitor-squid",
     "roles/hxr.simple-nagios",
-    "roles/jasonroyle.rabbitmq",    
-    "roles/usegalaxy-eu.bashrc",
+    "roles/jasonroyle.rabbitmq",
     "templates/encoder/yaml_converter.py",
 ]
 
@@ -22,6 +21,5 @@ extend-exclude = """
     roles/hxr.monitor-squid|\
     roles/hxr.simple-nagios|\
     roles/jasonroyle.rabbitmq|\
-    roles/usegalaxy-eu.bashrc|\
     templates/encoder/yaml_converter.py\
 """

--- a/roles/usegalaxy-eu.bashrc/files/galaxy_jwd.py
+++ b/roles/usegalaxy-eu.bashrc/files/galaxy_jwd.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
-# Description: Galaxy jobs's job working directory (JWD) script. Can get you
-# the path of a JWD and can delete JWD's of job failed within last X days.
+"""Galaxy jobs's job working directory (JWD) script.
+
+Can get you the path of a JWD and can delete JWD's of job failed within last X
+days.
+"""
 
 import argparse
 import os
@@ -14,8 +17,8 @@ import yaml
 
 
 def main():
-    """
-    JWD script
+    """Main function of the JWD script.
+
     1. Can get you the path of a JWD
     2. Can delete JWD's of job failed within last X days
     """
@@ -42,7 +45,7 @@ def main():
             clean_jwds:
                 Dry run: python galaxy_jwd.py clean_jwds --dry_run --days 5
                 No dry run: python galaxy_jwd.py clean_jwds --no_dry_run --days 5
-        """,
+        """,  # noqa: E501
     )
 
     # Parser for the get_jwd subcommand
@@ -73,7 +76,10 @@ def main():
     )
     clean_jwds_parser.add_argument(
         "--days",
-        help="Number of days within which the jobs were last updated to be considered for deletion (default: 5)",
+        help=(
+            "Number of days within which the jobs were last updated to be"
+            "considered for deletion (default: 5)"
+        ),
         default=5,
     )
 
@@ -117,7 +123,8 @@ def main():
         or os.stat(os.path.expanduser("~/.pgpass")).st_size == 0
     ):
         raise ValueError(
-            "Please create a ~/.pgpass file in format: <pg_host>:5432:*:<pg_user>:<pg_password>"
+            "Please create a ~/.pgpass file in format: "
+            "<pg_host>:5432:*:<pg_user>:<pg_password>"
         )
     db_password = extract_password_from_pgpass(
         pgpass_file=os.path.expanduser("~/.pgpass")
@@ -159,13 +166,17 @@ def main():
         # Check if the given Galaxy log directory exists
         if not os.path.isdir(galaxy_log_dir):
             raise ValueError(
-                f"The given Galaxy log directory {galaxy_log_dir} does not exist"
+                f"The given Galaxy log directory {galaxy_log_dir} does not"
+                f"exist"
             )
 
         # Set variables
         dry_run = args.dry_run
         days = args.days
-        jwd_cleanup_log = f"{galaxy_log_dir}/jwd_cleanup_{datetime.now().strftime('%d_%m_%Y-%I_%M_%S')}.log"
+        jwd_cleanup_log = (
+            f"{galaxy_log_dir}/"
+            f"jwd_cleanup_{datetime.now().strftime('%d_%m_%Y-%I_%M_%S')}.log"
+        )
         failed_jobs = db.get_failed_jobs(days=days)
 
         # Delete JWD folders if dry_run is False
@@ -191,7 +202,7 @@ def main():
 
 
 def extract_password_from_pgpass(pgpass_file):
-    """Extract the password from the ~/.pgpass file
+    """Extract the password from the ~/.pgpass file.
 
     The ~/.pgpass file should have the following format:
     <pg_host>:5432:*:<pg_user>:<pg_password>
@@ -209,12 +220,13 @@ def extract_password_from_pgpass(pgpass_file):
                 return line.split(":")[4].strip()
             else:
                 raise ValueError(
-                    f"Please add the password for '{os.environ.get('PGHOST')}' to the ~/.pgpass file in format: {pgpass_format} "
+                    f"Please add the password for '{os.environ.get('PGHOST')}'"
+                    f"to the ~/.pgpass file in format: {pgpass_format}"
                 )
 
 
 def get_object_store_conf_path(galaxy_config_file):
-    """Get the path to the object_store_conf.xml file
+    """Get the path to the object_store_conf.xml file.
 
     Args:
         galaxy_config_file (str): Path to the galaxy.yml file
@@ -236,7 +248,7 @@ def get_object_store_conf_path(galaxy_config_file):
 
 
 def parse_object_store(object_store_conf):
-    """Get the path of type 'job_work' from the extra_dir's for each backend
+    """Get the path of type 'job_work' from the extra_dir's for each backend.
 
     Args:
         object_store_conf (str): Path to the object_store_conf.xml file
@@ -257,7 +269,7 @@ def parse_object_store(object_store_conf):
 
 
 def get_pulsar_staging_dir(galaxy_pulsar_app_conf):
-    """Get the path to the pulsar staging directory
+    """Get the path to the pulsar staging directory.
 
     Args:
         galaxy_pulsar_app_conf (str): Path to the pulsar_app.yml file
@@ -280,13 +292,15 @@ def get_pulsar_staging_dir(galaxy_pulsar_app_conf):
 
 
 def decode_path(job_id, metadata, backends_dict, job_runner_name=None):
-    """Decode the path of JWD's and check if the path exists
+    """Decode the path of JWD's and check if the path exists.
 
     Args:
-        job_id (int): Job id
-        metadata (list): List of object_store_id and update_time
-        backends_dict (dict): Dictionary of backend id and path of type 'job_work'
-        job_runner_name (str, optional): Name of the job runner. Defaults to None.
+        job_id (int): Job id.
+        metadata (list): List of object_store_id and update_time.
+        backends_dict (dict): Dictionary of backend id and path of type
+            'job_work'.
+        job_runner_name (str, optional): Name of the job runner. Defaults to
+            None.
 
     Returns:
         str: Path to the JWD
@@ -296,21 +310,27 @@ def decode_path(job_id, metadata, backends_dict, job_runner_name=None):
     # Check if object_store_id exists in our object store config
     if metadata[0] not in backends_dict.keys():
         raise ValueError(
-            f"Object store id '{metadata[0]}' does not exist in the object_store_conf.xml file"
+            f"Object store id '{metadata[0]}' does not exist in the "
+            f"object_store_conf.xml file."
         )
 
-    # Pulsar embedded jobs uses the staging directory and this has a different path structure
+    # Pulsar embedded jobs uses the staging directory and this has a different
+    # path structure
     if job_runner_name == "pulsar_embedded":
         jwd_path = f"{backends_dict[job_runner_name]}/{job_id}"
     else:
-        jwd_path = f"{backends_dict[metadata[0]]}/0{job_id[0:2]}/{job_id[2:5]}/{job_id}"
+        jwd_path = (
+            f"{backends_dict[metadata[0]]}/"
+            f"0{job_id[0:2]}/{job_id[2:5]}/{job_id}"
+        )
 
     # Validate that the path is a JWD
     # It is a JWD if the following conditions are true:
     # 1. Check if tool_script.sh exists
     # 2. Check if directories 'inputs', and 'outputs' exist
-    # 3. Additionally, we can also try and find the file '__instrument_core_epoch_end'
-    # and compare the timestamp in that with the 'update_time' (metadata[1]) of the job.
+    # 3. Additionally, we can also try and find the file
+    # '__instrument_core_epoch_end' and compare the timestamp in that with the
+    # 'update_time' (metadata[1]) of the job.
     if (
         os.path.exists(jwd_path)
         and os.path.exists(f"{jwd_path}/tool_script.sh")
@@ -323,7 +343,7 @@ def decode_path(job_id, metadata, backends_dict, job_runner_name=None):
 
 
 def delete_jwd(jwd_path):
-    """Delete JWD folder and all its contents
+    """Delete JWD folder and all its contents.
 
     Args:
         jwd_path (str): Path to the JWD folder
@@ -336,16 +356,17 @@ def delete_jwd(jwd_path):
 
 
 class Database:
-    """Class to connect to the database and query DB
+    """Class to connect to the database and query DB.
 
     Args:
-        dbname (str): Name of the database
-        dbuser (str): Name of the database user
-        dbhost (str): Hostname of the database
-        dbpassword (str): Password of the database user
+        dbname (str): Name of the database.
+        dbuser (str): Name of the database user.
+        dbhost (str): Hostname of the database.
+        dbpassword (str): Password of the database user.
     """
 
     def __init__(self, dbname, dbuser, dbhost, dbpassword):
+        """Create a connection to the Galaxy database."""
         try:
             self.conn = psycopg2.connect(
                 dbname=dbname, user=dbuser, host=dbhost, password=dbpassword
@@ -354,13 +375,14 @@ class Database:
             print(f"Unable to connect to database: {e}")
 
     def get_failed_jobs(self, days):
-        """Get failed jobs for DB
+        """Get failed jobs for DB.
 
         Args:
-            days (int): Number of days to look back for failed jobs
+            days (int): Number of days to look back for failed jobs.
 
         Returns:
-            dict: Dictionary with job_id as key and object_store_id, and update_time as list of values
+            dict: Dictionary with job_id as key and object_store_id, and
+                update_time as list of values.
 
 
         """
@@ -379,7 +401,8 @@ class Database:
         cur.close()
         self.conn.close()
 
-        # Create a dictionary with job_id as key and object_store_id, and update_time as values
+        # Create a dictionary with job_id as key and object_store_id, and
+        # update_time as values
         failed_jobs_dict = {}
         for job_id, object_store_id, update_time in failed_jobs:
             failed_jobs_dict[job_id] = [object_store_id, update_time]
@@ -391,7 +414,7 @@ class Database:
         return failed_jobs_dict
 
     def get_job_info(self, job_id):
-        """Get object_store_id and job_runner_name for a given job id
+        """Get object_store_id and job_runner_name for a given job id.
 
         Args:
             job_id (int): Job id
@@ -405,7 +428,8 @@ class Database:
             f"""
             SELECT object_store_id, job_runner_name
             FROM job
-            WHERE id = '{job_id}' AND object_store_id IS NOT NULL AND job_runner_name IS NOT NULL
+            WHERE id = '{job_id}' AND object_store_id IS NOT NULL
+            AND job_runner_name IS NOT NULL
             """
         )
         object_store_id, job_runner_name = cur.fetchone()
@@ -414,7 +438,8 @@ class Database:
 
         if not object_store_id:
             print(
-                f"Object store id and/or the job runner name for the job '{job_id}' was not found in the database"
+                f"Object store id and/or the job runner name for the job"
+                f"'{job_id}' was not found in the database"
             )
             sys.exit(1)
 

--- a/roles/usegalaxy-eu.bashrc/files/galaxy_jwd.py
+++ b/roles/usegalaxy-eu.bashrc/files/galaxy_jwd.py
@@ -8,6 +8,7 @@ import shutil
 import sys
 from datetime import datetime
 from xml.dom.minidom import parse
+
 import psycopg2
 import yaml
 

--- a/roles/usegalaxy-eu.bashrc/files/galaxy_jwd.py
+++ b/roles/usegalaxy-eu.bashrc/files/galaxy_jwd.py
@@ -188,7 +188,10 @@ def main():
         if jwd_path:
             print(jwd_path)
         else:
-            print(f"INFO: Job working directory (of {job_id}) does not exist")
+            print(
+                f"ERROR: Job working directory (of {job_id}) does not exist",
+                file=sys.stderr,
+            )
             sys.exit(1)
 
     # For the clean subcommand
@@ -438,7 +441,10 @@ class Database:
             failed_jobs_dict[job_id] = [object_store_id, update_time]
 
         if not failed_jobs_dict:
-            print(f"No failed jobs found within the last {days} days")
+            print(
+                f"No failed jobs found within the last {days} days",
+                file=sys.stderr,
+            )
             sys.exit(1)
 
         return failed_jobs_dict
@@ -469,7 +475,8 @@ class Database:
         if not object_store_id:
             print(
                 f"Object store id and/or the job runner name for the job"
-                f"'{job_id}' was not found in the database"
+                f"'{job_id}' was not found in the database",
+                file=sys.stderr,
             )
             sys.exit(1)
 

--- a/roles/usegalaxy-eu.bashrc/files/galaxy_jwd.py
+++ b/roles/usegalaxy-eu.bashrc/files/galaxy_jwd.py
@@ -12,6 +12,7 @@ import sys
 import textwrap
 from argparse import RawDescriptionHelpFormatter
 from datetime import datetime
+from typing import Optional, Tuple
 from xml.dom.minidom import parse
 
 import psycopg2
@@ -55,8 +56,8 @@ def main():
         formatter_class=SubcommandHelpFormatter,
     )
     subparsers = parser.add_subparsers(
+        dest="operation",
         title="operations",
-        required=True,
         help=None,
         metavar="",
     )
@@ -177,7 +178,7 @@ def main():
     )
 
     # For the get subcommand
-    if args.subcommand == "get":
+    if args.operation == "get":
         job_id = args.job_id
         object_store_id, job_runner_name = db.get_job_info(job_id)
         jwd_path = decode_path(
@@ -195,7 +196,7 @@ def main():
             sys.exit(1)
 
     # For the clean subcommand
-    if args.subcommand == "clean":
+    if args.operation == "clean":
         # Check if the given Galaxy log directory exists
         if not os.path.isdir(galaxy_log_dir):
             raise ValueError(
@@ -338,7 +339,7 @@ def decode_path(
     job_id: int,
     metadata: list,
     backends_dict: dict,
-    job_runner_name: str | None = None,
+    job_runner_name: Optional[str] = None,
 ) -> str:
     """Decode the path of JWDs and check if the path exists.
 
@@ -466,7 +467,7 @@ class Database:
 
         return failed_jobs_dict
 
-    def get_job_info(self, job_id: int) -> tuple[str, str]:
+    def get_job_info(self, job_id: int) -> Tuple[str, str]:
         """Get object_store_id and job_runner_name for a given job id.
 
         Args:

--- a/roles/usegalaxy-eu.bashrc/files/galaxy_jwd.py
+++ b/roles/usegalaxy-eu.bashrc/files/galaxy_jwd.py
@@ -58,7 +58,9 @@ def main():
     clean_jwds_parser = subparsers.add_parser(
         "clean_jwds", help="Clean JWD's of jobs failed within last X days"
     )
-    dry_run_group = clean_jwds_parser.add_mutually_exclusive_group(required=True)
+    dry_run_group = clean_jwds_parser.add_mutually_exclusive_group(
+        required=True
+    )
     dry_run_group.add_argument(
         "--dry_run",
         help="Dry run (Print's the JWD's that would be deleted)",
@@ -125,7 +127,9 @@ def main():
     backends = parse_object_store(object_store_conf)
 
     # Add pulsar staging directory (runner: pulsar_embedded) to backends
-    backends["pulsar_embedded"] = get_pulsar_staging_dir(galaxy_pulsar_app_conf)
+    backends["pulsar_embedded"] = get_pulsar_staging_dir(
+        galaxy_pulsar_app_conf
+    )
 
     # Connect to Galaxy database
     db = Database(
@@ -139,7 +143,9 @@ def main():
     if args.subcommand == "get_jwd":
         job_id = args.job_id
         object_store_id, job_runner_name = db.get_job_info(job_id)
-        jwd_path = decode_path(job_id, [object_store_id], backends, job_runner_name)
+        jwd_path = decode_path(
+            job_id, [object_store_id], backends, job_runner_name
+        )
 
         # Check
         if jwd_path:


### PR DESCRIPTION
This PR changes the behavior of galaxy_jwd.py so that it deletes old failed jobs rather than recently failed jobs. It also contains cosmetic changes.

The branch was rebased on top of `kysrpex:python_formatting`, so to have a clean Git history, #823 should be merged first. Alternatively if #823 does not get merged, certain commits could be removed from this PR.

Due to the cosmetic changes, and the fact that it contains #823, you will see a lot of changes in the _"Files changed"_ tab when reviewing the PR. I have split all changes in different commits focused in different kinds of change precisely for this reason, so that you can select specific commits from the drop-down menu and focus on one commit at a time.