### PR TITLE
increase DB max_connections by 50% to avoid connection errors

### DIFF
--- a/group_vars/sn05.yml
+++ b/group_vars/sn05.yml
@@ -39,7 +39,7 @@ software_groups_to_install:
 # PostgreSQL
 postgresql_conf:
   - listen_addresses: "'*'"
-  - max_connections: 512
+  - max_connections: 768
   - shared_buffers: "4GB"
   - temp_buffers: "64MB"
   - max_prepared_transactions: 100


### PR DESCRIPTION
Error: FATAL: remaining connection slots are reserved for non-replication superuser connections

