### PR TITLE
Add schedd field to HTCondor monitoring

### DIFF
--- a/roles/hxr.monitor-cluster/files/cluster_queue-condor-jobs.sh
+++ b/roles/hxr.monitor-cluster/files/cluster_queue-condor-jobs.sh
@@ -5,6 +5,7 @@
 condor_q -global -autoformat GlobalJobId JobStatus Cmd RemoteHost RequestCpus RequestMemory QDate JobStartDate JobDescription | awk '{
   if ($8 != "undefined") $8 = strftime("%Y-%m-%d %H:%M:%S", $8);
   split($1,globalID,"#");
+  split(globalID[2],condorID,"#");
   status["0"]="Unexpanded"; status["1"]="Idle"; status["2"]="Running"; status["3"]="Removed"; status["4"]="Completed"; status["5"]="Held"; status["6"]="Submission_err";
 
   jobdesc = $9;
@@ -13,5 +14,5 @@ condor_q -global -autoformat GlobalJobId JobStatus Cmd RemoteHost RequestCpus Re
     jobdesc = jobdesc "_" $i;
   }
 
-  printf "condor_queued_jobs_status,schedd=\"%s\",clusterid=\"%s\" jobstatus=\"%s\",cmd=\"%s\",remotehost=\"%s\",requestcpus=%s,requestmemory=%s,qdate=\"%s\",jobstartdate=\"%s\",jobdescription=\"%s\"\n", globalID[1], globalID[2], status[$2], $3, $4, $5, $6, strftime("%Y-%m-%d %H:%M:%S", $7), $8, jobdes
+  printf "condor_queued_jobs_status,schedd=%s,clusterid=%s jobstatus=\"%s\",cmd=\"%s\",remotehost=\"%s\",requestcpus=%s,requestmemory=%s,qdate=\"%s\",jobstartdate=\"%s\",jobdescription=\"%s\"\n", globalID[1], condorID[1], status[$2], $3, $4, $5, $6, strftime("%Y-%m-%d %H:%M:%S", $7), $8, jobdesc
 }'

--- a/roles/hxr.monitor-cluster/files/cluster_queue-condor-jobs.sh
+++ b/roles/hxr.monitor-cluster/files/cluster_queue-condor-jobs.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 
+
 # This script is used to monitor the condor jobs status in the cluster including the compute resources, job submit time to the queue, job start time, job description, etc.
-condor_q -global -autoformat ClusterId JobStatus Cmd RemoteHost RequestCpus RequestMemory QDate JobStartDate JobDescription | awk '{
+condor_q -global -autoformat GlobalJobId JobStatus Cmd RemoteHost RequestCpus RequestMemory QDate JobStartDate JobDescription | awk '{
   if ($8 != "undefined") $8 = strftime("%Y-%m-%d %H:%M:%S", $8);
+  split($1,globalID,"#");
   status["0"]="Unexpanded"; status["1"]="Idle"; status["2"]="Running"; status["3"]="Removed"; status["4"]="Completed"; status["5"]="Held"; status["6"]="Submission_err";
 
   jobdesc = $9;
@@ -11,5 +13,5 @@ condor_q -global -autoformat ClusterId JobStatus Cmd RemoteHost RequestCpus Requ
     jobdesc = jobdesc "_" $i;
   }
 
-  printf "condor_queued_jobs_status,clusterid=\"%s\" jobstatus=\"%s\",cmd=\"%s\",remotehost=\"%s\",requestcpus=%s,requestmemory=%s,qdate=\"%s\",jobstartdate=\"%s\",jobdescription=\"%s\"\n", $1, status[$2], $3, $4, $5, $6, strftime("%Y-%m-%d %H:%M:%S", $7), $8, jobdesc
+  printf "condor_queued_jobs_status,schedd=\"%s\",clusterid=\"%s\" jobstatus=\"%s\",cmd=\"%s\",remotehost=\"%s\",requestcpus=%s,requestmemory=%s,qdate=\"%s\",jobstartdate=\"%s\",jobdescription=\"%s\"\n", globalID[1], globalID[2], status[$2], $3, $4, $5, $6, strftime("%Y-%m-%d %H:%M:%S", $7), $8, jobdes
 }'

--- a/roles/hxr.monitor-cluster/files/cluster_queue-condor.sh
+++ b/roles/hxr.monitor-cluster/files/cluster_queue-condor.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
-condor_q -global -total | grep "all" | sed 's/.* jobs;\s*//g;s/, /\n/g' | while read line ; do
-    type=$(echo $line | sed 's/^[0-9]* //g');
-    count=$(echo $line | sed 's/ .*//g');
-    echo "cluster.queue,engine=condor,state=$type count=$count"
+condor_q -global -total | grep "all\|Schedd"  | while read hostline; read numbersline; do
+    host=$(echo $hostline | awk -F": " '{gsub(/ /, "", $2); print$2}');
+    echo $numbersline | sed 's/.* jobs;\s*//g;s/, /\n/g' | while read line; do
+        type=$(echo $line | sed 's/^[0-9]* //g');
+        count=$(echo $line | sed 's/ .*//g');
+        echo "cluster.queue,engine=condor,schedd=$host state=$type count=$count"
+    done;
 done;

--- a/roles/hxr.monitor-cluster/files/cluster_queue-condor.sh
+++ b/roles/hxr.monitor-cluster/files/cluster_queue-condor.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
-condor_q -global -total | grep "all\|Schedd"  | while read hostline; read numbersline; do
+condor_q -global -total | grep "all\|Schedd"  | while read hostline; read numbersline; do                                                                                        
     host=$(echo $hostline | awk -F": " '{gsub(/ /, "", $2); print$2}');
     echo $numbersline | sed 's/.* jobs;\s*//g;s/, /\n/g' | while read line; do
         type=$(echo $line | sed 's/^[0-9]* //g');
         count=$(echo $line | sed 's/ .*//g');
-        echo "cluster.queue,engine=condor,schedd=$host state=$type count=$count"
+        echo cluster.queue,engine=condor,schedd="$host",state=$type count=$count
     done;
 done;


### PR DESCRIPTION
This adds a field `schedd` in influxDB like this to following measurements:
1.  `cluster.queue`
~~~diff
-cluster.queue,engine=condor,state=idle count=210
+cluster.queue,engine=condor,schedd=htcondor,state=idle count=210
~~~
2. `condor_queued_jobs_status`
~~~diff
-condor_queued_jobs_status,clusterid="48277094.0" jobstatus="Running",cmd="/data/jwd02f/main/067/879/xxxxxxx/galaxy_xxxxxx.sh",remotehost="slot1_27@vgcnbwc-worker-c120m425-htcondor-secondary-0000.novalocal",requestcpus=1,requestmemory=3072,qdate="2024-03-13 11:40:34",jobstartdate="2024-03-13 11:40:37",jobdescription=""
+condor_queued_jobs_status,schedd="sn06.galaxyproject.eu",clusterid="48277094.0" jobstatus="Running",cmd="/data/jwd02f/main/067/879/xxxxxx/galaxy_xxxxxxxx.sh",remotehost="slot1_27@vgcnbwc-worker-c120m425-htcondor-secondary-0000.novalocal",requestcpus=1,requestmemory=3072,qdate="2024-03-13 11:40:34",jobstartdate="2024-03-13 11:40:37",jobdescription=""
~~~

This is already in production and visible in the dashboard