### PR TITLE
Increase cores for bakta

### DIFF
--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -1119,3 +1119,6 @@ tools:
     scheduling:
       require:
         - singularity
+
+  toolshed.g2.bx.psu.edu/repos/iuc/bakta/bakta/.*:
+    cores: 20


### PR DESCRIPTION
Hi,

Bakta runs for several hours on usegalaxy.eu and only few minutes on usegalaxy.fr (with the same input and parameters).
The difference I see was on the number of allocated cores.

