### PR TITLE
increase memory of quast

### DIFF
--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -733,6 +733,10 @@ tools:
       - if: input_size >= 25
         fail: Too much data, please check if the input is correct.
 
+  toolshed.g2.bx.psu.edu/repos/iuc/quast/quast/.*:
+    cores: 10
+    mem: 80
+
   toolshed.g2.bx.psu.edu/repos/devteam/freebayes/freebayes/.*:
     # see https://github.com/usegalaxy-eu/infrastructure-playbook/pull/881 for some numbers
     cores: 10


### PR DESCRIPTION
Some quast jobs take forever, I assume this is due to low memory allowance (was 12 GB so far: https://github.com/galaxyproject/tpv-shared-database/blob/3be0403ffc960effd180c65fa0e2242dfe5e6aa9/tools.yml#L2121C1-L2123C12); but ideally I would like to work on a solution similar to https://github.com/usegalaxy-eu/infrastructure-playbook/pull/881 if an admin can query it for me. 