### PR TITLE
Bump ansible-flower 0.3.1-alpha → 2.0.0, disable install, logs to journald

### DIFF
--- a/group_vars/celerycluster.yml
+++ b/group_vars/celerycluster.yml
@@ -46,9 +46,9 @@ galaxy_systemd_celery_internal_workers: 10
 galaxy_systemd_celery_external_workers: 2
 
 # Flower
-flower_python_version: python38
+flower_custom_logging: false
+flower_install: false
 flower_app_dir: /opt/galaxy
-flower_log_file: /var/log/flower
 flower_python_path: server/lib
 flower_venv_dir: /opt/galaxy/venv
 flower_app_name: galaxy.celery

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -111,7 +111,7 @@ roles:
   - name: usegalaxy_eu.influxdbserver
     version: 1.1.1
   - name: usegalaxy_eu.flower
-    version: 0.3.1-alpha
+    version: 2.0.0
   # `geerlingguy.pip` is here only because it is a dependency of
   # `paprikant.beacon` and because no version has been pinned when declaring
   # the dependency, the role is affected by this bug:


### PR DESCRIPTION
Rolls out the new ansible-flower role release:
https://github.com/usegalaxy-eu/flower-ansible-role/releases/tag/2.0.0

This should fix the issue that flower gets installed twice; on the headnode and on NFS
as well as the logging issues we had.