### PR TITLE
Revert "Backofen members to the new cluster"

### DIFF
--- a/files/galaxy/tpv/roles.yml
+++ b/files/galaxy/tpv/roles.yml
@@ -6,10 +6,7 @@ roles:
   storage-test*:
     params:
       object_store_id: "s3_netapp01"
-  Backofen:
-    scheduling:
-      require:
-        - condor-secondary
+
   rstudio-poweruser*:
     rules:
       - id: rstudio_poweruser

--- a/files/galaxy/tpv/users.yml
+++ b/files/galaxy/tpv/users.yml
@@ -5,4 +5,7 @@ users:
       require:
         - condor-secondary
   bjoern.gruening@gmail.com:
+    scheduling:
+      require:
+        - condor-secondary
   kuntzm@informatik.uni-freiburg.de:


### PR DESCRIPTION
Reverts usegalaxy-eu/infrastructure-playbook#1004

@bgruening At the moment, a fraction of jobs (see #1010) is going to the secondary cluster for everyone, so this is just creating an imbalance (more jobs than that fraction go to the secondary cluster). I think we no longer need this.