### PR TITLE
Open HTCondor shared port in the HTCondor clusters playbook

### DIFF
--- a/htcondor.yml
+++ b/htcondor.yml
@@ -228,6 +228,14 @@
         mode: "0644"
       notify: Reload HTCondor
 
+    - name: Open HTCondor shared port in the firewall.
+      ansible.posix.firewalld:
+        port: "{{ htcondor_port }}/tcp"
+        state: enabled
+        permanent: true
+        immediate: true
+      when: inventory_hostname != "nspawn-htcondor.sn06.galaxyproject.eu"
+
     - name: Check if HTCondor is running.
       ansible.builtin.service_facts:
       register: service_facts


### PR DESCRIPTION
Open the HTCondor shared port in the firewall. Do not open it for the systemd-nspawn container (the firewall is managed by the host).