### PR TITLE
lower galaxy_systemd_memory_limit

### DIFF
--- a/group_vars/sn06.yml
+++ b/group_vars/sn06.yml
@@ -220,7 +220,7 @@ galaxy_systemd_gunicorn_env: "{{ apollo_env }}"
 galaxy_systemd_handler_env: "{{ galaxy_systemd_gunicorn_env }}"
 galaxy_systemd_workflow_scheduler_env: "{{ galaxy_systemd_gunicorn_env }}"
 
-galaxy_systemd_memory_limit: 120
+galaxy_systemd_memory_limit: 40
 galaxy_systemd_memory_limit_handler: 30
 galaxy_systemd_memory_limit_workflow: 15
 


### PR DESCRIPTION
and keep observing, I think we bumped it last time when there was a memory leak, it should not grow that high anymore