### PR TITLE
the magic TPV destination gets even more magic

### DIFF
--- a/files/galaxy/tpv/destinations.yml.j2
+++ b/files/galaxy/tpv/destinations.yml.j2
@@ -326,11 +326,15 @@ destinations:
     min_accepted_gpus: 0
     max_accepted_gpus: 0
     params:
+      require_container: true
       container:
         - type: singularity
           shell: "/bin/bash"
           resolve_dependencies: true
-          identifier: "{{ dnb.0.path }}/singularity_base_images/centos:8.3.2011"
+          # Use Centos 7 as a fallback container here
+          # Most times this fallback is needed for very old tools
+          # Centos 7 has libncurses.so.5.9 and python 2.7
+          identifier: "/data/0/singularity_base_images/centos:7.9.2009"
     scheduling:
       require:
         - singularity

--- a/files/galaxy/tpv/destinations.yml.j2
+++ b/files/galaxy/tpv/destinations.yml.j2
@@ -326,7 +326,7 @@ destinations:
     min_accepted_gpus: 0
     max_accepted_gpus: 0
     params:
-      container_override:
+      container:
         - type: singularity
           shell: "/bin/bash"
           resolve_dependencies: true


### PR DESCRIPTION
@jmchilton @cat-bro This actually seems to work :tada:  . I'm just too stupid to read the documentation carefully. 

I guess it would help if we could rename `container` to `containers_fallback`. At least for people like me.

Background:

This destination can now schedule jobs in containers. At first native containers (here Singularity) are used iff available. If they are not available a default container is used `centos:8.3.2011` ... and here comes the magic ... in which conda (and toolshed-dependencies - who remembers what those are?) is used as dependency resolution. That means this fallback container is just an isolated environment. The dependency resolution still happens with conda - but inside the container.


Thanks to @cat-bro and @jmchilton for pushing me in the right direction. 