### PR TITLE
Query Galaxy database also for queued jobs when removing orphan Condor jobs

### DIFF
--- a/roles/usegalaxy-eu.remove-orphan-condor-jobs/files/remove-orphan-condor-jobs
+++ b/roles/usegalaxy-eu.remove-orphan-condor-jobs/files/remove-orphan-condor-jobs
@@ -10,7 +10,7 @@ IFS=$'\n'
 # Get running jobs from the HTCondor queue
 condor_running_jobs=(`condor_q -autoformat Cmd ClusterId JobStatus | grep " 2$" | cut -d " " -f1,2 | awk '{n = split($1, arr, "/"); print arr[n-1], $2}'`)
 # Get running jobs from the Galaxy database
-galaxy_running_jobs=(`gxadmin query queue-detail | grep running | awk '{print$3}'`)
+galaxy_running_jobs=(`gxadmin query queue-detail | grep -E "queued|running" | awk '{print$3}'`)
 
 # Safeguard: abort if no jobs seem to be known to Galaxy
 if [ "${#galaxy_running_jobs[@]}" -eq 0 ]; then

--- a/roles/usegalaxy-eu.remove-orphan-condor-jobs/files/remove-orphan-condor-jobs
+++ b/roles/usegalaxy-eu.remove-orphan-condor-jobs/files/remove-orphan-condor-jobs
@@ -5,23 +5,28 @@
 # be removed
 source ~/.bashrc
 date
-# Get running jobs from database
+
+IFS=$'\n'
+# Get running jobs from the HTCondor queue
+condor_running_jobs=(`condor_q -autoformat Cmd ClusterId JobStatus | grep " 2$" | cut -d " " -f1,2 | awk '{n = split($1, arr, "/"); print arr[n-1], $2}'`)
+# Get running jobs from the Galaxy database
 galaxy_running_jobs=(`gxadmin query queue-detail | grep running | awk '{print$3}'`)
 
+# Safeguard: abort if no jobs seem to be known to Galaxy
 if [ "${#galaxy_running_jobs[@]}" -eq 0 ]; then
-    exit
+    exit 1
 fi
 
-# Check if each result from condor queue matches an entry from the galaxy_running_jobs list
-condor_q -autoformat Cmd ClusterId JobStatus | grep " 2$" | cut -d " " -f1,2 | awk '{n = split($1, arr, "/"); print arr[n-1], $2}' |
-while IFS=' ' read col1 col2; do
+# Check if each result from the HTCondor queue matches an entry from the galaxy_running_jobs list
+for job in "${condor_running_jobs[@]}"; do
+    IFS=' ' read -r galaxy_job_id condor_job_id <<< $job
 
     # Remove the Job from the condor cluster if the Galaxy ID was not found in galaxy_running_jobs
-    if [[ ! " ${galaxy_running_jobs[*]} " =~ " ${col1} " ]]; then
+    if [[ ! "${galaxy_running_jobs[*]}" =~ $galaxy_job_id ]]; then
         if [ "$1" = "--dry-run" ]; then
-            echo $col1 $col2
+            echo $galaxy_job_id $condor_job_id
         else
-            condor_rm $col2
+            condor_rm $condor_job_id
         fi
     fi
 done


### PR DESCRIPTION
While testing the script in dry-run mode, I have spotted that in some cases it removes jobs that `gxadmin report job-info` reports as being in "running" state.

When a Galaxy job goes into queued state, it is sent to HTCondor via `condor_submit`, entering the HTCondor queue in "idle" state. When the job enters the running state in HTCondor, then its state also changes to "running" in Galaxy.

However, the state change in Galaxy is not instantaneous. This means that a job can be running in HTCondor, yet Galaxy does not necessarily have to know about it (it would still be shown as "queued" in Galaxy). This is precisely the case that results in the removal of a job that is in fact running.

"Requires": #1044. I say "Requires" because I have written the explanation above (and thus the PR) to be considered on top of 347d089ab10134c53efc92c5035f929b8f133804. Yet, if you consider it, it is also ok to rebase 347d089ab10134c53efc92c5035f929b8f133804 onto a46584f6b5fca193391fa659593a370d6a370626 and the fix would be even more useful, because in a46584f6b5fca193391fa659593a370d6a370626, first the Galaxy queue is retrieved and then HTCondor's. There is even more time for jobs to go from the queued state to the running state in-between the queries.