### PR TITLE
set a default mem value to flye if the input size is too small

### DIFF
--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -1169,7 +1169,7 @@ tools:
 
   toolshed.g2.bx.psu.edu/repos/bgruening/flye/flye/.*:
     cores: 20
-    mem: 3.8 if min(input_size*1.2, 256) < 3.8 else min(input_size*1.2, 256)
+    mem: min(max(input_size*1.2, 3.8), 256)
     scheduling:
       require:
         - singularity

--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -1169,7 +1169,7 @@ tools:
 
   toolshed.g2.bx.psu.edu/repos/bgruening/flye/flye/.*:
     cores: 20
-    mem: min(input_size*1.2, 256)
+    mem: 3.8 if min(input_size*1.2, 256) < 3.8 else min(input_size*1.2, 256)
     scheduling:
       require:
         - singularity


### PR DESCRIPTION
We have a couple of error reports with the error `ERROR: Looks like the system ran out of memory` because the memory set for the tool based on the job's input dataset size was only 7MB and 53 MB, respectively. This PR sets the default memory to a minimum of 3.8G (based on the default mem we set for tools).

The flexible mem was introduced to flye here: https://github.com/usegalaxy-eu/infrastructure-playbook/pull/1101