### PR TITLE
Fix the condor requirements for interactive tools

### DIFF
--- a/files/galaxy/tpv/destinations.yml.j2
+++ b/files/galaxy/tpv/destinations.yml.j2
@@ -30,7 +30,6 @@ destinations:
       submit_request_memory: "{mem}G"
       outputs_to_working_directory: false
       container_monitor_result: callback
-      submit_requirements: "GalaxyDockerHack == True"
 
   basic_singularity_destination:
     abstract: true

--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -273,6 +273,8 @@ tools:
 
 
   basic_docker_tool:
+    params:
+      submit_requirements: "GalaxyDockerHack == True"
     scheduling:
       require:
         - docker


### PR DESCRIPTION
Because of TPV's merge order the `submit_requirements` key was overwritten by the destination:
https://total-perspective-vortex.readthedocs.io/en/latest/topics/concepts.html