### PR TITLE
Enable embedded Pulsar on the secondary HTCondor cluster

### DIFF
--- a/files/galaxy/tpv/destinations.yml.j2
+++ b/files/galaxy/tpv/destinations.yml.j2
@@ -71,6 +71,8 @@ destinations:
         $working_directory:rw,
         {{ cvmfs.data.path }}:{{ cvmfs.data.docker_perm }}"
 
+{# Save embedded Pulsar destinations to replicate them in the secondary cluster. #}
+{% set embedded_pulsar %}
   interactive_pulsar:
     inherits: embedded_pulsar_docker_abstract
     scheduling:
@@ -109,6 +111,18 @@ destinations:
       GPU_AVAILABLE: "1"
     params:
       requirements: 'GalaxyGroup == "compute_gpu"'
+{%- endset %}{{ embedded_pulsar }}
+
+{# Generate secondary cluster destinations. #}
+{% for name, destination in (embedded_pulsar | from_yaml).items() %}
+  secondary_{{ name }}:
+    inherits: {{ name }}
+    runner: pulsar_embedded_secondary
+    scheduling:
+      require:
+        - condor-secondary
+
+{% endfor %}
 
   #######################
   # PULSAR DESTINATIONS #

--- a/group_vars/sn06.yml
+++ b/group_vars/sn06.yml
@@ -408,6 +408,8 @@ galaxy_config_templates:
     dest: "{{ galaxy_config_dir }}/grt.yml"
   - src: "{{ galaxy_config_template_src_dir }}/config/pulsar_app.yml"
     dest: "{{ galaxy_config_dir }}/pulsar_app.yml"
+  - src: "{{ galaxy_config_template_src_dir }}/config/pulsar_app_secondary.yml"
+    dest: "{{ galaxy_config_dir }}/pulsar_app_secondary.yml"
   - src: "{{ galaxy_config_template_src_dir }}/config/tool_conf.xml.j2"
     dest: "{{ galaxy_config_dir }}/tool_conf.xml"
   - src: "{{ galaxy_config_template_src_dir }}/config/galaxy_workflow_scheduler.j2"

--- a/templates/galaxy/config/job_conf.yml
+++ b/templates/galaxy/config/job_conf.yml
@@ -26,6 +26,9 @@ galaxy_jobconf:
     - id: pulsar_embedded
       load: galaxy.jobs.runners.pulsar:PulsarEmbeddedJobRunner
       pulsar_config: "{{ galaxy_config_dir }}/pulsar_app.yml"
+    - id: pulsar_embedded_secondary
+      load: galaxy.jobs.runners.pulsar:PulsarEmbeddedJobRunner
+      pulsar_config: "{{ galaxy_config_dir }}/pulsar_app_secondary.yml"
 
     - id: pulsar_eu_it01
       load: galaxy.jobs.runners.pulsar:PulsarMQJobRunner

--- a/templates/galaxy/config/pulsar_app_secondary.yml
+++ b/templates/galaxy/config/pulsar_app_secondary.yml
@@ -1,0 +1,9 @@
+private_token: {{ pulsar_private_token }}
+staging_directory: /data/jwd01/pulsar_staging/
+tool_dependency_dir: /data/dnb01/galaxy_db/pulsar_dependencies/
+
+managers:
+  _default_:
+    type: queued_condor
+    condor_rm_cmd: "sudo {{ nspawn_condor_rm_command }}"
+    condor_submit_cmd: "sudo {{ nspawn_condor_submit_command }}"


### PR DESCRIPTION
Add a second embedded Pulsar job runner that sends jobs to the secondary HTCondor cluster using `systemd-run`. Add the corresponding TPV destinations.

This should fix interactive tools on the secondary cluster.

Requires #1003.