### PR TITLE
Update capabilities of GPU destinations after GPU infrastructure maintenance

### DIFF
--- a/files/galaxy/tpv/destinations.yml.j2
+++ b/files/galaxy/tpv/destinations.yml.j2
@@ -348,8 +348,8 @@ destinations:
 
   condor_gpu:
     runner: condor
-    max_accepted_cores: 8
-    max_accepted_mem: 16
+    max_accepted_cores: 14
+    max_accepted_mem: 40
     min_accepted_gpus: 1
     max_accepted_gpus: 1
     env:
@@ -361,8 +361,8 @@ destinations:
     inherits: basic_docker_destination
     # shorter than inheriting from condor_gpu
     runner: condor
-    max_accepted_cores: 8
-    max_accepted_mem: 16
+    max_accepted_cores: 14
+    max_accepted_mem: 40
     min_accepted_gpus: 1
     max_accepted_gpus: 1
     scheduling:

--- a/files/galaxy/tpv/destinations.yml.j2
+++ b/files/galaxy/tpv/destinations.yml.j2
@@ -349,7 +349,7 @@ destinations:
   condor_gpu:
     runner: condor
     max_accepted_cores: 14
-    max_accepted_mem: 40
+    max_accepted_mem: 37
     min_accepted_gpus: 1
     max_accepted_gpus: 1
     env:
@@ -362,7 +362,7 @@ destinations:
     # shorter than inheriting from condor_gpu
     runner: condor
     max_accepted_cores: 14
-    max_accepted_mem: 40
+    max_accepted_mem: 37
     min_accepted_gpus: 1
     max_accepted_gpus: 1
     scheduling:


### PR DESCRIPTION
The resource limits should be increased in the TPV destinations file to match the most powerful OpenStack GPU flavors introduced in usegalaxy-eu/vgcn-infrastructure#205.