### PR TITLE
add sudoers hack to vgcn monitoring role

### DIFF
--- a/roles/usegalaxy-eu.vgcn-monitoring/tasks/main.yml
+++ b/roles/usegalaxy-eu.vgcn-monitoring/tasks/main.yml
@@ -7,6 +7,14 @@
     group: root
     mode: 0755
 
+- name: Add command to sudoers to ensure condor permissions
+  community.general.sudoers:
+    name: vgcn-monitoring
+    user: telegraf
+    commands:
+      - "{{ custom_vgcn_env }} /usr/local/bin/vgcn_monitoring.py"
+  notify: restart telegraf
+
 - name: Add VGCN monitoring Telegraf configuration
   template:
     src: vgcn_monitoring.conf.j2


### PR DESCRIPTION
As discussed, this solves the condor permission issue for telegraf (in a hacky way)
(also used by the other condor monitor roles like https://github.com/usegalaxy-eu/infrastructure-playbook/blob/6c3d6a7944bb597b1a1ba8b503cd78836ec2faab/roles/hxr.monitor-cluster/tasks/condor.yml#L26