### PR TITLE
Invert query order when removing orphan Condor jobs

### DIFF
--- a/roles/usegalaxy-eu.remove-orphan-condor-jobs/files/remove-orphan-condor-jobs
+++ b/roles/usegalaxy-eu.remove-orphan-condor-jobs/files/remove-orphan-condor-jobs
@@ -5,23 +5,28 @@
 # be removed
 source ~/.bashrc
 date
-# Get running jobs from database
+
+IFS=$'\n'
+# Get running jobs from the HTCondor queue
+condor_running_jobs=(`condor_q -autoformat Cmd ClusterId JobStatus | grep " 2$" | cut -d " " -f1,2 | awk '{n = split($1, arr, "/"); print arr[n-1], $2}'`)
+# Get running jobs from the Galaxy database
 galaxy_running_jobs=(`gxadmin query queue-detail | grep running | awk '{print$3}'`)
 
+# Safeguard: abort if no jobs seem to be known to Galaxy
 if [ "${#galaxy_running_jobs[@]}" -eq 0 ]; then
-    exit
+    exit 1
 fi
 
-# Check if each result from condor queue matches an entry from the galaxy_running_jobs list
-condor_q -autoformat Cmd ClusterId JobStatus | grep " 2$" | cut -d " " -f1,2 | awk '{n = split($1, arr, "/"); print arr[n-1], $2}' |
-while IFS=' ' read col1 col2; do
+# Check if each result from the HTCondor queue matches an entry from the galaxy_running_jobs list
+for job in "${condor_running_jobs[@]}"; do
+    IFS=' ' read -r galaxy_job_id condor_job_id <<< $job
 
     # Remove the Job from the condor cluster if the Galaxy ID was not found in galaxy_running_jobs
-    if [[ ! " ${galaxy_running_jobs[*]} " =~ " ${col1} " ]]; then
+    if [[ ! "${galaxy_running_jobs[*]}" =~ $galaxy_job_id ]]; then
         if [ "$1" = "--dry-run" ]; then
-            echo $col1 $col2
+            echo $galaxy_job_id $condor_job_id
         else
-            condor_rm $col2
+            condor_rm $condor_job_id
         fi
     fi
 done


### PR DESCRIPTION
Originally, the script first gets the jobs from the Galaxy database, then from Condor. If a new job is submitted in between the two queries, it will get killed.

Arguably this is very unlikely, but over the years such sources of mysterious failure accumulate and things get messy.

Invert the order of the queries so that the problem cannot occur in the first place.

I ran this sanity check, whose output looks legit to me.

```shell
[galaxy@htcondor tmp]$ for job in $(./remove-orphan-condor-jobs --dry-run | tail -n +2 | awk '{print $1}'); do gxadmin report job-info $job | grep -i state | head -n1; done | sort | uniq
State | deleted
State | error
```
