### PR TITLE
Increase Galaxy handler memory limit to 26G

### DIFF
--- a/group_vars/sn06.yml
+++ b/group_vars/sn06.yml
@@ -219,7 +219,7 @@ galaxy_systemd_handler_env: "{{ galaxy_systemd_gunicorn_env }}"
 galaxy_systemd_workflow_scheduler_env: "{{ galaxy_systemd_gunicorn_env }}"
 
 galaxy_systemd_memory_limit: 120
-galaxy_systemd_memory_limit_handler: 22
+galaxy_systemd_memory_limit_handler: 26
 galaxy_systemd_memory_limit_workflow: 15
 
 # HTCondor


### PR DESCRIPTION
I do not think this is the solution to the problem, but this should do what you want.