### PR TITLE
revert migration of stop-its to maintenance node

### DIFF
--- a/maintenance.yml
+++ b/maintenance.yml
@@ -91,6 +91,6 @@
     - usegalaxy-eu.fix-user-quotas
     - ssh_hardening
     - dj-wasabi.telegraf
-    - usegalaxy-eu.fix-stop-ITs
+    # - usegalaxy-eu.fix-stop-ITs
     - usegalaxy-eu.vgcn-monitoring
     - usegalaxy-eu.logrotate

--- a/sn06.yml
+++ b/sn06.yml
@@ -226,4 +226,4 @@
     - dj-wasabi.telegraf
     # - dev-sec.os-hardening
     - dev-sec.ssh-hardening
-    # - usegalaxy-eu.vgcn-monitoring
+    - usegalaxy-eu.fix-stop-ITs


### PR DESCRIPTION
uses `condor_rm` and at the moment doesn't work via the maintenance node. Refer to this [PR](https://github.com/usegalaxy-eu/infrastructure-playbook/pull/855)