### PR TITLE
Disable the rollout of old htcondor on sn06

### DIFF
--- a/sn06.yml
+++ b/sn06.yml
@@ -229,7 +229,7 @@
     - geerlingguy.docker
 
     # HTCondor Cluster setup
-    - usegalaxy_eu.htcondor
+    # - usegalaxy_eu.htcondor
 
     # Misc.
     - role: hxr.galaxy-nonreproducible-tools


### PR DESCRIPTION
I forgot to push this change yesterday, so the old htcondor role was installed again. This PR will stop installing the old htcondor role on sn06.

I will repeat yesterday's process, purge the old Condor packages, and install the latest HTCondor.