### PR TITLE
remove interactive tool guacamole from EU

### DIFF
--- a/templates/galaxy/config/tool_conf.xml.j2
+++ b/templates/galaxy/config/tool_conf.xml.j2
@@ -550,7 +550,6 @@
 	<tool file="interactive/interactivetool_pyiron.xml" />
 	<tool file="interactive/interactivetool_higlass.xml" /> 
 	<tool file="interactive/interactivetool_openrefine.xml" />
-	<tool file="interactive/interactivetool_guacamole_desktop.xml" />
         <tool file="interactive/interactivetool_panoply.xml" />
 	<tool file="interactive/interactivetool_askomics.xml" />
 	<tool file="interactive/interactivetool_cellxgene.xml" />


### PR DESCRIPTION
Removing it for suspicious activity-related reasons. 