### PR TITLE
Escape ampersand in earth system subdomain

### DIFF
--- a/templates/galaxy/config/tool_conf.xml.j2
+++ b/templates/galaxy/config/tool_conf.xml.j2
@@ -615,7 +615,7 @@
     <tool file="interactive/interactivetool_pangeo_notebook.xml" />
     <tool file="interactive/interactivetool_pangeo_ml_notebook.xml" />
   </section>
-  <label id="earth-system-label-dynamics" text="Earth & Environmental dynamics" />
+  <label id="earth-system-label-dynamics" text="Earth &amp; Environmental dynamics" />
   <section id="earth-system-section-watercoastal" name="Water Coastal Dynamics">
     <tool file="interactive/interactivetool_divand.xml" />
     <tool file="interactive/interactivetool_source.xml" />


### PR DESCRIPTION
The ampersand needs to be escaped to prevent XML parsing errors.

Follow-up of #958.