### PR TITLE
Remove redundant rule requiring registration to run GPU interactive tools

### DIFF
--- a/files/galaxy/tpv/interactive_tools.yml
+++ b/files/galaxy/tpv/interactive_tools.yml
@@ -24,9 +24,6 @@ tools:
       container_monitor_result: callback
       submit_requirements: 'GalaxyDockerHack == True'
     rules:
-      - if: not user
-        fail: |
-          Interactive tools require registration. Please log-in or register on https://usegalaxy.eu/login
       - if: user and 'gpu_access_validated' in [role.name for role in user.all_roles() if not role.deleted]
         scheduling:
           require:
@@ -35,7 +32,7 @@ tools:
       - if: |
           not user or not any([ role for role in user.all_roles() if (role.name in ['gpu_access_validated'] and not role.deleted) ])
         fail: |
-          This tool has restricted access. Please request access by visiting https://usegalaxy.eu/gpu-request.
+          Interactive tools require registration. Moreover, this tool has restricted access even for registered users. Please log-in or register on https://usegalaxy.eu/login and then request access by visiting https://usegalaxy.eu/gpu-request.
 
 
   interactive_tool_divand:


### PR DESCRIPTION
A rule enforcing registrarion+explicit approval already exists for GPU interactive tools.