### PR TITLE
Update galaxy bashrc function and stop-ITs

### DIFF
--- a/roles/usegalaxy-eu.bashrc/tasks/bashrc_tasks.yml
+++ b/roles/usegalaxy-eu.bashrc/tasks/bashrc_tasks.yml
@@ -76,7 +76,7 @@
           fi
 
           JID=$1
-          JWD=$(python /usr/local/bin/galaxy_jwd get_jwd $JID)
+          JWD=$(python /usr/local/bin/galaxy_jwd get $JID)
 
           # Check the return code and whether the job working directory exists
           if [[ $? -ne 0 || ! -d $JWD ]]; then

--- a/roles/usegalaxy-eu.fix-stop-ITs/templates/stop-ITs.sh.j2
+++ b/roles/usegalaxy-eu.fix-stop-ITs/templates/stop-ITs.sh.j2
@@ -4,7 +4,7 @@ DAY=86400
 cd ~
 for job in $(gxadmin query queue-details --all | grep running | grep interactive_tool | awk '{print $3}')
 do
-    JWD=$(python /usr/local/bin/galaxy_jwd get_jwd $job)
+    JWD=$(python /usr/local/bin/galaxy_jwd get $job)
     pushd $JWD
     ClusterID=$( head -n 1 job_condor.log | awk '{print $2}' | awk -F. '{print $1"."$2}' | sed 's/^(//' )
     if [ "$(condor_q $ClusterID -autoformat JobStartDate)" == "undefined" ] || [ "$(condor_q $ClusterID -autoformat JobStartDate)" == "" ]


### PR DESCRIPTION
galaxy_jwd scripts 'get_jwd' function is now called 'get' as a result of [this PR](https://github.com/usegalaxy-eu/infrastructure-playbook/pull/827)