### PR TITLE
Configure "galaxy" user and group in the HTCondor cluster

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -1,4 +1,15 @@
 ---
+# Galaxy user and group
+galaxy_user:
+  name: galaxy
+  create_home: true
+  home: /opt/galaxy
+  uid: 999
+  shell: /bin/bash
+galaxy_group:
+  name: galaxy
+  gid: 999
+
 # Certbot defaults
 certbot_auto_renew_hour: "{{ 23 |random(seed=inventory_hostname)  }}"
 certbot_auto_renew_minute: "{{ 59 |random(seed=inventory_hostname)  }}"
@@ -62,11 +73,6 @@ telegraf_plugins_default:
   - plugin: net
   - plugin: netstat
   - plugin: chrony
-
-
-# ???
-galaxy_uid: 999
-galaxy_gid: 999
 
 # Automated yum updates
 yum_cron:

--- a/group_vars/htcondor/vars.yml
+++ b/group_vars/htcondor/vars.yml
@@ -51,3 +51,18 @@ condor_extra: |
   JOB_START_DELAY = {{ htcondor_job_start_delay }}
   CLAIM_WORKLIFE = {{ htcondor_claim_worklife }}
   NEGOTIATOR_POST_JOB_RANK = {{ htcondor_negotiator_post_job_rank }}
+
+# Configuration of `usegalaxy_eu.handy.os_setup`.
+enable_create_user: true
+enable_remap_user: true
+handy_users:
+  - user_name: "{{ galaxy_user.name }}"
+    user_uid: "{{ galaxy_user.uid }}"
+    user_group: "{{ galaxy_group.name }}"
+    user_comment: "Galaxy useraccount"
+    user_create_home: "{{ galaxy_user.create_home }}"
+    user_home: "{{ galaxy_user.home }}"
+    user_shell: "{{ galaxy_user.shell }}"
+handy_groups:
+  - group_name: "{{ galaxy_group.name }}"
+    group_gid: "{{ galaxy_group.gid }}"

--- a/htcondor.yml
+++ b/htcondor.yml
@@ -1,5 +1,5 @@
 ---
-- name: Systemd-nspawn container aimed at running a second HTCondor installation.
+- name: Create a systemd-nspawn container aimed at running a second HTCondor installation.
   hosts: htcondor-secondary-submit-host
   handlers:
     - name: Reload sshd  # (in the container)
@@ -203,6 +203,12 @@
         name: condor
         state: reloaded
   pre_tasks:
+    - name: Ensure findutils is installed.
+      become: true
+      ansible.builtin.package:
+        name: findutils
+        state: installed
+
     - name: Ensure the HTCondor configuration directory exists.
       become: true
       ansible.builtin.file:
@@ -226,4 +232,5 @@
       ansible.builtin.service_facts:
       register: service_facts
   roles:
+    - usegalaxy_eu.handy.os_setup
     - grycap.htcondor

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -21,7 +21,7 @@ collections:
     source: https://galaxy.ansible.com
     type: galaxy
   - name: usegalaxy_eu.handy
-    version: 3.0.0
+    version: 3.0.2
     source: https://galaxy.ansible.com
   - name: ansible.windows
     version: 1.14.0


### PR DESCRIPTION
Please remember that at the moment, this commit only affects the secondary HTCondor cluster, because the htcondor.yml playbook excludes `sn06.galaxyproject.eu` (which plays the central manager and submit roles in the primary cluster), and the worker nodes are not managed via this repository.

Run `usegalaxy_eu.handy.os_setup` on all members of the HTCondor cluster. Configure the group variables so that the role frees up uid 999 and gid 999 and creates a "galaxy" user with those identifiers.

Additionally, `galaxy_user` and `galaxy_group` are now defined globally (for all hosts).

Requires usegalaxy-eu/ansible-collection-handy#16 and publishing a new release of `usegalaxy_eu.handy.os_setup` (v3.0.2).