### PR TITLE
Skip `birna01` bind mount in secondary HTCondor playbook

### DIFF
--- a/group_vars/central-manager-secondary-host.yml
+++ b/group_vars/central-manager-secondary-host.yml
@@ -17,7 +17,7 @@ nspawn_packages:
 
 nspawn_config: |
   [Files]
-  {% for mount in jwd.values() %}
+  {% for mount in jwd.values() if mount.name != "birna01" %}
   Bind={{ mount.path }}
   {% endfor %}
 


### PR DESCRIPTION
`birna01` is not part of the AutoFS mounts.