### PR TITLE
Patch galaxy_jwd.py to return the correct JWD for embedded Pulsar jobs running on the secondary cluster

### DIFF
--- a/roles/usegalaxy-eu.bashrc/files/galaxy_jwd.py
+++ b/roles/usegalaxy-eu.bashrc/files/galaxy_jwd.py
@@ -363,8 +363,8 @@ def decode_path(
 
     # Pulsar embedded jobs uses the staging directory and this has a different
     # path structure
-    if job_runner_name == "pulsar_embedded":
-        jwd_path = f"{backends_dict[job_runner_name]}/{job_id}"
+    if job_runner_name.startswith("pulsar_embedded"):
+        jwd_path = f"{backends_dict['pulsar_embedded']}/{job_id}"
     else:
         jwd_path = (
             f"{backends_dict[metadata[0]]}/"


### PR DESCRIPTION
The embedded Pulsar job runner for the secondary cluster is called `pulsar_embedded_secondary`. Since galaxy_jwd.py uses different logic for getting the JWD of embedded pulsar jobs but only applies it when `job_runner_name == "pulsar_embedded"`, it yields the wrong job working directories for jobs whose runner is `pulsar_embedded_secondary`.

This patch works around the issue so that the stop-ITs script works on the secondary cluster. It does NOT fix it properly, because if all embedded pulsar runners do not use the same staging dir then it breaks.

I hope that's ok for the HTCondor migration.