### PR TITLE
Remove deprecated `-XX:MaxPermSize=2G` command line option to fix trimmomatic

### DIFF
--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -977,7 +977,7 @@ tools:
 
   toolshed.g2.bx.psu.edu/repos/pjbriggs/trimmomatic/trimmomatic/.*:
     env:
-      _JAVA_OPTIONS: -XX:MaxPermSize=2G -Xmx6G -Xms1G -Djava.io.tmpdir=/data/2/galaxy_db/tmp -Duser.home=/data/2/galaxy_db/tmp
+      _JAVA_OPTIONS: -Xmx6G -Xms1G -Djava.io.tmpdir=/data/2/galaxy_db/tmp -Duser.home=/data/2/galaxy_db/tmp
 
   toolshed.g2.bx.psu.edu/repos/iuc/unicycler/unicycler/.*:
     cores: 16


### PR DESCRIPTION
Remove deprecated `-XX:MaxPermSize=2G` command line option to fix the following error.

```
Picked up _JAVA_OPTIONS: -XX:MaxPermSize=2G -Xmx6G -Xms1G -Djava.io.tmpdir=/data/2/galaxy_db/tmp -Duser.home=/data/2/galaxy_db/tmp
Unrecognized VM option 'MaxPermSize=2G'
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.
```

I think we have already encountered this, but anyway [here](https://stackoverflow.com/a/12114284) is a reminder of why this is not needed anymore.