### PR TITLE
Move cleanup, cron tasks to the maintenance node

### DIFF
--- a/group_vars/sn06.yml
+++ b/group_vars/sn06.yml
@@ -27,43 +27,6 @@ autofs_mount_points:
 
 # fs-maintenance
 fsm_maintenance_dir: "/data/dnb01/maintenance"
-
-fsm_scripts:
-  temporary_dirs:
-    enable: true
-    src: "temporary_dirs.sh.j2"
-    dst: "{{ fsm_maintenance_dir }}/temporary_dirs.sh"
-    user: "{{ fsm_galaxy_user.username }}"
-    group: "{{ fsm_galaxy_user.groupname }}"
-    paths:
-      - /data/2/galaxy_db/tmp
-      - /data/dnb01/galaxy_db/tmp
-      - /data/dnb02/galaxy_db/tmp
-      - /data/dnb03/galaxy_db/tmp
-      - /data/jwd/tmp
-    time: "{{ fsm_intervals.long }}"
-  upload_dirs:
-    enable: true
-    src: "uploads.sh.j2"
-    dst: "{{ fsm_maintenance_dir }}/uploads.sh"
-    user: "{{ fsm_galaxy_user.username }}"
-    group: "{{ fsm_galaxy_user.groupname }}"
-    paths:
-      - "{{ galaxy_config['galaxy']['nginx_upload_store'] }}"
-      - "{{ galaxy_config['galaxy']['nginx_upload_job_files_store'] }}"
-    time: "{{ fsm_intervals.medium }}"
-  job_working_dirs:
-    enable: true
-    src: "job_working_dir.sh.j2"
-    dst: "{{ fsm_maintenance_dir }}/job_working_dir.sh"
-    user: "{{ fsm_galaxy_user.username }}"
-    group: "{{ fsm_galaxy_user.groupname }}"
-    paths:
-      - "{{ galaxy_config['galaxy']['job_working_directory'] }}"
-      - /data/dnb03/galaxy_db/job_working_directory
-      - /data/jwd/main
-    time: "{{ fsm_intervals.long }}"
-
 fsm_cron_tasks:
   docker:
     enable: true
@@ -85,8 +48,6 @@ fsm_cron_tasks:
     dow: "*"
     job: "{{ custom_telegraf_env }} /usr/bin/gxadmin galaxy cleanup 60"
     user: "{{ fsm_galaxy_user.username }}"
-
-fsm_htcondor_enable: true
 
 # TIaaS
 tiaas_virtualenv_python: "python3.8"
@@ -298,12 +259,6 @@ gie_proxy_verbose: true
 postgres_user: galaxy
 postgres_host: sn05.galaxyproject.eu
 postgres_port: 5432
-
-# Slurp script
-galaxy_slurper: galaxy
-galaxy_slurp_influx_pass: "{{ influxdb.node.password }}"
-galaxy_slurp_influx_user: "{{ influxdb.node.username }}"
-galaxy_slurp_influx_url: "{{ influxdb.url }}"
 
 # GRT
 galaxy_grt_exporter: galaxy

--- a/maintenance.yml
+++ b/maintenance.yml
@@ -83,15 +83,14 @@
     - ssh-host-sign
     - hxr.postgres-connection
     - galaxyproject.gxadmin
-    # # uncomment (commented roles) when in production
-    # - usegalaxy-eu.galaxy-slurp
-    # - usegalaxy_eu.fs_maintenance
-    # - usegalaxy-eu.htcondor_release
-    # - usegalaxy-eu.fix-unscheduled-workflows
-    # - usegalaxy-eu.fix-ancient-ftp-data
-    # - usegalaxy-eu.fix-user-quotas
+    - usegalaxy-eu.galaxy-slurp
+    - usegalaxy_eu.fs_maintenance
+    - usegalaxy-eu.htcondor_release
+    - usegalaxy-eu.fix-unscheduled-workflows
+    - usegalaxy-eu.fix-ancient-ftp-data
+    - usegalaxy-eu.fix-user-quotas
     - ssh_hardening
     - dj-wasabi.telegraf
-    # - usegalaxy-eu.fix-stop-ITs
+    - usegalaxy-eu.fix-stop-ITs
     - usegalaxy-eu.vgcn-monitoring
     - usegalaxy-eu.logrotate

--- a/sn06.yml
+++ b/sn06.yml
@@ -192,7 +192,6 @@
     - galaxyproject.tiaas2
     - usegalaxy-eu.nginx
     # TODO move under monitoring + telegraf.
-    - usegalaxy-eu.galaxy-slurp
     - usegalaxy-eu.gapars-galaxy
     # The REAL galaxy role
     - role: galaxyproject.galaxy
@@ -217,16 +216,11 @@
     - usegalaxy_eu.fs_maintenance # Filesystems maintenance
     - usegalaxy-eu.logrotate # Rotate logs
     - usegalaxy-eu.error-pages # Copy the NGINX error pages
-    - usegalaxy-eu.htcondor_release # Condor release held jobs increasing memory
     # Various ugly fixes
     - usegalaxy-eu.fix-unscheduled-jobs # Workaround for ???
-    - usegalaxy-eu.fix-unscheduled-workflows # Workaround for https://github.com/galaxyproject/galaxy/issues/8209
     - usegalaxy-eu.fix-stuck-handlers # Restart handlers to prevent several classes of issues
     - usegalaxy-eu.log-cleaner # do not retain journalctl logs, they are unnecessary/risky under GDPR
-    - usegalaxy-eu.fix-ancient-ftp-data # Remove FTP data older than 3 months, create FTP user directories
     - usegalaxy-eu.galaxy-procstat # Some custom telegraf monitoring that's templated
-    - usegalaxy-eu.fix-user-quotas # Automatically recalculate user quotas and attribute ELIXIR quota to ELIXIR AAI user on a regular basis
-    - usegalaxy-eu.fix-stop-ITs # remove IT jobs after 24h from queue
     - usegalaxy_eu.tpv_auto_lint
     # Some of our 'cleanups' also generate telegraf format so this goes at end.
     - dj-wasabi.telegraf


### PR DESCRIPTION
Through this PR all cron tasks, cleanups etc that can be moved to the maintenance node are being moved. 

**ToDo Manully on sn06:**
1. Role: usegalaxy-eu.galaxy-slurp
	1. Remove files:
		1. `/usr/bin/galaxy-slurp`
		2. `/usr/bin/galaxy-slurp-upto`
	2. Remove cron jobs from galaxy user:
		1. Slurp daily Galaxy stats into InfluxDB
		2. Slurp up-to-today galaxy stats into InfluxDB upto version		
2. Role: usegalaxy-eu.htcondor_release
	1. Remove file:
		1. `/usr/bin/htcondor-release-held-jobs`
	2. Remove cron job from galaxy user:
		1. Condor release held jobs increasing memory
3. Role: usegalaxy-eu.fix-unscheduled-workflows
	1. Remove file:
		1. `/usr/bin/galaxy-fix-unscheduled-workflows`
	2. Remove cron job (if exists):
		1. Fix unscheduled workflows `galaxyproject/galaxy#8209`
4. Role: usegalaxy-eu.fix-ancient-ftp-data
	1. Remove files:
		1. `/usr/bin/fix-ftp`
	2. Remove cron jobs from galaxy user:
		1. Remove old FTP data
		2. Fix ftp
5. Role: usegalaxy-eu.fix-user-quotas
	1. Remove files:
		1. `/usr/bin/galaxy-fix-user-quotas`
		2. `/usr/bin/galaxy-fix-elixir-user-quotas`
	2. Remove cron jobs from galaxy user:
		1. Recalculate user quotas
		2. Attribute ELIXIR quota to ELIXIR AAI users
6. Role: usegalaxy-eu.fix-stop-ITs
	1. Remove files:
		1. `/usr/bin/stop-ITs`
	2. Remove cron jobs from galaxy user:
		1. Stop ITs older than 24h
	3. Remove log rotate:
		1. `/etc/logrotate.d/stop-ITs`
7. Role: usegalaxy_eu.fs_maintenance
	1. Remove cron jobs from galaxy user:
		1. Condor maintenance tasks submitter

**Other dependencies:**
1. Merge this PR: https://github.com/usegalaxy-eu/ansible-fs-maintenance/pull/4, and build a new release
2. Add the latest version to the requirements.yml file

This PR moves 6 roles from `sn06` to the `maintenance` node and only some tasks from the `usegalaxy_eu.fs_maintenance` role (the `gxadmin` tasks in `fsm_cron_tasks` uses the galaxy's log directory `/var/log/galaxy` for cleanup, so it should stay on `sn06`). 

The above cleanup should be performed for each role on `sn06` so there will not be any redundancy.

