### PR TITLE
Jenkins projects break due to some ansible dependency resolution issue

### DIFF
--- a/requirements.yaml
+++ b/requirements.yaml
@@ -106,6 +106,8 @@ roles:
     version: 1.1.1
   - name: usegalaxy_eu.flower
     version: 0.3.1-alpha
+  - name: geerlingguy.pip
+    version: 2.2.0
   - name: paprikant.beacon
     src: https://github.com/Paprikant/ansible-role-beacon
   - name: paprikant.beacon-importer

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -106,6 +106,11 @@ roles:
     version: 1.1.1
   - name: usegalaxy_eu.flower
     version: 0.3.1-alpha
+  # `geerlingguy.pip` is here only because it is a dependency of
+  # `paprikant.beacon` and because no version has been pinned when declaring
+  # the dependency, the role is affected by this bug:
+  # https://forum.ansible.com/t/role-import-from-github-results-in-master-release-not-the-tag-release-breaking-installs/1856
+  # Remove `geerlingguy.pip` from this list when the bug above has been fixed.
   - name: geerlingguy.pip
     version: 2.2.0
   - name: paprikant.beacon


### PR DESCRIPTION
Issue: https://forum.ansible.com/t/role-import-from-github-results-in-master-release-not-the-tag-release-breaking-installs/1856

Error: `[WARNING]: - geerlingguy.pip was NOT installed successfully: Unable to compare role versions (1.0.0, 1.1.0, 1.2.0, 1.2.1, 1.2.2, 1.3.0, 2.0.0, 2.1.0, 2.2.0, master) to determine the most recent version due to
incompatible version formats. Please contact the role author to resolve versioning conflicts, or specify an explicit role version to install.
ERROR! - you can use --ignore-errors to skip failed roles and finish processing the list.`

`paprikant.beacon` role (https://github.com/Paprikant/ansible-role-beacon) requires `geerlingguy.pip` and I am not sure whether we have access to that and whether someone is maintaining that role. So to fix it I am adding this dependency to our requirements file at least until the above-mentioned issue is resolved by Ansible.

Latest version is 3.0.0 and its getting resolved as master instead of the tag. So using the available "latest" version `2.2.0`.