### PR TITLE
diamond: Add loc file for manual database updates

### DIFF
--- a/files/galaxy/config/tool_data_table_conf.xml
+++ b/files/galaxy/config/tool_data_table_conf.xml
@@ -66,8 +66,11 @@
         <columns>value, name, path</columns>
         <file path="/opt/galaxy/tool-data/lastz_seqs.loc" />
     </table>
-
-
+    <!-- Locations of DIAMOND reference databases -->
+    <table name="diamond_database" comment_char="#" allow_duplicate_entries="False">
+        <columns>value, name, db_path</columns>
+        <file path="/opt/galaxy/tool-data/diamond_database.loc" />
+    </table>
     <!-- Locations of 2bit sequence files for use in deepTools -->
     <table name="deepTools_seqs" comment_char="#">
         <columns>value, name, path</columns>


### PR DESCRIPTION
Add diamond_database.loc to tool_data_table_conf.xml. The loc file was already on the server although empty.

This is part of the efforts to solve usegalaxy-eu/issues#463. Merging it will immediately add UniProtKB Swiss-Prot (2023-03) to DIAMOND (with taxonomic data from https://ftp.ncbi.nlm.nih.gov/pub/taxonomy/accession2taxid/prot.accession2taxid.gz).