### PR TITLE
Replicate concurrency limit for interactive pulsar on the secondary HTCondor cluster

### DIFF
--- a/templates/galaxy/config/job_conf.yml.j2
+++ b/templates/galaxy/config/job_conf.yml.j2
@@ -139,7 +139,7 @@ limits:
 {# Replicate destination limits for the secondary HTCondor cluster #}
 {% for limit in galaxy_jobconf['limits'] | sort(attribute='type') %}
 {% if limit['type'].startswith('destination_') and 'id' in limit
-and limit['id'].startswith('condor_') %}
+and (limit['id'].startswith('condor_') or limit['id'].startswith('interactive_pulsar')) %}
   - type: {{ limit['type'] }}
     value: {{ limit['value'] }}
     id: secondary_{{ limit['id'] }}


### PR DESCRIPTION
Should prevent an excess number of ITs from being queued.