### PR TITLE
Remove non-functional default option from remote resource selection in the user preferences

### DIFF
--- a/files/galaxy/config/user_preferences_extra_conf.yml
+++ b/files/galaxy/config/user_preferences_extra_conf.yml
@@ -48,7 +48,6 @@ preferences:
         type: select
         required: False
         options:
-          - ["Select the remote resources", None]
           - ["default - Galaxy will decide where to put your job", None]
           # - ["Freiburg (Germany) - Condor cluster using Singularity with Conda", condor_singularity_with_conda]
           # - ["Joint remote GPU cluster using docker engine - Galaxy will decide where to put your job", remote_condor_cluster_gpu_docker]
@@ -119,9 +118,9 @@ preferences:
   # Require to attach pulsar endpoint to the Pulsar Network
   byoc_pulsar:
     description: >
-        Bring your own Pulsar endpoint to Galaxy. You can add here your Pulsar credentials and specifications.
-        After 24 hours Galaxy's job scheduling systems will take your Pulsar into account and schedule appropriate jobs to your compute resources.
-        This is an experimental feature. Contact us if you want to learn more about it.
+      Bring your own Pulsar endpoint to Galaxy. You can add here your Pulsar credentials and specifications.
+      After 24 hours Galaxy's job scheduling systems will take your Pulsar into account and schedule appropriate jobs to your compute resources.
+      This is an experimental feature. Contact us if you want to learn more about it.
     inputs:
       - name: username
         label: RabbitMQ custom username (e.g. mypulsarendpoint).


### PR DESCRIPTION
We have a non-functional default select option and an exclusive default option with value `None`, which leads to UI not properly displaying or selecting the actual default resource. So, by removing the non-functional default, the jobs automatically go to the default selector even when `None` is used as the value.