### PR TITLE
freebayes: Dynamic memory allocation

### DIFF
--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -689,6 +689,7 @@ tools:
         fail: Too much data, please check if the input is correct.
 
   toolshed.g2.bx.psu.edu/repos/devteam/freebayes/freebayes/.*:
+    # see https://github.com/usegalaxy-eu/infrastructure-playbook/pull/881 for some numbers
     cores: 10
     mem: 9 + input_size * 1
 

--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -689,6 +689,7 @@ tools:
         fail: Too much data, please check if the input is correct.
 
   toolshed.g2.bx.psu.edu/repos/devteam/freebayes/freebayes/.*:
+    cores: 10
     mem: 9 + input_size * 1
 
   toolshed.g2.bx.psu.edu/repos/iuc/shovill/shovill/.*:

--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -688,6 +688,9 @@ tools:
       - if: input_size >= 25
         fail: Too much data, please check if the input is correct.
 
+  toolshed.g2.bx.psu.edu/repos/devteam/freebayes/freebayes/.*:
+    mem: 9 + input_size * 1
+
   toolshed.g2.bx.psu.edu/repos/iuc/shovill/shovill/.*:
     inherits: toolshed.g2.bx.psu.edu/repos/nml/spades/spades/.*
 


### PR DESCRIPTION
I have noticed that we have accumulated almost 200 freebayes jobs in the Condor queue (50% to 75% of the queue). I have looked a bit into the memory requirements of this tool by taking as sample the successful job runs since mid-May.

Most jobs have inputs smaller than 10GB and use less than 15GB of memory, rather than the 90GB that are [currently being requested](https://github.com/galaxyproject/tpv-shared-database/blob/a8464ae96a13525e26318fde33908563eaebc19c/tools.yml#L412C1-L412C1).

![grafik](https://github.com/usegalaxy-eu/infrastructure-playbook/assets/43052541/5c9944eb-458d-47a7-80f9-cf96d20adc2b)

![grafik](https://github.com/usegalaxy-eu/infrastructure-playbook/assets/43052541/946e30bc-8ad3-4e5d-b0bc-198b7181a411)

I suggest thus the following simple solution: request `9 + input_size * 1` GB of memory. Since UseGalaxy.eu [resubmits jobs](https://github.com/usegalaxy-eu/infrastructure-playbook/blob/c7f4d8bffebb5cdbc94eda245a54f559ef02748a/roles/usegalaxy-eu.htcondor_release/tasks/main.yml#L7-L8) up to two times when they run out of memory, tripling the memory request each time, this should cover about 99% of jobs within two resubmissions (see the graph below).

![grafik](https://github.com/usegalaxy-eu/infrastructure-playbook/assets/43052541/fea80905-8f70-429c-bbb7-f77301dd8ea1)

Hopefully we can have the jobs queued faster with this change. I have tried to figure out why still a sizeable amount of jobs with small input sizes require huge amounts of memory, but have been unable to find a quick answer.
