### PR TITLE
configure the amount of celery worker that we start

### DIFF
--- a/group_vars/celerycluster.yml
+++ b/group_vars/celerycluster.yml
@@ -41,6 +41,9 @@ galaxy_systemd_celery_internal_max_tasks: 50
 galaxy_systemd_celery_beat_schedule_path: "/opt/galaxy/celery/celery-beat-schedule"
 galaxy_systemd_watchdog: true
 
+galaxy_systemd_celery_internal_workers: 10
+galaxy_systemd_celery_external_workers: 2
+
 # Flower
 flower_python_version: python38
 flower_app_dir: /opt/galaxy


### PR DESCRIPTION
xref: https://github.com/usegalaxy-eu/ansible-galaxy-systemd/blob/96800be34add8e5eadbb9266a1abdd92ae1deb69/defaults/main.yml#L70

We do not use `external` currently, so keep those worker numbers low. We could spin up a lot more internal workers if we need.