### PR TITLE
bump WALL·E 0.0.1→0.0.2 fix 'None' symlinks

### DIFF
--- a/requirements.yaml
+++ b/requirements.yaml
@@ -113,7 +113,7 @@ roles:
   - name: usegalaxy_eu.flower
     version: 2.0.0
   - name: usegalaxy_eu.walle
-    version: 0.0.1
+    version: 0.0.2
   # `geerlingguy.pip` is here only because it is a dependency of
   # `paprikant.beacon` and because no version has been pinned when declaring
   # the dependency, the role is affected by this bug:


### PR DESCRIPTION
related to:
- https://github.com/usegalaxy-eu/WallE/pull/3