### PR TITLE
Move rule cz-pulsar_alphafold to tools.yml

### DIFF
--- a/files/galaxy/tpv/tool_defaults.yml
+++ b/files/galaxy/tpv/tool_defaults.yml
@@ -42,14 +42,6 @@ tools:
               entity.tpv_tags = entity.tpv_tags.combine(
                   TagSetManager(tags=[pulsar_tag])
               )
-      - id: cz-pulsar_alphafold
-        if: |
-          all((
-              "cz-pulsar" in {tag.value for tag in entity.tpv_tags.tags},
-              tool.id.startswith("toolshed.g2.bx.psu.edu/repos/galaxy-australia/alphafold2/alphafold"),
-              helpers.tool_version_gte(tool, '2.3.1'),
-          ))
-        gpus: 1
 
     rank: |
       final_destinations = helpers.weighted_random_sampling(candidate_destinations)

--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -269,10 +269,7 @@ tools:
         mem: 69
       - id: cz-pulsar_alphafold
         if: |
-          (
-              "cz-pulsar" in {tag.value for tag in entity.tpv_tags.tags}
-              and helpers.tool_version_gte(tool, '2.3.1')
-          )
+          True
         gpus: 1
     scheduling:
       require:

--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -267,6 +267,13 @@ tools:
       - id: model_preset_multimer
         if: job.get_param_values(app).get("model_preset") == "multimer"
         mem: 69
+      - id: cz-pulsar_alphafold
+        if: |
+          (
+              "cz-pulsar" in {tag.value for tag in entity.tpv_tags.tags}
+              and helpers.tool_version_gte(tool, '2.3.1')
+          )
+        gpus: 1
     scheduling:
       require:
         - singularity

--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -269,7 +269,10 @@ tools:
         mem: 69
       - id: cz-pulsar_alphafold
         if: |
-          True
+          (
+              "cz-pulsar" in {tag.value for tag in entity.tpv_tags.tags}
+              and helpers.tool_version_gte(tool, '2.3.1')
+          )
         gpus: 1
     scheduling:
       require:


### PR DESCRIPTION
Put rule `cz-pulsar_alphafold` under key [`toolshed.g2.bx.psu.edu/repos/galaxy-australia/alphafold2/alphafold/.*`](https://github.com/usegalaxy-eu/infrastructure-playbook/blob/3886cd108bc58942bc3c647c19633152dc614548/files/galaxy/tpv/tools.yml#L226) in [tools.yml](https://github.com/usegalaxy-eu/infrastructure-playbook/blob/3886cd108bc58942bc3c647c19633152dc614548/files/galaxy/tpv/tools.yml).

Serves as a workaround to fix TPV dry-run.