### PR TITLE
Revert "take biotools out again"

### DIFF
--- a/group_vars/gxconfig.yml
+++ b/group_vars/gxconfig.yml
@@ -579,7 +579,7 @@ base_app_main: &BASE_APP_MAIN
   # Point Galaxy at a repository consisting of a copy of the bio.tools
   # database (e.g. https://github.com/bio-tools/content/) to resolve
   # bio.tools data for tool metadata.
-  ### biotools_content_directory: '/opt/galaxy/mutable-data/cache/biotools/content'
+  biotools_content_directory: '/opt/galaxy/mutable-data/cache/biotools/content'
 
   # Set this to true to attempt to resolve bio.tools metadata for tools
   # for tool not resovled via biotools_content_directory.


### PR DESCRIPTION
This reverts commit 5f077e0fa7798a969b3c26c2a8ca202ea747eea6.

We have merged now usegalaxy-eu/galaxy#179, so bio.tools can be re-enabled.