### PR TITLE
Replace ampersand with "and" in earth system subdomain

### DIFF
--- a/templates/galaxy/config/tool_conf.xml.j2
+++ b/templates/galaxy/config/tool_conf.xml.j2
@@ -615,7 +615,7 @@
     <tool file="interactive/interactivetool_pangeo_notebook.xml" />
     <tool file="interactive/interactivetool_pangeo_ml_notebook.xml" />
   </section>
-  <label id="earth-system-label-dynamics" text="Earth &amp; Environmental dynamics" />
+  <label id="earth-system-label-dynamics" text="Earth and Environmental dynamics" />
   <section id="earth-system-section-watercoastal" name="Water Coastal Dynamics">
     <tool file="interactive/interactivetool_divand.xml" />
     <tool file="interactive/interactivetool_source.xml" />


### PR DESCRIPTION
Even if the ampersand is escaped to prevent XML parsing errors, it is later propagated (unescaped) to integrated_tool_panel.xml (generated by Galaxy).

Follow-up of #963.