### PR TITLE
Mount only Docker volumes required by Pulsar for tools running in `interactive_pulsar` and `embedded_pulsar_docker` (and their children)

### DIFF
--- a/files/galaxy/tpv/destinations.yml.j2
+++ b/files/galaxy/tpv/destinations.yml.j2
@@ -63,6 +63,12 @@ destinations:
     max_accepted_mem: 128
     min_accepted_gpus: 0
     max_accepted_gpus: 0
+    params:
+      docker_volumes: "$job_directory:rw,
+        $tool_directory:ro,
+        $job_directory/outputs:rw,
+        $working_directory:rw,
+        {{ cvmfs.data.path }}:{{ cvmfs.data.docker_perm }}"
     scheduling:
       accept:
         - docker
@@ -94,6 +100,12 @@ destinations:
     max_accepted_mem: 128
     min_accepted_gpus: 0
     max_accepted_gpus: 0
+    params:
+      docker_volumes: "$job_directory:rw,
+        $tool_directory:ro,
+        $job_directory/outputs:rw,
+        $working_directory:rw,
+        {{ cvmfs.data.path }}:{{ cvmfs.data.docker_perm }}"
     scheduling:
       require:
         - docker

--- a/files/galaxy/tpv/destinations.yml.j2
+++ b/files/galaxy/tpv/destinations.yml.j2
@@ -55,8 +55,9 @@ destinations:
   # EMBEDDED PULSAR DESTINATIONS #
   ################################
 
-  interactive_pulsar:
+  embedded_pulsar_docker_abstract:
     inherits: basic_docker_destination
+    abstract: true
     runner: pulsar_embedded
     max_accepted_cores: 24
     max_accepted_mem: 128
@@ -68,6 +69,9 @@ destinations:
         $job_directory/outputs:rw,
         $working_directory:rw,
         {{ cvmfs.data.path }}:{{ cvmfs.data.docker_perm }}"
+
+  interactive_pulsar:
+    inherits: embedded_pulsar_docker_abstract
     scheduling:
       accept:
         - docker
@@ -85,25 +89,12 @@ destinations:
 
   interactive_pulsar_rstudio_poweruser:
     inherits: interactive_pulsar
-    min_accepted_gpus: 0
-    max_accepted_gpus: 0
     scheduling:
       require:
         - rstudio-poweruser
 
   embedded_pulsar_docker:
-    inherits: basic_docker_destination
-    runner: pulsar_embedded
-    max_accepted_cores: 24
-    max_accepted_mem: 128
-    min_accepted_gpus: 0
-    max_accepted_gpus: 0
-    params:
-      docker_volumes: "$job_directory:rw,
-        $tool_directory:ro,
-        $job_directory/outputs:rw,
-        $working_directory:rw,
-        {{ cvmfs.data.path }}:{{ cvmfs.data.docker_perm }}"
+    inherits: embedded_pulsar_docker_abstract
     scheduling:
       require:
         - docker


### PR DESCRIPTION
Closes usegalaxy-eu/issues#461.

@mira-miracoli Please pay special attention during the review since you know better about pulsar than me :) We will also **not** merge without your review.