### PR TITLE
Add a few `become` statements to the cluster play in the HTCondor cluster playbook

### DIFF
--- a/htcondor.yml
+++ b/htcondor.yml
@@ -250,6 +250,7 @@
       when: htcondor_role_submit
 
     - name: Ensure crond is enabled and started.
+      become: true
       ansible.builtin.service:
         name: crond
         enabled: true
@@ -276,6 +277,7 @@
       notify: Reload HTCondor
 
     - name: Open HTCondor shared port in the firewall.
+      become: true
       ansible.posix.firewalld:
         port: "{{ htcondor_port }}/tcp"
         state: enabled
@@ -303,6 +305,7 @@
       when: htcondor_role_submit
   post_tasks:
     - name: Add /usr/local/bin to Galaxy's PATH in bashrc file. (usegalaxy-eu.fix-stop-ITs)
+      become: true
       when: htcondor_role_submit
       lineinfile:
         path: "{{ galaxy_user.home }}/.bashrc"


### PR DESCRIPTION
If we ever managed that roles attempt to escalate privileges only when they need to and the play can be run as non-root, those become statements would be needed for correctness.

This is NOT needed for #1057.