### PR TITLE
Add usrlocal mount to Celery node

### DIFF
--- a/group_vars/celerycluster.yml
+++ b/group_vars/celerycluster.yml
@@ -32,6 +32,7 @@ autofs_mount_points:
   - gxtest
   - gxkey
   - jwd
+  - usrlocal
   - usrlocal_celerycluster
 
 # SystemD


### PR DESCRIPTION
Without this mount point, Python in the galaxy's venv cannot be used on celery node to start celery services and will raise the following error

```bash
Could not find platform independent libraries <prefix>
Could not find platform dependent libraries <exec_prefix>
Python path configuration:
  PYTHONHOME = (not set)
  PYTHONPATH = 'server/lib'
  program name = '/opt/galaxy/venv/bin/python'
  isolated = 0
  environment = 1
  user site = 1
  safe_path = 0
  import site = 1
  is in build tree = 0
  stdlib dir = '/usr/local/tools/_conda/envs/__python@3.11.5/lib/python3.11'
  sys._base_executable = '/usr/local/tools/_conda/envs/__python@3.11.5/bin/python'
  sys.base_prefix = '/usr/local/tools/_conda/envs/__python@3.11.5'
  sys.base_exec_prefix = '/usr/local/tools/_conda/envs/__python@3.11.5'
  sys.platlibdir = 'lib'
  sys.executable = '/opt/galaxy/venv/bin/python'
  sys.prefix = '/usr/local/tools/_conda/envs/__python@3.11.5'
  sys.exec_prefix = '/usr/local/tools/_conda/envs/__python@3.11.5'
  sys.path = [
    '/opt/galaxy/server/lib',
    '/usr/local/tools/_conda/envs/__python@3.11.5/lib/python311.zip',
    '/usr/local/tools/_conda/envs/__python@3.11.5/lib/python3.11',
    '/usr/local/tools/_conda/envs/__python@3.11.5/lib/python3.11/lib-dynload',
  ]
Fatal Python error: init_fs_encoding: failed to get the Python codec of the filesystem encoding
Python runtime state: core initialized
ModuleNotFoundError: No module named 'encodings'
Current thread 0x00007f485ba3e740 (most recent call first):
  <no Python frame>
```

@bgruening manually mounted this in the past during the migration to Python 3.11 and Galaxy 23.1.