### PR TITLE
revert migration of htcondor release role

### DIFF
--- a/maintenance.yml
+++ b/maintenance.yml
@@ -85,7 +85,7 @@
     - galaxyproject.gxadmin
     - usegalaxy-eu.galaxy-slurp
     - usegalaxy_eu.fs_maintenance
-    - usegalaxy-eu.htcondor_release
+    # - usegalaxy-eu.htcondor_release
     - usegalaxy-eu.fix-unscheduled-workflows
     - usegalaxy-eu.fix-ancient-ftp-data
     - usegalaxy-eu.fix-user-quotas

--- a/roles/usegalaxy-eu.htcondor_release/tasks/main.yml
+++ b/roles/usegalaxy-eu.htcondor_release/tasks/main.yml
@@ -13,21 +13,21 @@
         echo "Created $LOG"
         fi
 
-        for j in $(condor_q -global -hold -autoformat ClusterId HoldReasonCode| awk '(($2-34) == 0){print $1}'| paste -s -d ' ')
+        for j in $(condor_q -hold -autoformat ClusterId HoldReasonCode| awk '(($2-34) == 0){print $1}'| paste -s -d ' ')
         do
           NUMBER_OF_TIMES_SUBMITTED=$(grep -c "$j" "$LOG")
           if [ $NUMBER_OF_TIMES_SUBMITTED -gt $RESUBMIT_CAP ]; then
             condor_rm -reason "This job was resubmitted $RESUBMIT_CAP times. Most likely because of running out of memory." "$j"
             continue
           fi
-          JOB_DESCRIPTION=$(condor_q "$j" -global -autoformat JobDescription)
-          MEMORY_PROVISIONED=$(condor_q "$j" -global -autoformat MemoryProvisioned)
+          JOB_DESCRIPTION=$(condor_q "$j" -autoformat JobDescription)
+          MEMORY_PROVISIONED=$(condor_q "$j" -autoformat MemoryProvisioned)
           if [ $(($MEMORY_PROVISIONED * $MULTIPLIER)) -gt $CAP ]; then
             REQUEST_MEMORY=$CAP
           else
             REQUEST_MEMORY=$(($MEMORY_PROVISIONED * $MULTIPLIER))
           fi
-          REMOTE_HOST=$(condor_q "$j" -global -autoformat LastRemoteHost|cut -f2 -d@|cut -f1 -d.)
+          REMOTE_HOST=$(condor_q "$j" -autoformat LastRemoteHost|cut -f2 -d@|cut -f1 -d.)
 
           DATE_WITH_TIME=$(date "+%d/%m/%Y-%H:%M:%S")
           /bin/cat <<EOM >>$LOG

--- a/sn06.yml
+++ b/sn06.yml
@@ -216,6 +216,7 @@
     - usegalaxy_eu.fs_maintenance # Filesystems maintenance
     - usegalaxy-eu.logrotate # Rotate logs
     - usegalaxy-eu.error-pages # Copy the NGINX error pages
+    - usegalaxy-eu.htcondor_release
     # Various ugly fixes
     - usegalaxy-eu.fix-unscheduled-jobs # Workaround for ???
     - usegalaxy-eu.fix-stuck-handlers # Restart handlers to prevent several classes of issues


### PR DESCRIPTION
`condor_rm` on the maintenance node does not work as the jobs are submitted by a different scheduler (sn06.galaxyproject.eu). At the moment there were more than 150 jobs in the held state that were due to memory issues and were supposed to be removed. To fix this for now I have manually added the script and enabled the cronjob (galaxy user) on sn06 and disabled it on the maintenance node.

I tried:
1. added the name of the scheduler to the `condor_rm` command but encountered authentication errors and issues

```bash
galaxy@maintenance:~$ condor_rm -name sn06.galaxyproject.eu -reason "This job was resubmitted $RESUBMIT_CAP times. Most likely because of running out of memory." 45013273
AUTHENTICATE:1003:Failed to authenticate with any method
AUTHENTICATE:1004:Failed to authenticate using GSI
GSI:5003:Failed to authenticate.  Globus is reporting error (851968:50).  There is probably a problem with your credentials.  (Did you run grid-proxy-init?)
AUTHENTICATE:1004:Failed to authenticate using KERBEROS
AUTHENTICATE:1004:Failed to authenticate using FS
Couldn't find/remove all jobs in cluster 45013273
```

Added more verbosity 

```bash
root@maintenance:~$ condor_rm -debug -name sn06.galaxyproject.eu -reason "This job was resubmitted $RESUBMIT_CAP times. Most likely because of running out of memory." 45013273
07/29/23 13:32:46 AUTH_ERROR: Cannot resolve network address for KDC in requested realm
07/29/23 13:32:46 authenticate_self_gss: acquiring self credentials failed. Please check your Condor configuration file if this is a server process. Or the user environment variable if this is a user process.

GSS Major Status: General failure
GSS Minor Status Error Chain:
globus_gsi_gssapi: Error with GSI credential
globus_gsi_gssapi: Error with gss credential handle
globus_credential: Valid credentials could not be found in any of the possible locations specified by the credential search order.
Valid credentials could not be found in any of the possible locations specified by the credential search order.
Attempt 1
globus_credential: Error reading host credential
globus_sysconfig: Could not find a valid certificate file: The host cert could not be found in:
1) env. var. X509_USER_CERT
2) /etc/grid-security/hostcert.pem
3) $GLOBUS_LOCATION/etc/hostcert.pem
4) $HOME/.globus/hostcert.pem

The host key could not be found in:
1) env. var. X509_USER_KEY
2) /etc/grid-security/hostkey.pem
3) $GLOBUS_LOCATION/etc/hostkey.pem
4) $HOME/.globus/hostkey.pem


Attempt 2
globus_credential: Error reading proxy credential
globus_sysconfig: Could not find a valid proxy certificate file location
globus_sysconfig: Error with key filename
globus_sysconfig: File does not exist: /tmp/x509up_u0 is not a valid file
Attempt 3
globus_credential: Error reading user credential
globus_sysconfig: Error with certificate filename: The user cert could not be found in:
1) env. var. X509_USER_CERT
2) $HOME/.globus/usercert.pem
3) $HOME/.globus/usercred.p12

07/29/23 13:32:46 SECMAN: required authentication with <132.230.223.239:9618> failed, so aborting command ACT_ON_JOBS.
07/29/23 13:32:46 DCSchedd::actOnJobs: Failed to send command (ACT_ON_JOBS) to the schedd
AUTHENTICATE:1003:Failed to authenticate with any method
AUTHENTICATE:1004:Failed to authenticate using GSI
GSI:5003:Failed to authenticate.  Globus is reporting error (851968:50).  There is probably a problem with your credentials.  (Did you run grid-proxy-init?)
AUTHENTICATE:1004:Failed to authenticate using KERBEROS
AUTHENTICATE:1004:Failed to authenticate using FS
Couldn't find/remove all jobs in cluster 45013273
```

Will investigate this further next week and see how to achieve the expected outcome and migrate this role with proper fix.