### PR TITLE
Use jq to query the HTCondor queue in the script for removing orphan Condor jobs

### DIFF
--- a/roles/usegalaxy-eu.remove-orphan-condor-jobs/files/remove-orphan-condor-jobs
+++ b/roles/usegalaxy-eu.remove-orphan-condor-jobs/files/remove-orphan-condor-jobs
@@ -8,7 +8,7 @@ date
 
 IFS=$'\n'
 # Get running jobs from the HTCondor queue
-condor_running_jobs=(`condor_q -autoformat Cmd ClusterId JobStatus | grep " 2$" | cut -d " " -f1,2 | awk '{n = split($1, arr, "/"); print arr[n-1], $2}'`)
+condor_running_jobs=(`condor_q -autoformat Cmd ClusterId JobStatus -json | jq -r -c '.[] | select(.JobStatus == 2) | [.Cmd, .ClusterId] | @sh' | cut -d " " -f1,2 | awk '{n = split($1, arr, "/"); print arr[n-1], $2}'`)
 # Get running jobs from the Galaxy database
 galaxy_running_jobs=(`gxadmin query queue-detail | grep running | awk '{print$3}'`)
 

--- a/roles/usegalaxy-eu.remove-orphan-condor-jobs/tasks/main.yml
+++ b/roles/usegalaxy-eu.remove-orphan-condor-jobs/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+- name: Install dependencies
+  ansible.builtin.package:
+    name: jq
+    state: present
+
 - name: "Deploy remove-orphan-condor-jobs script"
   ansible.builtin.copy:
     src: remove-orphan-condor-jobs


### PR DESCRIPTION
Call `condor_q -json` to retrieve jobs from the HTCondor queue, hopefully the JSON spec is less likely to undergo changes than the standard console output.

Suggested by @bgruening in #1045.