### PR TITLE
Update the container image for Braker3 version 3.0.7 to address AUGUSTUS tool CRF issue

### DIFF
--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -1086,7 +1086,7 @@ tools:
     mem: 4
     cores: 6
     params:
-      singularity_container_id_override: "docker://teambraker/braker3:v3.0.7.1"
+      singularity_container_id_override: "docker://teambraker/braker3:v3.0.7.3"
     scheduling:
       require:
         - singularity


### PR DESCRIPTION
We have an error report with the following error and issue

Error:

```
ERROR in file /opt/BRAKER/scripts/braker.pl at line 6971
failed to execute: /usr/bin//etraining --species=Sp_1 --CRF=1 --AUGUSTUS_CONFIG_PATH=/data/jwd05e/main/067/179/67179048/working/augustus_dir/ /data/jwd05e/main/067/179/67179048/working/braker/train.gb.train 1>/data/jwd05e/main/067/179/67179048/working/braker/crftraining.stdout 2>/data/jwd05e/main/067/179/67179048/working/braker/errors/crftraining.stderr
```

```
/usr/bin//etraining: ERROR
        FeatureCollection::esource: invalid source key: RM
```

Issue discussions:
1. https://github.com/Gaius-Augustus/BRAKER/issues/325
2. https://github.com/Gaius-Augustus/BRAKER/issues/591

Tool authors have released a new container image addressing this issue (see discussion in thread 2). This PR will update the [container image](https://hub.docker.com/r/teambraker/braker3/tags).
