### PR TITLE
Add Germark env back to braker3 version 3.0.6

### DIFF
--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -1072,6 +1072,9 @@ tools:
         - if: helpers.tool_version_eq(tool, '3.0.6+galaxy2')
           execute: |
             entity.params['singularity_container_id_override']="docker://teambraker/braker3:v1.0.6"
+          env:
+            GENEMARK_PATH: "/usr/local/tools/_conda/envs/__braker3@3.0.6/bin/genemark/bin/"
+            PROTHINT_PATH: "/usr/local/tools/_conda/envs/__braker3@3.0.6/bin/genemark/bin/gmes/ProtHint/bin/"            
         - if: helpers.tool_version_eq(tool, '3.0.7+galaxy2')
           execute: |
             entity.params['singularity_container_id_override']="docker://teambraker/braker3:v3.0.7.1"

--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -1074,7 +1074,7 @@ tools:
             entity.params['singularity_container_id_override']="docker://teambraker/braker3:v1.0.6"
           env:
             GENEMARK_PATH: "/usr/local/tools/_conda/envs/__braker3@3.0.6/bin/genemark/bin/"
-            PROTHINT_PATH: "/usr/local/tools/_conda/envs/__braker3@3.0.6/bin/genemark/bin/gmes/ProtHint/bin/"            
+            PROTHINT_PATH: "/usr/local/tools/_conda/envs/__braker3@3.0.6/bin/genemark/bin/gmes/ProtHint/bin/"
         - if: helpers.tool_version_eq(tool, '3.0.7+galaxy2')
           execute: |
             entity.params['singularity_container_id_override']="docker://teambraker/braker3:v3.0.7.1"


### PR DESCRIPTION
It got mistakenly removed in the PR https://github.com/usegalaxy-eu/infrastructure-playbook/pull/1091

@abueg shared a job ID from EMBO where the Braker3 is not working anymore. The issue is due to removing the `env` from the TPV during the previous updates. 

The error was ` line 23: /gmes/gmes_petap.pl: No such file or directory`