### PR TITLE
Add a new temp Nginx location directive for restricted access demo for BY-COVID federated analysis demo

### DIFF
--- a/templates/nginx/galaxy-main.j2
+++ b/templates/nginx/galaxy-main.j2
@@ -304,6 +304,13 @@ server {
 	add_header X-Robots-Tag none;
 
 	client_max_body_size 1G; # aka max upload size, defaults to 1M
+
+	# BY-COVID federated analysis demonstration data (restricted access demo)
+	location /federated_analysis_data {
+		alias /data/dnb01/federated_analysis_demo_data/;
+		allow 10.5.68.0/24;
+		deny all;
+	}
 }
 
 server {


### PR DESCRIPTION
**Note:** The `alias` directory is yet to be created.

I have tested a similar config in this PR via ESG instance, and everything works. 

I also wrote a gist about it in the past, and it can be found [here ](https://gist.github.com/sanjaysrikakulam/68a7de938b26460ef9371272ca5e2d72) for reference.