### PR TITLE
concat: Remove revision 855580142a12 from migrated_tools_conf.xml

### DIFF
--- a/files/galaxy/config/migrated_tools_conf.xml
+++ b/files/galaxy/config/migrated_tools_conf.xml
@@ -1043,6 +1043,17 @@
     </tool>
 </section>
 
+<!--section id="operate_on_genomic_intervals" name="Operate on Genomic Intervals" version="">
+  <tool file="toolshed.g2.bx.psu.edu/repos/devteam/concat/855580142a12/concat/concat.xml" guid="toolshed.g2.bx.psu.edu/repos/devteam/concat/gops_concat_1/1.0.1">
+      <tool_shed>toolshed.g2.bx.psu.edu</tool_shed>
+        <repository_name>concat</repository_name>
+        <repository_owner>devteam</repository_owner>
+        <installed_changeset_revision>855580142a12</installed_changeset_revision>
+        <id>toolshed.g2.bx.psu.edu/repos/devteam/concat/gops_concat_1/1.0.1</id>
+        <version>1.0.1</version>
+    </tool>
+</section-->
+
 <section id="gatk" name="GATK Tools" version="">
   <tool file="toolshed.g2.bx.psu.edu/repos/devteam/count_covariates/14e304b70425/count_covariates/count_covariates.xml" guid="toolshed.g2.bx.psu.edu/repos/devteam/count_covariates/gatk_count_covariates/0.0.5">
     <tool_shed>toolshed.g2.bx.psu.edu</tool_shed>

--- a/files/galaxy/config/migrated_tools_conf.xml
+++ b/files/galaxy/config/migrated_tools_conf.xml
@@ -1043,17 +1043,6 @@
     </tool>
 </section>
 
-<section id="operate_on_genomic_intervals" name="Operate on Genomic Intervals" version="">
-  <tool file="toolshed.g2.bx.psu.edu/repos/devteam/concat/855580142a12/concat/concat.xml" guid="toolshed.g2.bx.psu.edu/repos/devteam/concat/gops_concat_1/1.0.1">
-      <tool_shed>toolshed.g2.bx.psu.edu</tool_shed>
-        <repository_name>concat</repository_name>
-        <repository_owner>devteam</repository_owner>
-        <installed_changeset_revision>855580142a12</installed_changeset_revision>
-        <id>toolshed.g2.bx.psu.edu/repos/devteam/concat/gops_concat_1/1.0.1</id>
-        <version>1.0.1</version>
-    </tool>
-</section>
-
 <section id="gatk" name="GATK Tools" version="">
   <tool file="toolshed.g2.bx.psu.edu/repos/devteam/count_covariates/14e304b70425/count_covariates/count_covariates.xml" guid="toolshed.g2.bx.psu.edu/repos/devteam/count_covariates/gatk_count_covariates/0.0.5">
     <tool_shed>toolshed.g2.bx.psu.edu</tool_shed>


### PR DESCRIPTION
Somebody disabled the tool renaming concat.xml to concat._xml. Revision 32e1c8dac438 is at the moment also installed, tagged with the same version number and working.