### PR TITLE
Move telegraf items from sn06 to maintenance

### DIFF
--- a/group_vars/maintenance.yml
+++ b/group_vars/maintenance.yml
@@ -149,89 +149,103 @@ fsm_htcondor_enable: true
 telegraf_agent_hostname: "{{ hostname }}"
 telegraf_agent_version: 1.17.2
 custom_telegraf_env: "/usr/bin/env GDPR_MODE=1 PGUSER={{ galaxy_user.name }} PGHOST={{ postgres_host }} GALAXY_ROOT={{ galaxy_server_dir }} GALAXY_CONFIG_FILE={{ galaxy_config_file }} GXADMIN_PYTHON={{ galaxy_venv_dir }}/bin/python"
-# telegraf_plugins_extra:
-#   postgres:
-#     plugin: "postgresql"
-#     config:
-#       - address = "{{ galaxy_db_connection }}"
-#       - databases = ["galaxy", "galaxy-test", "apollo", "chado"]
-#   monitor_nfsstat:
-#     plugin: "exec"
-#     config:
-#       - commands = ["/usr/bin/nfsstat-influx"]
-#       - timeout = "10s"
-#       - data_format = "influx"
-#       - interval = "15s"
-#   galaxy_uploaded:
-#     plugin: "exec"
-#     config:
-#       - commands = ["{{ custom_telegraf_env }} /usr/bin/gxadmin iquery upload-gb-in-past-hour"]
-#       - timeout = "360s"
-#       - data_format = "influx"
-#       - interval = "1h"
-#   galaxy_jobs_queued:
-#     plugin: "exec"
-#     config:
-#       - commands = ["{{ custom_telegraf_env }} /usr/bin/gxadmin iquery jobs-queued"]
-#       - timeout = "15s"
-#       - data_format = "influx"
-#       - interval = "1m"
-#   galaxy_jobs_queued_internal:
-#     plugin: "exec"
-#     config:
-#       - commands = ["{{ custom_telegraf_env }} /usr/bin/gxadmin iquery jobs-queued-internal-by-handler"]
-#       - timeout = "15s"
-#       - data_format = "influx"
-#       - interval = "1m"
-#   galaxy_jobs_queue_overview:
-#     plugin: "exec"
-#     config:
-#       - commands = ["{{ custom_telegraf_env }} /usr/bin/gxadmin iquery queue-overview --short-tool-id"]
-#       - timeout = "30s"
-#       - data_format = "influx"
-#       - interval = "1m"
-#   galaxy_oidc:
-#     plugin: "exec"
-#     config:
-#       - commands = ["{{ custom_telegraf_env }} /usr/bin/gxadmin iquery users-with-oidc"]
-#       - timeout = "15s"
-#       - data_format = "influx"
-#       - interval = "1m"
-#   galaxy_workflow:
-#     plugin: "exec"
-#     config:
-#       - commands = ["{{ custom_telegraf_env }} /usr/bin/gxadmin iquery workflow-invocation-status"]
-#       - timeout = "15s"
-#       - data_format = "influx"
-#       - interval = "1m"
-#   galaxy_workflow_totals:
-#     plugin: "exec"
-#     config:
-#       - commands = ["{{ custom_telegraf_env }} /usr/bin/gxadmin iquery workflow-invocation-totals"]
-#       - timeout = "15s"
-#       - data_format = "influx"
-#       - interval = "1m"
-#   postgres_extra:
-#     plugin: "exec"
-#     config:
-#       - commands = [
-#         "{{ custom_telegraf_env }} /usr/bin/gxadmin iquery pg-cache-hit",
-#         "{{ custom_telegraf_env }} /usr/bin/gxadmin iquery pg-index-size",
-#         "{{ custom_telegraf_env }} /usr/bin/gxadmin iquery pg-index-usage",
-#         "{{ custom_telegraf_env }} /usr/bin/gxadmin iquery pg-table-bloat",
-#         "{{ custom_telegraf_env }} /usr/bin/gxadmin iquery pg-table-size",
-#         "{{ custom_telegraf_env }} /usr/bin/gxadmin iquery pg-unused-indexes",
-#         "{{ custom_telegraf_env }} /usr/bin/gxadmin iquery pg-vacuum-stats",
-#         "{{ custom_telegraf_env }} /usr/bin/gxadmin iquery pg-stat-bgwriter",
-#         "{{ custom_telegraf_env }} /usr/bin/gxadmin iquery pg-stat-user-tables",
-#         ]
-#       - timeout = "60s"
-#       - data_format = "influx"
-#       - interval = "2m"
+telegraf_plugins_extra:
+  postgres:
+    plugin: "postgresql"
+    config:
+      - address = "{{ galaxy_db_connection }}"
+      - databases = ["galaxy", "galaxy-test", "apollo", "chado"]
+  monitor_nfsstat:
+    plugin: "exec"
+    config:
+      - commands = ["/usr/bin/nfsstat-influx"]
+      - timeout = "10s"
+      - data_format = "influx"
+      - interval = "15s"
+  galaxy_uploaded:
+    plugin: "exec"
+    config:
+      - commands = ["{{ custom_telegraf_env }} /usr/bin/gxadmin iquery upload-gb-in-past-hour"]
+      - timeout = "240s"
+      - data_format = "influx"
+      - interval = "1h"
+  galaxy_jobs_queued:
+    plugin: "exec"
+    config:
+      - commands = ["{{ custom_telegraf_env }} /usr/bin/gxadmin iquery jobs-queued"]
+      - timeout = "15s"
+      - data_format = "influx"
+      - interval = "1m"
+  galaxy_jobs_queued_internal:
+    plugin: "exec"
+    config:
+      - commands = ["{{ custom_telegraf_env }} /usr/bin/gxadmin iquery jobs-queued-internal-by-handler"]
+      - timeout = "15s"
+      - data_format = "influx"
+      - interval = "1m"
+  galaxy_jobs_queue_overview:
+    plugin: "exec"
+    config:
+      - commands = ["{{ custom_telegraf_env }} /usr/bin/gxadmin iquery queue-overview --short-tool-id"]
+      - timeout = "30s"
+      - data_format = "influx"
+      - interval = "1m"
+  galaxy_oidc:
+    plugin: "exec"
+    config:
+      - commands = ["{{ custom_telegraf_env }} /usr/bin/gxadmin iquery users-with-oidc"]
+      - timeout = "15s"
+      - data_format = "influx"
+      - interval = "1m"
+  galaxy_workflow:
+    plugin: "exec"
+    config:
+      - commands = ["{{ custom_telegraf_env }} /usr/bin/gxadmin iquery workflow-invocation-status"]
+      - timeout = "15s"
+      - data_format = "influx"
+      - interval = "1m"
+  galaxy_workflow_totals:
+    plugin: "exec"
+    config:
+      - commands = ["{{ custom_telegraf_env }} /usr/bin/gxadmin iquery workflow-invocation-totals"]
+      - timeout = "15s"
+      - data_format = "influx"
+      - interval = "1m"
+  monitor_condor_queue:
+    plugin: "exec"
+    config:
+      - commands = ["sudo /usr/bin/monitor-condor-queue"]
+      - timeout = "10s"
+      - data_format = "influx"
+      - interval = "1m"
+  monitor_condor_util:
+    plugin: "exec"
+    config:
+      - commands = ["sudo /usr/bin/monitor-condor-utilisation"]
+      - timeout = "10s"
+      - data_format = "influx"
+      - interval = "1m"
+  postgres_extra:
+    plugin: "exec"
+    config:
+      - commands = [
+        "{{ custom_telegraf_env }} /usr/bin/gxadmin iquery pg-cache-hit",
+        "{{ custom_telegraf_env }} /usr/bin/gxadmin iquery pg-index-size",
+        "{{ custom_telegraf_env }} /usr/bin/gxadmin iquery pg-index-usage",
+        "{{ custom_telegraf_env }} /usr/bin/gxadmin iquery pg-table-bloat",
+        "{{ custom_telegraf_env }} /usr/bin/gxadmin iquery pg-table-size",
+        "{{ custom_telegraf_env }} /usr/bin/gxadmin iquery pg-unused-indexes",
+        "{{ custom_telegraf_env }} /usr/bin/gxadmin iquery pg-vacuum-stats",
+        "{{ custom_telegraf_env }} /usr/bin/gxadmin iquery pg-stat-bgwriter",
+        "{{ custom_telegraf_env }} /usr/bin/gxadmin iquery pg-stat-user-tables",
+        ]
+      - timeout = "60s"
+      - data_format = "influx"
+      - interval = "2m"
+
 
 # Role: hxr.monitor-cluster
 monitor_condor: true
-monitor_condor_split_util: true
 
 # Role: usegalaxy-eu.dynmotd
 dynmotd_custom:

--- a/group_vars/sn06.yml
+++ b/group_vars/sn06.yml
@@ -96,12 +96,6 @@ telegraf_agent_hostname: "{{ hostname }}"
 telegraf_agent_version: 1.17.2
 custom_telegraf_env: "/usr/bin/env GDPR_MODE=1 PGUSER={{ galaxy_user.name }} PGHOST={{ postgres_host }} GALAXY_ROOT={{ galaxy_server_dir }} GALAXY_CONFIG_FILE={{ galaxy_config_file }} GALAXY_LOG_DIR={{ galaxy_log_dir }} GXADMIN_PYTHON={{ galaxy_venv_dir }}/bin/python"
 telegraf_plugins_extra:
-  postgres:
-    plugin: "postgresql"
-    config:
-      - address = "{{ galaxy_db_connection }}"
-      - databases = ["galaxy", "galaxy-test", "apollo", "chado"]
-
   listen_galaxy_routes:
     plugin: "statsd"
     config:
@@ -111,47 +105,7 @@ telegraf_plugins_extra:
       - allowed_pending_messages = 10000
       - percentile_limit = 100
 
-  #monitor_condor_queue_split:
-  #plugin: "exec"
-  #config:
-  ## TODO: sudoers rule?
-  #- commands = ["sudo /usr/bin/monitor-condor-queue-split"]
-  #- timeout = "10s"
-  #- data_format = "influx"
-  #- interval = "15s"
-
-  monitor_condor_queue:
-    plugin: "exec"
-    config:
-      - commands = ["sudo /usr/bin/monitor-condor-queue"]
-      - timeout = "10s"
-      - data_format = "influx"
-      - interval = "1m"
-
-  monitor_condor_util:
-    plugin: "exec"
-    config:
-      - commands = ["sudo /usr/bin/monitor-condor-utilisation"]
-      - timeout = "10s"
-      - data_format = "influx"
-      - interval = "1m"
-
-  monitor_nfsstat:
-    plugin: "exec"
-    config:
-      - commands = ["/usr/bin/nfsstat-influx"]
-      - timeout = "10s"
-      - data_format = "influx"
-      - interval = "15s"
-
-  # Some custom galaxy monitoring stuff
-  galaxy_uploaded:
-    plugin: "exec"
-    config:
-      - commands = ["{{ custom_telegraf_env }} /usr/bin/gxadmin iquery upload-gb-in-past-hour"]
-      - timeout = "120s"
-      - data_format = "influx"
-      - interval = "1h"
+  # Some custom galaxy monitoring stuff that can only run on the Galaxy server
   galaxy_lastlog:
     plugin: "exec"
     config:
@@ -159,73 +113,13 @@ telegraf_plugins_extra:
       - timeout = "15s"
       - data_format = "influx"
       - interval = "15s"
-  galaxy_jobs_queued:
-    plugin: "exec"
-    config:
-      - commands = ["{{ custom_telegraf_env }} /usr/bin/gxadmin iquery jobs-queued"]
-      - timeout = "15s"
-      - data_format = "influx"
-      - interval = "1m"
-  galaxy_jobs_queued_internal:
-    plugin: "exec"
-    config:
-      - commands = ["{{ custom_telegraf_env }} /usr/bin/gxadmin iquery jobs-queued-internal-by-handler"]
-      - timeout = "15s"
-      - data_format = "influx"
-      - interval = "1m"
-  galaxy_jobs_queue_overview:
-    plugin: "exec"
-    config:
-      - commands = ["{{ custom_telegraf_env }} /usr/bin/gxadmin iquery queue-overview --short-tool-id"]
-      - timeout = "30s"
-      - data_format = "influx"
-      - interval = "1m"
-  galaxy_oidc:
-    plugin: "exec"
-    config:
-      - commands = ["{{ custom_telegraf_env }} /usr/bin/gxadmin iquery users-with-oidc"]
-      - timeout = "15s"
-      - data_format = "influx"
-      - interval = "1m"
-  galaxy_workflow:
-    plugin: "exec"
-    config:
-      - commands = ["{{ custom_telegraf_env }} /usr/bin/gxadmin iquery workflow-invocation-status"]
-      - timeout = "15s"
-      - data_format = "influx"
-      - interval = "1m"
-  galaxy_workflow_totals:
-    plugin: "exec"
-    config:
-      - commands = ["{{ custom_telegraf_env }} /usr/bin/gxadmin iquery workflow-invocation-totals"]
-      - timeout = "15s"
-      - data_format = "influx"
-      - interval = "1m"
   galaxy_active_users:
     plugin: "exec"
     config:
-      - commands = ["/usr/bin/gxadmin local cu"]
+      - commands = ["/usr/bin/gxadmin gunicorn active-users"]
       - timeout = "15s"
       - data_format = "influx"
       - interval = "1m"
-
-  postgres_extra:
-    plugin: "exec"
-    config:
-      - commands = [
-        "{{ custom_telegraf_env }} /usr/bin/gxadmin iquery pg-cache-hit",
-        "{{ custom_telegraf_env }} /usr/bin/gxadmin iquery pg-index-size",
-        "{{ custom_telegraf_env }} /usr/bin/gxadmin iquery pg-index-usage",
-        "{{ custom_telegraf_env }} /usr/bin/gxadmin iquery pg-table-bloat",
-        "{{ custom_telegraf_env }} /usr/bin/gxadmin iquery pg-table-size",
-        "{{ custom_telegraf_env }} /usr/bin/gxadmin iquery pg-unused-indexes",
-        "{{ custom_telegraf_env }} /usr/bin/gxadmin iquery pg-vacuum-stats",
-        "{{ custom_telegraf_env }} /usr/bin/gxadmin iquery pg-stat-bgwriter",
-        "{{ custom_telegraf_env }} /usr/bin/gxadmin iquery pg-stat-user-tables",
-        ]
-      - timeout = "60s"
-      - data_format = "influx"
-      - interval = "2m"
 
 # Custom pip installer
 pip_venv_path: "{{ galaxy_venv_dir }}"
@@ -260,10 +154,6 @@ all_yum_repositories:
     gpgcheck: false
     retries: 1
     timeout: 10
-
-# Galaxy monitoring
-monitor_condor: true
-monitor_condor_split_util: true
 
 # Certbot
 certbot_virtualenv_package_name: python3-virtualenv

--- a/maintenance.yml
+++ b/maintenance.yml
@@ -75,7 +75,7 @@
     - influxdata.chrony
     - usegalaxy-eu.autofs
     # # Uncomment (commented roles) when in production
-    # - hxr.monitor-cluster
+    - hxr.monitor-cluster
     # - usegalaxy-eu.monitoring
     - usegalaxy-eu.bashrc
     - usegalaxy_eu.htcondor

--- a/roles/hxr.monitor-cluster/files/cluster_queue-condor.sh
+++ b/roles/hxr.monitor-cluster/files/cluster_queue-condor.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-condor_q -total | grep "all" | sed 's/.* jobs;\s*//g;s/, /\n/g' | while read line ; do
+condor_q -global -total | grep "all" | sed 's/.* jobs;\s*//g;s/, /\n/g' | while read line ; do
     type=$(echo $line | sed 's/^[0-9]* //g');
     count=$(echo $line | sed 's/ .*//g');
     echo "cluster.queue,engine=condor,state=$type count=$count"

--- a/roles/hxr.monitor-cluster/files/cluster_util-condor.sh
+++ b/roles/hxr.monitor-cluster/files/cluster_util-condor.sh
@@ -1,8 +1,25 @@
 #!/bin/bash
-mem_total=$(condor_status -autoformat TotalMemory | paste -s -d'+' | bc)
-mem_alloc=$(condor_status -autoformat Memory      | paste -s -d'+' | bc)
-mem_perc=$(echo "$mem_alloc / $mem_total" | bc -l)
-cpu_total=$(condor_status -autoformat DetectedCpus | paste -s -d'+' | bc)
-cpu_alloc=$(condor_status -autoformat Cpus         | paste -s -d'+' | bc)
-cpu_perc=$(echo "$cpu_alloc / $cpu_total" | bc -l)
-echo "cluster.alloc,cluster=condor cores=0$cpu_perc,memory=0$mem_perc"
+# mem_total=$(condor_status -autoformat TotalMemory | paste -s -d'+' | bc)
+# mem_alloc=$(condor_status -autoformat Memory      | paste -s -d'+' | bc)
+# mem_perc=$(echo "$mem_alloc / $mem_total" | bc -l)
+# cpu_total=$(condor_status -autoformat DetectedCpus | paste -s -d'+' | bc)
+# cpu_alloc=$(condor_status -autoformat Cpus         | paste -s -d'+' | bc)
+# cpu_perc=$(echo "$cpu_alloc / $cpu_total" | bc -l)
+# echo "cluster.alloc,cluster=condor cores=0$cpu_perc,memory=0$mem_perc"
+
+# As of 04.07.2023, the following is used to collect data from the cluster
+# Details:
+# SlotType: Dynamic or partitionable slots. Each host is partitioned to 1 slot and that slot is further dynamically partitioned to several slots
+# Name: Name of the slot
+# State: Claimed or Unclaimed slot
+# Activity: Idle or Busy
+# DetectedCpus: Total CPU cores available at machine level
+# Cpus: Total CPU cores available at slot level
+# TotalMemory: Total memory available at machine level
+# Memory: Total memory available at slot level
+# LoadAvg: Load avergate at slot level
+# TotalLoadAvg: Total load average at the machine level
+# GalaxyGroup: Group name of the machine
+
+# Command:
+condor_status -af:l Name SlotType State Activity GalaxyGroup DetectedCpus Cpus TotalMemory Memory LoadAvg TotalLoadAvg -constraint 'SlotType == "Dynamic" || SlotType == "Partitionable"' | awk -F '[= ]+' '{printf("htcondor_cluster_usage,classad=\"slot\" %s=\"%s\",%s=\"%s\",%s=\"%s\",%s=\"%s\",%s=\"%s\",%s=%s,%s=%s,%s=%s,%s=%s,%s=%s,%s=%s\n", $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23)}'

--- a/sn06.yml
+++ b/sn06.yml
@@ -142,7 +142,6 @@
     - galaxyproject.cvmfs # Galaxy datasets
 
     ## Monitoring
-    - hxr.monitor-cluster
     - hxr.monitor-email
     - hxr.monitor-galaxy-journalctl
     # - usegalaxy-eu.monitor-disk-access-time


### PR DESCRIPTION
1. Migrates Telegraf monitoring items/confs from sn06 to the maintenance playbook
2. Add new htcondor cluster utilization command and disable the old one
3. Add `-global` to condor queue to collect the output from all queues in the pool. This is needed because this will be run from the maintenance node
4. Remove `hxr.monitor-cluster` role from sn06 and enable it on the maintenance node