### PR TITLE
change celery setting

### DIFF
--- a/group_vars/celerycluster.yml
+++ b/group_vars/celerycluster.yml
@@ -37,6 +37,7 @@ autofs_mount_points:
 # SystemD
 galaxy_systemd_mode: ""
 galaxy_systemd_celery: true
+galaxy_systemd_celery_internal_max_tasks: 50
 galaxy_systemd_celery_beat_schedule_path: "/opt/galaxy/celery/celery-beat-schedule"
 galaxy_systemd_watchdog: true
 


### PR DESCRIPTION
It seems this leads to a reload of the worker every 4 tasks. So increase this to 50 and see how this works.