### PR TITLE
AlphaFold: Increase memory requirements for multimer model

### DIFF
--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -247,6 +247,10 @@ tools:
       - if: helpers.tool_version_gte(tool, '2.3.1+galaxy2')
         params:
           singularity_run_extra_arguments: "--env ALPHAFOLD_DB=/data/db/databases/alphafold_databases,ALPHAFOLD_USE_GPU=False"
+        # tweak amount of requested memory depending on the AlphaFold model to be run
+      - id: model_preset_multimer
+        if: job.get_param_values(app).get("model_preset") == "multimer"
+        mem: 69
     scheduling:
       require:
         - singularity


### PR DESCRIPTION
AlphaFold's current memory requirement definition is insufficient when launched with the `--model_preset=multimer` argument . The new memory requirement is just based on [what Galaxy Australia is using for all models](https://github.com/usegalaxy-au/infrastructure/blob/1316ad9a402a9f04304702db4b2947207a26a8ca/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml#L658).

Closes usegalaxy-eu/issues#455.