### PR TITLE
Let the secondary HTCondor users use Pulsar

### DIFF
--- a/files/galaxy/tpv/destinations.yml.j2
+++ b/files/galaxy/tpv/destinations.yml.j2
@@ -165,6 +165,7 @@ destinations:
         - singularity
         - docker
         - condor-tpv
+        - condor-secondary
 
   pulsar_mira_tpv:
     inherits: pulsar_default


### PR DESCRIPTION
Let the abstract Pulsar destination accept jobs tagged with the `condor-secondary` scheduling tag, so that users of the secondary HTCondor cluster (`scheduling: require: ["condor-secondary"]`) do not get their jobs rejected.