### PR TITLE
Open HTCondor shared port only on manager nodes

### DIFF
--- a/htcondor.yml
+++ b/htcondor.yml
@@ -279,7 +279,7 @@
         state: enabled
         permanent: true
         immediate: true
-      when: inventory_hostname != "nspawn-htcondor.sn06.galaxyproject.eu"
+      when: htcondor_role_manager
 
     - name: Check if HTCondor is running.
       ansible.builtin.service_facts:


### PR DESCRIPTION
Only the central manager should need to listen on the shared port.