### PR TITLE
Fix bug in galaxy_jwd.py

### DIFF
--- a/roles/usegalaxy-eu.bashrc/files/galaxy_jwd.py
+++ b/roles/usegalaxy-eu.bashrc/files/galaxy_jwd.py
@@ -363,7 +363,7 @@ def decode_path(
 
     # Pulsar embedded jobs uses the staging directory and this has a different
     # path structure
-    if job_runner_name.startswith("pulsar_embedded"):
+    if (job_runner_name or "").startswith("pulsar_embedded"):
         jwd_path = f"{backends_dict['pulsar_embedded']}/{job_id}"
     else:
         jwd_path = (


### PR DESCRIPTION
`job_runner_name` may be `None`, triggering the error below.

```
Traceback (most recent call last):
  File "/usr/local/bin/galaxy_jwd", line 505, in <module>
    main()
  File "/usr/local/bin/galaxy_jwd", line 226, in main
    jwd_path = decode_path(job_id, metadata, backends)
  File "/usr/local/bin/galaxy_jwd", line 366, in decode_path
    if job_runner_name.startswith("pulsar_embedded"):
AttributeError: 'NoneType' object has no attribute 'startswith'
```