### PR TITLE
Workaround error installing Ansible role `geerlingguy.pip` (a dependency of `paprikant.beacon`)

### DIFF
--- a/requirements.yaml
+++ b/requirements.yaml
@@ -108,6 +108,13 @@ roles:
     version: 0.3.1-alpha
   - name: paprikant.beacon
     src: https://github.com/Paprikant/ansible-role-beacon
+  - name: geerlingguy.pip
+    version: 2.2.0
+  # `geerlingguy.pip` is here only because it is a dependency of
+  # `paprikant.beacon` and because no version has been pinned when declaring
+  # the dependency, the role is affected by this bug:
+  # https://forum.ansible.com/t/role-import-from-github-results-in-master-release-not-the-tag-release-breaking-installs/1856
+  # Remove `geerlingguy.pip` from this list when the bug above has been fixed.
   - name: paprikant.beacon-importer
     src: https://github.com/Paprikant/ansible-role-beacon_importer
   - name: galaxyproject.miniconda


### PR DESCRIPTION
`paprikant.beacon` has `geerlingguy.pip` as a dependency, but no version has been pinned when declaring the dependency, thus it is affected by this bug https://forum.ansible.com/t/role-import-from-github-results-in-master-release-not-the-tag-release-breaking-installs/1856

Therefore, the following messages are displayed on Jenkins.

```text
20:19:58 [WARNING]: - geerlingguy.pip was NOT installed successfully: Unable to compare
20:19:58 role versions (1.0.0, 1.1.0, 1.2.0, 1.2.1, 1.2.2, 1.3.0, 2.0.0, 2.1.0, 2.2.0,
20:19:58 master) to determine the most recent version due to incompatible version
20:19:58 formats. Please contact the role author to resolve versioning conflicts, or
20:19:58 specify an explicit role version to install.
20:19:58 ERROR! - you can use --ignore-errors to skip failed roles and finish processing the list.
```

If you visit the forum thread, it seems like they are fixing it already, so this workaround will not be needed for long.