### PR TITLE
Fix influx timeout

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -58,7 +58,7 @@ telegraf_agent_output:
       - database = "{{ influxdb.node.database }}"
       - username = "{{ influxdb.node.username }}"
       - password = "{{ influxdb.node.password }}"
-
+      - timeout = "10s"
 telegraf_plugins_default:
   - plugin: cpu
     config:

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -70,7 +70,7 @@ telegraf_plugins_default:
   - plugin: mem
   - plugin: system
   - plugin: swap
-  - plugin: net
+  - plugin: nstat
   - plugin: netstat
   - plugin: chrony
 


### PR DESCRIPTION
As discussed in the OPs channel, this fixed the timeout error on the influxdb node for the local telegraf
additionally I **replace** net with nstat plugin, because it will be removed in v1.36