### PR TITLE
Revert "Hide option to enable job cache"

### DIFF
--- a/files/galaxy/config/user_preferences_extra_conf.yml
+++ b/files/galaxy/config/user_preferences_extra_conf.yml
@@ -7,17 +7,15 @@ preferences:
         type: text
         required: False
 
-  # Crashes Galaxy job handlers, see
-  # https://github.com/galaxyproject/galaxy/issues/17079
-  #use_cached_job:
-  #  description: Do you want to be able to re-use previously run jobs ?
-  #  inputs:
-  #    - name: use_cached_job_checkbox
-  #      label: Do you want to be able to re-use  equivalent jobs ?
-  #      type: boolean
-  #      checked: false
-  #      value: false
-  #      help: If you select yes, you will be able to select for each tool and workflow run if you would like to use this feature.
+  use_cached_job:
+    description: Do you want to be able to re-use previously run jobs ?
+    inputs:
+      - name: use_cached_job_checkbox
+        label: Do you want to be able to re-use  equivalent jobs ?
+        type: boolean
+        checked: false
+        value: false
+        help: If you select yes, you will be able to select for each tool and workflow run if you would like to use this feature.
 
   localization:
     description: Localization


### PR DESCRIPTION
Reverts usegalaxy-eu/infrastructure-playbook#1014

It is no longer a problem that people use the job cache, the fix for https://github.com/galaxyproject/galaxy/issues/17079 has been merged to our fork and things seem to be working properly (I tried the fix a few days ago with some of the problematic jobs).