### PR TITLE
add dry-run

### DIFF
--- a/roles/usegalaxy-eu.remove-orphan-condor-jobs/files/remove-orphan-condor-jobs
+++ b/roles/usegalaxy-eu.remove-orphan-condor-jobs/files/remove-orphan-condor-jobs
@@ -1,6 +1,8 @@
 #!/bin/bash
 # This script finds jobs that are known to HTCondor but not to Galaxy anymore
 # e.g. because we removed the jobs with `gxadmin mutate fail-job`
+# use --dry-run to only print the Galaxy ID and the Condor ID of the jobs that would
+# be removed
 
 # Get running jobs from database
 galaxy_running_jobs=(`gxadmin query queue-detail | grep running | awk '{print$3}'`)
@@ -13,7 +15,7 @@ while IFS=' ' read col1 col2; do
     # Remove the Job from the condor cluster if the Galaxy ID was not found in galaxy_running_jobs
     if [[ ! " ${galaxy_running_jobs[*]} " =~ " ${col1} " ]]; then
         if [ "$1" = "--dry-run" ]; then
-            echo $col2
+            echo $col1 $col2
         else
             condor_rm $col2
         fi

--- a/roles/usegalaxy-eu.remove-orphan-condor-jobs/files/remove-orphan-condor-jobs
+++ b/roles/usegalaxy-eu.remove-orphan-condor-jobs/files/remove-orphan-condor-jobs
@@ -12,6 +12,10 @@ while IFS=' ' read col1 col2; do
 
     # Remove the Job from the condor cluster if the Galaxy ID was not found in galaxy_running_jobs
     if [[ ! " ${galaxy_running_jobs[*]} " =~ " ${col1} " ]]; then
-        condor_rm $col2
+        if [ "$1" = "--dry-run" ]; then
+            echo $col2
+        else
+            condor_rm $col2
+        fi
     fi
 done


### PR DESCRIPTION
@bgruening 's idea in #1038 

`--dry-run` prints out both IDs, Condor and Galaxy for each job that would be removed
