### PR TITLE
Add new rule to TPV to workaround wrong remote resource selected or recorded in Galaxy DB

### DIFF
--- a/files/galaxy/tpv/tool_defaults.yml
+++ b/files/galaxy/tpv/tool_defaults.yml
@@ -55,8 +55,8 @@ tools:
                   pass
               remote_resource_destination = [d.dest_name for d in mapper.destinations.values() if any(d.tpv_dest_tags.filter(tag_value=remote_resource_tag))]
 
-          user is not None and not remote_resource_destination:
-              retval = True
+              if not remote_resource_destination:
+                  retval = True
           retval
         fail: |
           Invalid 'Remote resources id' selected in the config menu under 'User -> Preferences -> Manage Information'. Please reselect either 'default' or an appropriate remote resource.

--- a/files/galaxy/tpv/tool_defaults.yml
+++ b/files/galaxy/tpv/tool_defaults.yml
@@ -50,7 +50,7 @@ tools:
           if user is not None:
               try:
                   user_preferences = user.extra_preferences
-                  remote_resource_tag = user_preferences.get("distributed_compute|remote_resources", "None")
+                  remote_resource_tag = user_preferences.get("distributed_compute|remote_resources")
               except AttributeError:
                   pass
               remote_resource_destination = [d.dest_name for d in mapper.destinations.values() if any(d.tpv_dest_tags.filter(tag_value=remote_resource_tag))]

--- a/files/galaxy/tpv/tool_defaults.yml
+++ b/files/galaxy/tpv/tool_defaults.yml
@@ -56,7 +56,7 @@ tools:
               retval = True
           retval
         fail: |
-          Invalid 'Remote resources id' selected in the config menu under 'User -> Preferences -> Manage Information'. Please reselect either 'default' or appropriate remote resource
+          Invalid 'Remote resources id' selected in the config menu under 'User -> Preferences -> Manage Information'. Please reselect either 'default' or an appropriate remote resource.
 
     rank: |
       final_destinations = helpers.weighted_random_sampling(candidate_destinations)

--- a/files/galaxy/tpv/tool_defaults.yml
+++ b/files/galaxy/tpv/tool_defaults.yml
@@ -42,8 +42,9 @@ tools:
               entity.tpv_tags = entity.tpv_tags.combine(
                   TagSetManager(tags=[pulsar_tag])
               )
-      - if: |
-          # This rule will apply when users have non-exsisting remote resources selected or recorded in Galaxy DB
+      - id: removed_remote_resources
+        # This rule displays a meaningful error message when users that have selected remote resources that are no longer available (e.g. because they have been removed) attempt to send jobs to them.
+        if: |
           retval = False
           remote_resource_tag = None
           try:

--- a/files/galaxy/tpv/tool_defaults.yml
+++ b/files/galaxy/tpv/tool_defaults.yml
@@ -47,13 +47,15 @@ tools:
         if: |
           retval = False
           remote_resource_tag = None
-          try:
-              user_preferences = user.extra_preferences
-              remote_resource_tag = user_preferences.get("distributed_compute|remote_resources", "None")
-          except AttributeError:
-              pass
-          remote_resource_destination = [d.dest_name for d in mapper.destinations.values() if any(d.tpv_dest_tags.filter(tag_value=remote_resource_tag))]
-          if not remote_resource_destination:
+          if user is not None:
+              try:
+                  user_preferences = user.extra_preferences
+                  remote_resource_tag = user_preferences.get("distributed_compute|remote_resources", "None")
+              except AttributeError:
+                  pass
+              remote_resource_destination = [d.dest_name for d in mapper.destinations.values() if any(d.tpv_dest_tags.filter(tag_value=remote_resource_tag))]
+
+          user is not None and not remote_resource_destination:
               retval = True
           retval
         fail: |

--- a/files/galaxy/tpv/tool_defaults.yml
+++ b/files/galaxy/tpv/tool_defaults.yml
@@ -42,6 +42,17 @@ tools:
               entity.tpv_tags = entity.tpv_tags.combine(
                   TagSetManager(tags=[pulsar_tag])
               )
+      - if: |
+          # This rule will apply when users have non-exsisting remote resources selected or recorded in Galaxy DB
+          retval = False
+          user_preferences = user.extra_preferences
+          remote_resource_tag = user_preferences.get("distributed_compute|remote_resources", "None")
+          remote_resource_destination = [d.dest_name for d in mapper.destinations.values() if any(d.tpv_dest_tags.filter(tag_value=remote_resource_tag))]
+          if not remote_resource_destination:
+              retval = True
+          retval
+        fail: |
+          Invalid 'Remote resources id' selected in the config menu under 'User -> Preferences -> Manage Information'. Please reselect either 'default' or appropriate remote resource
 
     rank: |
       final_destinations = helpers.weighted_random_sampling(candidate_destinations)

--- a/files/galaxy/tpv/tool_defaults.yml
+++ b/files/galaxy/tpv/tool_defaults.yml
@@ -10,7 +10,7 @@ tools:
     env:
       GALAXY_MEMORY_MB: "{int(mem * 1024)}" # set 5/2023 might be moved to runner or tool wrappers, related to Galaxy issue 15952
     params:
-      metadata_strategy: 'extended'
+      metadata_strategy: "extended"
       tmp_dir: true
       request_cpus: "{cores}"
       request_memory: "{mem}G"
@@ -45,8 +45,12 @@ tools:
       - if: |
           # This rule will apply when users have non-exsisting remote resources selected or recorded in Galaxy DB
           retval = False
-          user_preferences = user.extra_preferences
-          remote_resource_tag = user_preferences.get("distributed_compute|remote_resources", "None")
+          remote_resource_tag = None
+          try:
+              user_preferences = user.extra_preferences
+              remote_resource_tag = user_preferences.get("distributed_compute|remote_resources", "None")
+          except AttributeError:
+              pass
           remote_resource_destination = [d.dest_name for d in mapper.destinations.values() if any(d.tpv_dest_tags.filter(tag_value=remote_resource_tag))]
           if not remote_resource_destination:
               retval = True


### PR DESCRIPTION
I tested it using `tpv dry-run` with scenarios `None`, the name of an existing remote resource, and the name of a non-existing remote resource. It fails and shows a message when a non-existing remote resource is used.

Example:
```
    rules:
      - if: |
          # This rule will apply when users have non-exsisting remote resources selected or recorded in Galaxy DB
          retval = False
          remote_resource_tag = 'dummy-non-existing'
          remote_resource_destination = [d.dest_name for d in mapper.destinations.values() if any(d.tpv_dest_tags.filter(tag_value=remote_resource_tag))]
          if not remote_resource_destination:
              retval = True
          retval
        fail: |
          Invalid 'Remote resources id' selected in the config menu under 'User -> Preferences -> Manage Information'.
 Please reselect either 'default' or appropriate remote resource.
```

Fail output:
```
(venv) [galaxy@galaxyesginstance ~]$ tpv -v dry-run --job-conf /opt/galaxy/config/job_conf.yml
Traceback (most recent call last):
  File "/opt/galaxy/venv/bin/tpv", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/opt/galaxy/venv/lib/python3.11/site-packages/tpv/commands/shell.py", line 140, in main
    return args.func(args)
           ^^^^^^^^^^^^^^^
  File "/opt/galaxy/venv/lib/python3.11/site-packages/tpv/commands/shell.py", line 57, in tpv_dry_run_config_files
    destination = dry_runner.run()
                  ^^^^^^^^^^^^^^^^
  File "/opt/galaxy/venv/lib/python3.11/site-packages/tpv/commands/dryrunner.py", line 20, in run
    return gateway.map_tool_to_destination(self.galaxy_app, self.job, self.tool, self.user,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/galaxy/venv/lib/python3.11/site-packages/tpv/rules/gateway.py", line 51, in map_tool_to_destination
    return ACTIVE_DESTINATION_MAPPER.map_to_destination(app, tool, user, job, job_wrapper, resource_params,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/galaxy/venv/lib/python3.11/site-packages/tpv/core/mapper.py", line 168, in map_to_destination
    evaluated_entity = self.match_combine_evaluate_entities(context, tool, user)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/galaxy/venv/lib/python3.11/site-packages/tpv/core/mapper.py", line 138, in match_combine_evaluate_entities
    evaluated_entity = combined_entity.evaluate_rules(context)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/galaxy/venv/lib/python3.11/site-packages/tpv/core/entities.py", line 489, in evaluate_rules
    rule = rule.evaluate(context)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/galaxy/venv/lib/python3.11/site-packages/tpv/core/entities.py", line 750, in evaluate
    raise JobMappingException(
galaxy.jobs.mapper.JobMappingException: Invalid 'Remote resources id' selected in the config menu under 'User -> Preferences -> Manage Information'. Please reselect either 'default' or appropriate remote resource
```

I have also tested the same by adding a `dummy` remote resource and ran 3 jobs each time updating my user preferences to `default` a test pulsar instance and `dummy`. It fails only when `dummy` is used. Feel free to test it via https://usegalaxy.esgwps.uno/ before merging (just to be sure, also for testing, you can use the fasta stats tool).