### PR TITLE
Allow additional IPs to access the restricted data of BY-COVID federated analysis demo data

### DIFF
--- a/templates/nginx/galaxy-main.j2
+++ b/templates/nginx/galaxy-main.j2
@@ -309,6 +309,8 @@ server {
 	location /federated_analysis_data {
 		alias /data/dnb01/federated_analysis_demo_data/;
 		allow 10.5.68.0/24;
+		allow 193.190.80.5;
+		allow 193.190.80.4;
 		deny all;
 	}
 }


### PR DESCRIPTION
This PR allows a couple of BE instances IPs (as requested by BE Galaxy admin).