### PR TITLE
enable_tool_source_display

### DIFF
--- a/group_vars/gxconfig.yml
+++ b/group_vars/gxconfig.yml
@@ -1949,7 +1949,7 @@ base_app_main: &BASE_APP_MAIN
   # the tool wrappers installed on this Galaxy server. If you have only
   # installed tool wrappers from  public tool sheds and tools shipped
   # with Galaxy there you can enable this option.
-  #enable_tool_source_display: false
+  enable_tool_source_display: true
 
   # XML config file that contains the job metric collection
   # configuration.


### PR DESCRIPTION
turn it on. Not sure what is does. We already can see the tool source.

[EDIT] turns out only admins can see it :)