### PR TITLE
Fix braker3 breaking TPV changes

### DIFF
--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -1060,24 +1060,26 @@ tools:
       require:
         - singularity
 
-  toolshed.g2.bx.psu.edu/repos/genouest/braker3/braker3/.*:
-    cores: 6
+  toolshed.g2.bx.psu.edu/repos/genouest/braker3/braker3/3.0.6.*:
     mem: 4
+    cores: 6
+    env:
+      GENEMARK_PATH: "/usr/local/tools/_conda/envs/__braker3@3.0.6/bin/genemark/bin/"
+      PROTHINT_PATH: "/usr/local/tools/_conda/envs/__braker3@3.0.6/bin/genemark/bin/gmes/ProtHint/bin/"
     params:
-      singularity_enabled: true
-      rules:
-        - if: any(helpers.tool_version_eq(tool, version) for version in ['3.0.3+galaxy0', '3.0.3+galaxy1', '3.0.3+galaxy2'])
-          execute: |
-            entity.params['singularity_container_id_override']="docker://teambraker/braker3:v.1.0.4"
-        - if: helpers.tool_version_eq(tool, '3.0.6+galaxy2')
-          execute: |
-            entity.params['singularity_container_id_override']="docker://teambraker/braker3:v1.0.6"
-          env:
-            GENEMARK_PATH: "/usr/local/tools/_conda/envs/__braker3@3.0.6/bin/genemark/bin/"
-            PROTHINT_PATH: "/usr/local/tools/_conda/envs/__braker3@3.0.6/bin/genemark/bin/gmes/ProtHint/bin/"
-        - if: helpers.tool_version_eq(tool, '3.0.7+galaxy2')
-          execute: |
-            entity.params['singularity_container_id_override']="docker://teambraker/braker3:v3.0.7.1"
+      singularity_container_id_override: docker://teambraker/braker3:v1.0.6
+    scheduling:
+      require:
+        - singularity
+
+  toolshed.g2.bx.psu.edu/repos/genouest/braker3/braker3/3.0.3.*:
+    mem: 4
+    cores: 6
+    params:
+      singularity_container_id_override: docker://teambraker/braker3:v.1.0.4
+    scheduling:
+      require:
+        - singularity
 
   # GeneMark is a pain and needs special casing
   toolshed.g2.bx.psu.edu/repos/genouest/braker/braker/.*:


### PR DESCRIPTION
Due to various TPV issues, I am restructuring (partially reverting it to match what was [there](https://github.com/usegalaxy-eu/infrastructure-playbook/blob/68c9ed91e41f2874d391949eb75c86a7b5d280f9/files/galaxy/tpv/tools.yml#L1063-L1085)) the changes introduced via the below PRs.

1. https://github.com/usegalaxy-eu/infrastructure-playbook/pull/1091
2. https://github.com/usegalaxy-eu/infrastructure-playbook/pull/1094

I have rolled out a version of this PR locally after several trial-and-error runs (thanks to @abueg for testing and reporting the issues). 

@rlibouba: Since the EU does not yet have the `3.0.7` version installed, I have removed it from the current TPV scheduling and updated the container images for both versions `3.0.3` and `3.0.6`. I had to remove it because I am unsure about the `GENEMARK_PATH` and the other `env` to be added. Please feel free to update once it is installed. To add a new version of this tool the change should go to this file https://github.com/usegalaxy-eu/usegalaxy-eu-tools/blob/9bdcca26aefcfece5f261b5c189104acf858e9b8/genome-annotation.yaml.lock#L253-L259 if I am not mistaken (@bgruening will be able to clarify on that).
