### PR TITLE
add new image tool

### DIFF
--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -284,6 +284,8 @@ tools:
 
   toolshed.g2.bx.psu.edu/repos/bgruening/biomodels_biomd0000001066/biomodels_biomd0000001066/.*:
     inherits: basic_docker_tool
+  toolshed.g2.bx.psu.edu/repos/imgteam/rfove/rfove/.*:
+    inherits: basic_docker_tool
   toolshed.g2.bx.psu.edu/repos/iuc/homer_findmotifs/homer_findMotifs/.*:
     inherits: basic_docker_tool
   toolshed.g2.bx.psu.edu/repos/gga/repeatexplorer_clustering/repeatexplorer_clustering/.*:


### PR DESCRIPTION
Why is our configuration or TPV not smart enough to detect that there is no conda for that tool and directly used Docker.

This is needed for the img community.