### PR TITLE
Rebalance JWDs

### DIFF
--- a/templates/galaxy/config/object_store_conf.xml.j2
+++ b/templates/galaxy/config/object_store_conf.xml.j2
@@ -170,7 +170,7 @@ The storage consists of 16 Gen6 type A200 storage nodes and 16 Gen5 type X410 no
             <!-- this is ws02 on the Netapp side and should not be used anymore, oo -->
             <extra_dir type="job_work" path="/data/jwd03f/main"/>
         </backend>
-        <backend id="files23" type="disk" weight="2" store_by="uuid">
+        <backend id="files23" type="disk" weight="7" store_by="uuid">
             <badges>
                 <more_stable />
                 <!--backed_up></backed_up-->
@@ -183,7 +183,7 @@ The storage consists of 16 Gen6 type A200 storage nodes and 16 Gen5 type X410 no
             <files_dir path="/data/dnb09/galaxy_db/files"/>
             <extra_dir type="job_work" path="/data/jwd02f/main"/>
         </backend>
-        <backend id="files24" type="disk" weight="2" store_by="uuid">
+        <backend id="files24" type="disk" weight="3" store_by="uuid">
             <badges>
                 <more_stable />
             </badges>


### PR DESCRIPTION
Have a look at the [storage stats](https://stats.galaxyproject.eu/d/IUk_uK04z/zfs?orgId=1&from=1693991266879&to=1694009113455), jwd05e is almost full while jwd02f is almost empty, despite both having the same weight (something is must be wrong with the job distribution).

I spent some time this morning familiarizing myself with the mechanism that chooses a storage backend to send new jobs to and at first glance the code looks legit, so I do not know what is causing the skew. There is a mechanism to exclude storage backends that are almost full, but the feature seems to be unfinished. I have tried it and some storage backends do not have the function that computes the free space implemented (e.g. S3).

For a few hours (since about 13:08), we have been operating like in this PR without issues: sending 70% of jobs to jwd02f and 30% to jwd05e.

The change seems to work properly.

```shell
$ journalctl -u "galaxy-handler@*" --since "2023-09-06 13:08:00" | grep "files23" | wc -l
5090
$ journalctl -u "galaxy-handler@*" --since "2023-09-06 13:08:00" | grep "files24" | wc -l
2066
```

Which arguably is weird, because if it works, the storage distribution should not have been skewed in the first place. Maybe we are storing something in jwd05e that we should not be storing?

If you want we can keep this for a day or two and then revert while we find out. Otherwise we may hit the storage limit soon. Sadly I have already cleaned up the job working directories for failed jobs :disappointed:.
