### PR TITLE
Set `LANG` environment variable for jobs running on the secondary HTCondor cluster

### DIFF
--- a/group_vars/htcondor-secondary-submit-host.yml
+++ b/group_vars/htcondor-secondary-submit-host.yml
@@ -38,6 +38,7 @@ nspawn_galaxy_environment_vars: |
   PATH={{ galaxy_venv_dir }}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/sbin
   DOCUTILSCONFIG=''
   PYTHONPATH={{ galaxy_server_dir }}/lib/galaxy/jobs/rules
+  LANG=en_US.UTF-8
   {% for var in galaxy_systemd_handler_env | split %}
   {{ var }}
   {% endfor %}


### PR DESCRIPTION
The `LANG` environment variable is unset for jobs running on the secondary cluster. Set it to the same value it is set for jobs running on the primary cluster (`en_US.UTF-8`).

Closes https://github.com/usegalaxy-eu/issues/issues/497.