### PR TITLE
Revert "Rebalance JWDs"

### DIFF
--- a/templates/galaxy/config/object_store_conf.xml.j2
+++ b/templates/galaxy/config/object_store_conf.xml.j2
@@ -170,7 +170,7 @@ The storage consists of 16 Gen6 type A200 storage nodes and 16 Gen5 type X410 no
             <!-- this is ws02 on the Netapp side and should not be used anymore, oo -->
             <extra_dir type="job_work" path="/data/jwd03f/main"/>
         </backend>
-        <backend id="files23" type="disk" weight="7" store_by="uuid">
+        <backend id="files23" type="disk" weight="2" store_by="uuid">
             <badges>
                 <more_stable />
                 <!--backed_up></backed_up-->
@@ -183,7 +183,7 @@ The storage consists of 16 Gen6 type A200 storage nodes and 16 Gen5 type X410 no
             <files_dir path="/data/dnb09/galaxy_db/files"/>
             <extra_dir type="job_work" path="/data/jwd02f/main"/>
         </backend>
-        <backend id="files24" type="disk" weight="3" store_by="uuid">
+        <backend id="files24" type="disk" weight="2" store_by="uuid">
             <badges>
                 <more_stable />
             </badges>


### PR DESCRIPTION
Reverts usegalaxy-eu/infrastructure-playbook#891

We no longer need this. The skew was due to a single job taking all the space.