### PR TITLE
Include maintenace group vars file exclusively for higher precedence

### DIFF
--- a/maintenance.yml
+++ b/maintenance.yml
@@ -8,6 +8,7 @@
     - secret_group_vars/all.yml
     - mounts/dest/all.yml
     - mounts/mountpoints.yml
+    - group_vars/maintenance.yml
   collections:
     - devsec.hardening
   handlers:


### PR DESCRIPTION
This fixes the broken Jenkins build job. 

The issue seems to be due to adding the host `maintenace.galaxyproject.eu` to the group `htcondor-secondary-submit`. I think @kysrpex wanted to simplify things with the htcondor stuff and once that is done, this PR can be reverted.