### PR TITLE
Replace recetox_msfinder fixed version with regex in TPV tools.yml

### DIFF
--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -283,7 +283,7 @@ tools:
       require:
         - docker
 
-  toolshed.g2.bx.psu.edu/repos/recetox/recetox_msfinder/recetox_msfinder/v3.5.2+galaxy4:
+  toolshed.g2.bx.psu.edu/repos/recetox/recetox_msfinder/recetox_msfinder/.*:
     inherits: basic_docker_tool
   toolshed.g2.bx.psu.edu/repos/imgteam/bioformats2raw/bf2raw/.*:
     inherits: basic_docker_tool


### PR DESCRIPTION
The tool is not going to the desired docker destination due to the absence of the regex pattern. 

When testing with the `tpv dry-run`, I observed that the destination is always the `secondary_condor_tpv`, and also we can see the same from the past jobs (`gxadmin query jobs --tool recetox_msfinder`)

Let's see if this solves the issue: https://github.com/usegalaxy-eu/infrastructure-playbook/issues/1092 or take us to the next step in the debugging process.

