### PR TITLE
Replace BE allowed IPs in nginx conf for bycovid demo

### DIFF
--- a/templates/nginx/galaxy-main.j2
+++ b/templates/nginx/galaxy-main.j2
@@ -309,8 +309,9 @@ server {
 	location /federated_analysis_data {
 		alias /data/dnb01/federated_analysis_demo_data/;
 		allow 10.5.68.0/24;
-		allow 193.190.80.5;
-		allow 193.190.80.4;
+		# BE instance IPs
+		allow 10.113.3.8;
+		allow 10.113.3.13;
 		deny all;
 	}
 }


### PR DESCRIPTION
BE admin shared new IPs to replace the ones from yesterday.