### PR TITLE
Rebalance JWDs: give same importance to jwd02f and jwd05e

### DIFF
--- a/templates/galaxy/config/object_store_conf.xml.j2
+++ b/templates/galaxy/config/object_store_conf.xml.j2
@@ -170,7 +170,7 @@ The storage consists of 16 Gen6 type A200 storage nodes and 16 Gen5 type X410 no
             <!-- this is ws02 on the Netapp side and should not be used anymore, oo -->
             <extra_dir type="job_work" path="/data/jwd03f/main"/>
         </backend>
-        <backend id="files23" type="disk" weight="1" store_by="uuid">
+        <backend id="files23" type="disk" weight="2" store_by="uuid">
             <files_dir path="/data/dnb09/galaxy_db/files"/>
             <extra_dir type="job_work" path="/data/jwd02f/main"/>
         </backend>


### PR DESCRIPTION
I enabled this manually as little experiment to see if the situation can be improved and things immediately improved, it seems there is no other option than to use the full bandwith provided by two disks.

![grafik](https://github.com/usegalaxy-eu/infrastructure-playbook/assets/43052541/9dd009a5-227e-4a25-8ce3-c726dcdec15a)

