### PR TITLE
Fix trailing space in tools.yml

### DIFF
--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -1030,7 +1030,7 @@ tools:
     mem: 4
     cores: 6
     params:
-      singularity_container_id_override: docker://quay.io/bgruening/braker3:v.1.0.4 
+      singularity_container_id_override: docker://quay.io/bgruening/braker3:v.1.0.4
     scheduling:
       require:
         - singularity


### PR DESCRIPTION
Fix trailing space introduced in 9d9350bb0fe9f0269c9c70d5ddb52473441ee49f.