### PR TITLE
increase handler memory limit

### DIFF
--- a/group_vars/sn06.yml
+++ b/group_vars/sn06.yml
@@ -219,7 +219,7 @@ galaxy_systemd_handler_env: "{{ galaxy_systemd_gunicorn_env }}"
 galaxy_systemd_workflow_scheduler_env: "{{ galaxy_systemd_gunicorn_env }}"
 
 galaxy_systemd_memory_limit: 120
-galaxy_systemd_memory_limit_handler: 12
+galaxy_systemd_memory_limit_handler: 22
 galaxy_systemd_memory_limit_workflow: 15
 
 # HTCondor


### PR DESCRIPTION
Currently, the handlers are restarting every hour because systemd kills them. I think this just happens since yesterday when systemd was restarted.

12 is unfortunately too low for the new Galaxy release and I think it was larger the last weeks. I might have changed that and never applied it to the playbook. Which I'm doing now.