### PR TITLE
Add Singularity GPU destination, decrease requirements for helixer

### DIFF
--- a/files/galaxy/tpv/destinations.yml.j2
+++ b/files/galaxy/tpv/destinations.yml.j2
@@ -405,3 +405,19 @@ destinations:
       GPU_AVAILABLE: 1
     params:
       requirements: 'GalaxyGroup == "compute_gpu"'
+
+  condor_singularity_gpu:
+    inherits: basic_singularity_destination
+    # shorter than inheriting from condor_gpu
+    runner: condor
+    max_accepted_cores: 14
+    max_accepted_mem: 37
+    min_accepted_gpus: 1
+    max_accepted_gpus: 1
+    scheduling:
+      require:
+        - singularity
+    env:
+      GPU_AVAILABLE: 1
+    params:
+      requirements: 'GalaxyGroup == "compute_gpu"'

--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -624,8 +624,8 @@ tools:
     mem: 90
 
   toolshed.g2.bx.psu.edu/repos/genouest/helixer/helixer/.*:
-    cores: 8
-    mem: 64
+    cores: 4
+    mem: 30
     gpus: 1
     params:
       singularity_run_extra_arguments: ' --nv '


### PR DESCRIPTION
Add `condor_singularity_gpu` to run GPU jobs in Singularity.