### PR TITLE
Added simple form for adding ARC compute element endpoint

### DIFF
--- a/files/galaxy/config/user_preferences_extra_conf.yml
+++ b/files/galaxy/config/user_preferences_extra_conf.yml
@@ -36,7 +36,7 @@ preferences:
     description: The URL to your ARC remote HPC compute resource.
     inputs:
       - name: remote_arc_resources
-        label: Add your remote resource url (example: https://arctestcluster-slurm-el9-arc7-ce1.cern-test.uiocloud.no)
+        label: "Add your remote resource url (example: https://arctestcluster-slurm-el9-arc7-ce1.cern-test.uiocloud.no)"
         type: text
         required: False
 	      

--- a/files/galaxy/config/user_preferences_extra_conf.yml
+++ b/files/galaxy/config/user_preferences_extra_conf.yml
@@ -39,7 +39,7 @@ preferences:
         label: "Add your remote resource url (example: https://arctestcluster-slurm-el9-arc7-ce1.cern-test.uiocloud.no)"
         type: text
         required: False
-	      
+
   distributed_compute:
     description: Use distributed compute resources
     inputs:

--- a/files/galaxy/config/user_preferences_extra_conf.yml
+++ b/files/galaxy/config/user_preferences_extra_conf.yml
@@ -32,6 +32,14 @@ preferences:
           - [Français, fr]
           - [日本語, ja]
 
+  distributed_arc_compute:
+    description: The URL to your ARC remote HPC compute resource.
+    inputs:
+      - name: remote_arc_resources
+        label: Add your remote resource url (example: https://arctestcluster-slurm-el9-arc7-ce1.cern-test.uiocloud.no)
+        type: text
+        required: False
+	      
   distributed_compute:
     description: Use distributed compute resources
     inputs:


### PR DESCRIPTION
A simple user form to add one ARC endpoint to go with the new (not yet available) ARC runner. 
The user can with this form add his own ARC endpoint and use that to submit the jobs from Galaxy. 


<img width="1110" alt="Screenshot 2023-08-30 at 11 19 23" src="https://github.com/usegalaxy-eu/infrastructure-playbook/assets/22190352/ee979d13-034f-4dc1-a9dc-dbd7297adb4b">

In the future it would be nice if the user could add more than one endpoint, see related request: https://github.com/galaxyproject/galaxy/issues/16596



## How to test the changes?
Once the ARC runner is merged, the entries in this form can actually be tested. 
A user can right away add an endpoint, but it will not be used in any jobs at the moment. 

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
