### PR TITLE
Add WallE to maintenance

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -157,6 +157,17 @@ ssh_client_alive_interval: 600
 # Apollo env vars
 apollo_env: "GALAXY_WEBAPOLLO_URL={{ GALAXY_WEBAPOLLO_URL }} GALAXY_WEBAPOLLO_USER={{ GALAXY_WEBAPOLLO_USER }} GALAXY_WEBAPOLLO_PASSWORD={{ GALAXY_WEBAPOLLO_PASSWORD }} GALAXY_WEBAPOLLO_EXT_URL={{ GALAXY_WEBAPOLLO_EXT_URL }} GALAXY_SHARED_DIR={{ GALAXY_SHARED_DIR }} GALAXY_APOLLO_ORG_SUFFIX=id"
 
+# WallE
+walle_verbose: true
+walle_tool: interactive
+walle_user_name: "{{ galaxy_user.name }}"
+walle_user_group: "{{ galaxy_group.name }}"
+walle_virtualenv: "{{ galaxy_venv_dir }}"
+walle_bashrc: "{{ galaxy_user.home }}/.bashrc"
+walle_pgpass_file: "{{ galaxy_user.home }}/.pgpass"
+walle_malware_database_location: "/data/dnb01/maintenance"
+walle_database_file: checksums.yml
+
 # 03/11/2022: Autofs configuration for mounting NFS volumes
 # usegalaxy-eu.autofs role uses this variable
 # gxtest, gxkey, and jwd will also mount under /data as before

--- a/group_vars/sn06.yml
+++ b/group_vars/sn06.yml
@@ -108,6 +108,8 @@ pip_install_dependencies:
   - pyyaml
   - GitPython
   - python-openstackclient
+  # WallE
+  - tqdm # progress bar, has no dependencies
 
 yum_exclude_repos:
   - condor*
@@ -196,6 +198,16 @@ dynmotd_custom:
 
 # TPV Script
 tpv_config_dir_name: total_perspective_vortex
+
+# WallE
+walle_verbose: true
+walle_tool: interactive
+walle_user_name: "{{ galaxy_user.name }}"
+walle_user_group: "{{ galaxy_group.name }}"
+walle_virtualenv: "{{ galaxy_venv_dir }}"
+walle_malware_database_location: "{{ galaxy_config_dir }}"
+walle_bashrc: "{{ galaxy_user.home }}/.bashrc"
+walle_pgpass_file: "{{ galaxy_user.home }}/.pgpass"
 
 # CVMFS
 cvmfs_role: client

--- a/group_vars/sn06.yml
+++ b/group_vars/sn06.yml
@@ -199,16 +199,6 @@ dynmotd_custom:
 # TPV Script
 tpv_config_dir_name: total_perspective_vortex
 
-# WallE
-walle_verbose: true
-walle_tool: interactive
-walle_user_name: "{{ galaxy_user.name }}"
-walle_user_group: "{{ galaxy_group.name }}"
-walle_virtualenv: "{{ galaxy_venv_dir }}"
-walle_malware_database_location: "{{ galaxy_config_dir }}"
-walle_bashrc: "{{ galaxy_user.home }}/.bashrc"
-walle_pgpass_file: "{{ galaxy_user.home }}/.pgpass"
-
 # CVMFS
 cvmfs_role: client
 galaxy_cvmfs_repos_enabled: config-repo

--- a/maintenance.yml
+++ b/maintenance.yml
@@ -132,3 +132,4 @@
     # - usegalaxy-eu.fix-stop-ITs
     - usegalaxy-eu.vgcn-monitoring
     - usegalaxy-eu.logrotate
+    - usegalaxy_eu.walle

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -112,6 +112,8 @@ roles:
     version: 1.1.1
   - name: usegalaxy_eu.flower
     version: 2.0.0
+  - name: usegalaxy_eu.walle
+    version: 0.0.1
   # `geerlingguy.pip` is here only because it is a dependency of
   # `paprikant.beacon` and because no version has been pinned when declaring
   # the dependency, the role is affected by this bug:

--- a/roles/usegalaxy-eu.bashrc/tasks/bashrc_tasks.yml
+++ b/roles/usegalaxy-eu.bashrc/tasks/bashrc_tasks.yml
@@ -119,6 +119,8 @@
         - "export GALAXY_ROOT={{ galaxy_server_dir }}"
         - "export VIRTUAL_ENV={{ galaxy_venv_dir }}"
         - "export GALAXY_PULSAR_APP_CONF={{ galaxy_pulsar_app_conf }}"
+        - 'export MALWARE_LIB="{{ walle_malware_database_location }}/{{ walle_database_file }}"'
+        - 'export PGPASSFILE="{{ walle_pgpass_file }}"'
       loop_control:
         loop_var: task_item
 

--- a/sn06.yml
+++ b/sn06.yml
@@ -295,4 +295,3 @@
     # - dev-sec.os-hardening
     - dev-sec.ssh-hardening
     - usegalaxy-eu.fix-stop-ITs
-    - usegalaxy_eu.walle

--- a/sn06.yml
+++ b/sn06.yml
@@ -295,3 +295,4 @@
     # - dev-sec.os-hardening
     - dev-sec.ssh-hardening
     - usegalaxy-eu.fix-stop-ITs
+    - usegalaxy_eu.walle


### PR DESCRIPTION
Not ideal, because the walle role will do `lineinfile` operation on `/opt/galaxy/.bashrc`
However I think the only scenario were this is relevant is when we first deploy it. then we have to make sure `sn06` runs before `maintenance`