### PR TITLE
Hide option to enable job cache

### DIFF
--- a/files/galaxy/config/user_preferences_extra_conf.yml
+++ b/files/galaxy/config/user_preferences_extra_conf.yml
@@ -7,15 +7,17 @@ preferences:
         type: text
         required: False
 
-  use_cached_job:
-    description: Do you want to be able to re-use previously run jobs ?
-    inputs:
-      - name: use_cached_job_checkbox
-        label: Do you want to be able to re-use  equivalent jobs ?
-        type: boolean
-        checked: false
-        value: false
-        help: If you select yes, you will be able to select for each tool and workflow run if you would like to use this feature.
+  # Crashes Galaxy job handlers, see
+  # https://github.com/galaxyproject/galaxy/issues/17079
+  #use_cached_job:
+  #  description: Do you want to be able to re-use previously run jobs ?
+  #  inputs:
+  #    - name: use_cached_job_checkbox
+  #      label: Do you want to be able to re-use  equivalent jobs ?
+  #      type: boolean
+  #      checked: false
+  #      value: false
+  #      help: If you select yes, you will be able to select for each tool and workflow run if you would like to use this feature.
 
   localization:
     description: Localization


### PR DESCRIPTION
Using the job cache can cause job handlers to crash during startup, see https://github.com/galaxyproject/galaxy/issues/17079.