### PR TITLE
Mark gitlabfs required to False in user preferences

### DIFF
--- a/files/galaxy/config/user_preferences_extra_conf.yml
+++ b/files/galaxy/config/user_preferences_extra_conf.yml
@@ -193,4 +193,4 @@ preferences:
       - name: read_access_token
         label: API Read Access Token
         type: password
-        required: True
+        required: False


### PR DESCRIPTION
You marked the rest of the required fields `False`; you probably missed this one. 