### PR TITLE
Run the cluster play in the HTCondor cluster playbook as root

### DIFF
--- a/htcondor.yml
+++ b/htcondor.yml
@@ -205,6 +205,7 @@
 
 - name: HTCondor cluster.
   hosts: htcondor:!sn06.galaxyproject.eu
+  become: true
   handlers:
     - name: Reload HTCondor
       when: "'condor_service' in service_facts.ansible_facts.services and \


### PR DESCRIPTION
Our roles are designed to be run as root, so unless we go over every role and fix the details we are stuck with this approach.