### PR TITLE
Deploy remove-orphan-condor-jobs role on the maintenance node instead of the headnode

### DIFF
--- a/maintenance.yml
+++ b/maintenance.yml
@@ -127,6 +127,7 @@
     - usegalaxy-eu.fix-unscheduled-workflows
     - usegalaxy-eu.fix-ancient-ftp-data
     - usegalaxy-eu.fix-user-quotas
+    - usegalaxy-eu.remove-orphan-condor-jobs
     - ssh_hardening
     - dj-wasabi.telegraf
     # - usegalaxy-eu.fix-stop-ITs

--- a/roles/usegalaxy-eu.remove-orphan-condor-jobs/files/remove-orphan-condor-jobs
+++ b/roles/usegalaxy-eu.remove-orphan-condor-jobs/files/remove-orphan-condor-jobs
@@ -8,7 +8,7 @@ date
 
 IFS=$'\n'
 # Get running jobs from the HTCondor queue
-condor_running_jobs=(`condor_q -autoformat Cmd ClusterId JobStatus -json | jq -r -c '.[] | select(.JobStatus == 2) | [.Cmd, .ClusterId] | @sh' | cut -d " " -f1,2 | awk '{n = split($1, arr, "/"); print arr[n-1], $2}'`)
+condor_running_jobs=(`condor_q -global -autoformat Cmd ClusterId JobStatus -json | jq -r -c '.[] | select(.JobStatus == 2) | [.Cmd, .ClusterId] | @sh' | cut -d " " -f1,2 | awk '{n = split($1, arr, "/"); print arr[n-1], $2}'`)
 # Get running jobs from the Galaxy database
 galaxy_running_jobs=(`gxadmin query queue-detail | grep -E "queued|running" | awk '{print$3}'`)
 

--- a/sn06.yml
+++ b/sn06.yml
@@ -287,7 +287,6 @@
     - usegalaxy-eu.htcondor_release
     # Various ugly fixes
     - usegalaxy-eu.fix-unscheduled-jobs # Workaround for ???
-    - usegalaxy-eu.remove-orphan-condor-jobs
     - usegalaxy-eu.fix-stuck-handlers # Restart handlers to prevent several classes of issues
     - usegalaxy-eu.log-cleaner # do not retain journalctl logs, they are unnecessary/risky under GDPR
     - usegalaxy-eu.galaxy-procstat # Some custom telegraf monitoring that's templated


### PR DESCRIPTION
Since we have migrated to the secondary htcondor, the cron job deployed on the head node does not work. However, the maintenance node has already been deployed and integrated with the new htcondor version. We can run this cron job by adding a `-global` argument to the `condor_q` to fetch the job details.

_Note: the cron job on the head node should be removed manually_