### PR TITLE
For PG, raise 'log_min_duration_statement' to 500 ms

### DIFF
--- a/group_vars/sn05.yml
+++ b/group_vars/sn05.yml
@@ -52,7 +52,7 @@ postgresql_conf:
   - effective_cache_size: "16GB"
 #  - log_line_prefix: "'%t:%r:%u@%d:[%p]<%m>: '"
   - log_checkpoints: "on"
-  - log_min_duration_statement: 100
+  - log_min_duration_statement: 500
 postgresql_pg_hba_conf:
   - "host    postgres        galaxy          132.230.223.239/32      md5"
   - "host    postgres        galaxy          10.5.68.237/32          md5"


### PR DESCRIPTION
Before I forget it - here's one to review on Monday (no config changes on Fridays): This PR raises the Postgres config parameter `log_min_duration_statement` to 500 ms. We haven't rly ever looked at the plethora of statements taking more than 100 ms to execute that are currently being logged, now have we? IMO it would be far more informative to just log those relatively few queries that take *rly* long. If we ever need to override this for a debugging session, a local config file added in `data/conf.d` will do nicely (`log_min_duration_statement`  only requires a reload, *not* a full restart).