### PR TITLE
Fix global host filters

### DIFF
--- a/group_vars/sn06.yml
+++ b/group_vars/sn06.yml
@@ -418,7 +418,7 @@ galaxy_config_templates:
   - src: "{{ galaxy_config_template_src_dir }}/config/build_sites.yml.j2"
     dest: "{{ galaxy_config['galaxy']['build_sites_config_file'] }}"
   - src: "{{ galaxy_config_template_src_dir }}/config/global_host_filters.py.j2"
-    dest: "{{ galaxy_server_dir }}/lib/galaxy/tools/toolbox/filters/global_host_filters.py"
+    dest: "{{ galaxy_server_dir }}/lib/galaxy/tool_util/toolbox/filters/global_host_filters.py"
   - src: "{{ galaxy_config_template_src_dir }}/config/job_conf.yml.j2"
     dest: "{{ galaxy_config_dir }}/job_conf.yml"
   - src: "{{ galaxy_config_template_src_dir }}/config/container_resolvers_conf.xml.j2"


### PR DESCRIPTION
The location of global_host_filters.py was changed in https://github.com/galaxyproject/galaxy/commit/fbd2fb10ff115399c31e46e59da133f7bfe9de88.