### PR TITLE
Enable overriding HTCondor cli commands for the Pulsar Condor manager via a patched version of Pulsar (HTCondor migration)

### DIFF
--- a/sn06.yml
+++ b/sn06.yml
@@ -87,6 +87,44 @@
     - name: Disable SELinux
       selinux:
         state: disabled
+    - name: Inject custom Pulsar build in the Galaxy requirements file (HTCondor migration).
+      # This Pulsar build makes the `condor_rm` and `condor_submit` commands configurable.
+      # See https://github.com/kysrpex/pulsar/commits/condor_manager_prefix_option for more details.
+      block:
+        - name: Allocate a temporary directory.
+          ansible.builtin.tempfile:
+            prefix: ansible.galaxyproject.galaxy_requirements_file
+            state: directory
+          changed_when: false
+          register: galaxy_requirements_file_directory
+        - name: Clone Galaxy.
+          git:
+            dest: "{{ galaxy_requirements_file_directory.path }}/galaxy"
+            depth: 1
+            repo: "{{ galaxy_repo }}"
+            version: "{{ galaxy_commit_id }}"
+            executable: "{{ git_executable | default(omit) }}"
+          changed_when: false
+        - name: Retrieve the requirements file.
+          ansible.builtin.copy:
+            remote_src: true
+            src: "{{ galaxy_requirements_file_directory.path }}/galaxy/lib/galaxy/dependencies/pinned-requirements.txt"
+            dest: "{{ galaxy_requirements_file_directory.path }}/requirements.txt"
+          changed_when: false
+        - name: Replace `pulsar-galaxy-lib` with a patched version in the requirements file.
+          ansible.builtin.lineinfile:
+            path: "{{ galaxy_requirements_file_directory.path }}/requirements.txt"
+            regexp: 'pulsar-galaxy-lib'
+            line: 'git+https://github.com/kysrpex/pulsar.git@condor_manager_prefix_option#egg=pulsar-galaxy-lib ; python_version >= "3.7" and python_version < "3.12"'
+        - name: Configure the Galaxy role to use the modified version of the requirements file.
+          ansible.builtin.set_fact:
+            galaxy_requirements_file: "{{ galaxy_requirements_file_directory.path }}/requirements.txt"
+      always:
+        - name: Remove the Galaxy clone.
+          changed_when: false
+          ansible.builtin.file:
+            path: "{{ galaxy_requirements_file_directory.path }}/galaxy"
+            state: absent
   post_tasks:
     - name: Append some users to the systemd-journal group
       user:


### PR DESCRIPTION
Install a patched Pulsar version on the headnode that allows overriding the commands that Pulsar Condor manager calls to interact with HTCondor. The overrides can be configured using the parameters `prefix`, `condor_rm_cmd` and `condor_submit_cmd`.

This can be used to make interactive tools work on the secondary cluster, using exactly the same approach as in https://github.com/usegalaxy-eu/infrastructure-playbook/pull/981 (second Embedded Pulsar runner).