### PR TITLE
freebayes_wrapper: Comment revision 33a0e6aca936 from migrated_tools_conf.xml

### DIFF
--- a/files/galaxy-test/config/migrated_tools_conf.xml
+++ b/files/galaxy-test/config/migrated_tools_conf.xml
@@ -709,7 +709,7 @@
     </tool>
 </section>
 
-<section id="variant_calling" name="Variant Calling">
+<!--section id="variant_calling" name="Variant Calling">
   <tool file="toolshed.g2.bx.psu.edu/repos/devteam/freebayes_wrapper/33a0e6aca936/freebayes_wrapper/freebayes.xml" guid="toolshed.g2.bx.psu.edu/repos/devteam/freebayes_wrapper/freebayes_wrapper/0.5.0">
       <tool_shed>toolshed.g2.bx.psu.edu</tool_shed>
         <repository_name>freebayes_wrapper</repository_name>
@@ -718,7 +718,7 @@
         <id>toolshed.g2.bx.psu.edu/repos/devteam/freebayes_wrapper/freebayes_wrapper/0.5.0</id>
         <version>0.5.0</version>
     </tool>
-</section>
+</section-->
 
 <section id="metagenomic_analyses" name="Metagenomic Analysis" version="">
   <tool file="toolshed.g2.bx.psu.edu/repos/devteam/gi2taxonomy/7b1b03c4465d/gi2taxonomy/gi2taxonomy.xml" guid="toolshed.g2.bx.psu.edu/repos/devteam/gi2taxonomy/Fetch Taxonomic Ranks/1.1.0">


### PR DESCRIPTION
The folder `toolshed.g2.bx.psu.edu/repos/devteam/freebayes_wrapper/` exists but it is empty. Everything has been likely migrated to `toolshed.g2.bx.psu.edu/repos/devteam/freebayes/`.

Again this comes [from Sentry](https://sentry.galaxyproject.org/organizations/galaxy/issues/124159/events/10b6c229d6be492cab20d5414045e1c8/).