### PR TITLE
Fix user filters

### DIFF
--- a/group_vars/sn06.yml
+++ b/group_vars/sn06.yml
@@ -424,7 +424,7 @@ galaxy_config_templates:
   - src: "{{ galaxy_config_template_src_dir }}/config/container_resolvers_conf.xml.j2"
     dest: "{{ galaxy_config_dir }}/container_resolvers_conf.xml"
   - src: "{{ galaxy_config_template_src_dir }}/config/user_filters.py.j2"
-    dest: "{{ galaxy_server_dir }}/lib/galaxy/tools/toolbox/filters/user_filters.py"
+    dest: "{{ galaxy_server_dir }}/lib/galaxy/tool_util/toolbox/filters/user_filters.py"
   - src: "{{ galaxy_config_template_src_dir }}/config/nagios_tool_conf.xml"
     dest: "{{ galaxy_config_dir }}/nagios_tool_conf.xml"
   - src: "{{ galaxy_config_template_src_dir }}/config/oidc_backends_config.xml"


### PR DESCRIPTION
The location of user_filters.py was changed in galaxyproject/galaxy@fbd2fb1. This PR is analogous to #927.