### PR TITLE
Update stop ITs role

### DIFF
--- a/roles/usegalaxy-eu.fix-stop-ITs/tasks/main.yml
+++ b/roles/usegalaxy-eu.fix-stop-ITs/tasks/main.yml
@@ -10,7 +10,7 @@
 - name: Create cron log directory
   file:
     state: directory
-    path: /var/log/cron
+    path: /var/log/stop-ITs-cron
     mode: 0755
     owner: root
     group: root
@@ -18,7 +18,7 @@
 - name: Create logfile
   file:
     state: touch
-    path: /var/log/cron/stop-ITs.log
+    path: /var/log/stop-ITs-cron/stop-ITs.log
     mode: 0664
     owner: "{{ galaxy_user.name }}"
     group: "{{ galaxy_group.name }}"
@@ -26,7 +26,7 @@
 - name: Setup logrotate
   copy:
     content: |
-      /var/log/cron/stop-ITs.log
+      /var/log/stop-ITs-cron/stop-ITs.log
       {
           rotate 6
           daily
@@ -48,4 +48,4 @@
     hour: "*/1"
     minute: "0"
     user: "{{ galaxy_user.name }}"
-    job: /usr/bin/stop-ITs >> /var/log/cron/stop-ITs.log 2>&1
+    job: /usr/bin/stop-ITs >> /var/log/stop-ITs-cron/stop-ITs.log 2>&1

--- a/roles/usegalaxy-eu.fix-stop-ITs/templates/stop-ITs.sh.j2
+++ b/roles/usegalaxy-eu.fix-stop-ITs/templates/stop-ITs.sh.j2
@@ -2,15 +2,15 @@
 DAY=86400
 . {{ galaxy_root }}/.bashrc
 cd ~
-for job in $(gxadmin query queue-details --all | grep running | grep interactive_tool | awk '{print $3}')
+for job in $(gxadmin query queue-detail --all | grep running | grep interactive_tool | awk '{print $3}')
 do
-    JWD=$(python /usr/local/bin/galaxy_jwd get $job)
+    JWD=$(python3 /usr/local/bin/galaxy_jwd get $job)
     pushd $JWD
     ClusterID=$( head -n 1 job_condor.log | awk '{print $2}' | awk -F. '{print $1"."$2}' | sed 's/^(//' )
-    if [ "$(condor_q $ClusterID -autoformat JobStartDate)" == "undefined" ] || [ "$(condor_q $ClusterID -autoformat JobStartDate)" == "" ]
+    if [ "$(condor_q -global $ClusterID -autoformat JobStartDate)" == "undefined" ] || [ "$(condor_q -global $ClusterID -autoformat JobStartDate)" == "" ]
     then
             condor_rm $ClusterID
-    elif [ $(($(date +"%s") - $(condor_q $ClusterID -autoformat JobStartDate))) -ge $DAY ]
+    elif [ $(($(date +"%s") - $(condor_q -global $ClusterID -autoformat JobStartDate))) -ge $DAY ]
     then
         condor_rm $ClusterID
     fi


### PR DESCRIPTION
1. Update the cron folder name. The previous name interferes with the system cron file name. So creating a dedicated folder for stop ITs cron
2. Update script
    1. fix gxadmin query
    2. add `-global` to condor_q (otherwise results will be empty)
    3. Instead of Python use Python3 on the maintenance node else script will fail.