### PR TITLE
re-balance JWDs

### DIFF
--- a/templates/galaxy/config/object_store_conf.xml.j2
+++ b/templates/galaxy/config/object_store_conf.xml.j2
@@ -174,11 +174,11 @@ The storage consists of 16 Gen6 type A200 storage nodes and 16 Gen5 type X410 no
             <files_dir path="/data/dnb09/galaxy_db/files"/>
             <extra_dir type="job_work" path="/data/jwd02f/main"/>
         </backend>
-        <backend id="files24" type="disk" weight="1" store_by="uuid">
+        <backend id="files24" type="disk" weight="2" store_by="uuid">
             <files_dir path="/data/dnb09/galaxy_db/files"/>
             <extra_dir type="job_work" path="/data/jwd05e/main"/>
         </backend>
-        <backend id="files25" type="disk" weight="2" store_by="uuid">
+        <backend id="files25" type="disk" weight="1" store_by="uuid">
             <files_dir path="/data/dnb09/galaxy_db/files"/>
             <extra_dir type="job_work" path="/data/jwd01/main"/>
         </backend>


### PR DESCRIPTION
jwd01 is slow and the reason why a lot of jobs are in the unprocessed state for a couple of days. On Monday we saw the same behaviour, especially during the night and the same happened last night.

The current speed of active JWDs:

``` bash
galaxy@sn06:/tmp$ dd if=/dev/zero of=/data/jwd02f/main/testfile bs=1G count=1 oflag=direct
1+0 records in
1+0 records out
1073741824 bytes (1.1 GB, 1.0 GiB) copied, 2.09852 s, 512 MB/s
galaxy@sn06:/tmp$ dd if=/dev/zero of=/data/jwd05e/main/testfile bs=1G count=1 oflag=direct
1+0 records in
1+0 records out
1073741824 bytes (1.1 GB, 1.0 GiB) copied, 1.89249 s, 567 MB/s
galaxy@sn06:/tmp$ dd if=/dev/zero of=/data/jwd01/main/testfile bs=1G count=1 oflag=direct
1+0 records in
1+0 records out
1073741824 bytes (1.1 GB, 1.0 GiB) copied, 20.0609 s, 53.5 MB/s
```
