### PR TITLE
set iteractive destinations to offline

### DIFF
--- a/files/galaxy/tpv/destinations.yml.j2
+++ b/files/galaxy/tpv/destinations.yml.j2
@@ -68,6 +68,7 @@ destinations:
         - docker
       require:
         - interactive
+        - offline
 
   interactive_pulsar_gpu:
     inherits: interactive_pulsar


### PR DESCRIPTION
This change was deployed locally due to the [ongoing investigation](https://github.com/galaxyproject/galaxy-hub/pull/2100) of suspicious activity on ITs. So this destination will be marked offline until the investigation is over.