### PR TITLE
Workaround Ansible vault password not being available to GitHub.

### DIFF
--- a/.github/workflows/tpv.py
+++ b/.github/workflows/tpv.py
@@ -132,7 +132,9 @@ def make_playbook(
         dummy_vars = {}
         # - determinate what is already defined in group variables
         group_vars = set()
-        for file_path in glob.glob(str(directory / "group_vars" / "*")):
+        for file_path in glob.glob(
+            str(directory / "group_vars" / "**" / "*.y*ml"), recursive=True
+        ):
             contents = yaml.safe_load(open(file_path))
             group_vars |= set(contents)
         # - for vars files

--- a/.github/workflows/tpv.yml
+++ b/.github/workflows/tpv.yml
@@ -22,6 +22,12 @@ jobs:
         with:
           path: 'infrastructure-playbook'
 
+      - name: Workaround Ansible vault password not being available to GitHub.
+        working-directory: 'infrastructure-playbook'
+        run: |
+          rm -f group_vars/htcondor/vault.yml
+          rm -f group_vars/htcondor-secondary/vault.yml
+
       - name: Update git submodules.
         working-directory: 'infrastructure-playbook'
         run: |
@@ -180,6 +186,12 @@ jobs:
         with:
           fetch-depth: ${{ github.event_name == 'pull_request' && 2 || 0 }}
           path: 'infrastructure-playbook'
+
+      - name: Workaround Ansible vault password not being available to GitHub.
+        working-directory: 'infrastructure-playbook'
+        run: |
+          rm -f group_vars/htcondor/vault.yml
+          rm -f group_vars/htcondor-secondary/vault.yml
 
       - name: Update git submodules.
         working-directory: 'infrastructure-playbook'


### PR DESCRIPTION
Works around Ansible being unable to decrypt vault files for the HTCondor cluster.

It is a bullshit workaround, but I guess we gotta keep the show running and other things are on the table.

@bgruening Should make TPV linter and dry-run work in #976.