### PR TITLE
Update sanjay pulsar instance env and params

### DIFF
--- a/files/galaxy/tpv/destinations.yml.j2
+++ b/files/galaxy/tpv/destinations.yml.j2
@@ -170,6 +170,11 @@ destinations:
     max_accepted_mem: 15
     min_accepted_gpus: 0
     max_accepted_gpus: 0
+    env:
+      SINGULARITY_CACHEDIR: "/pulsar_data/container_cache"
+    params:
+      jobs_directory: "/pulsar_data/staging/ps02"
+      persistence_directory: "/pulsar_data/persisted_data/ps02"
     scheduling:
       require:
         - sanjay-pulsar


### PR DESCRIPTION
I am doing the testing for submitting jobs from multiple Galaxy instances to one host running two Pulsar instances via two systemd services. One Pulsar instance or service is communicating with the ESG test instance's MQ server and the other one is with the EU's MQ instance. 

The following change in the respective destination configures the paths that jobs submitted via EU should go to and use.