### PR TITLE
Added RAM to exec nodes at SK01 pulsar endpoint.

### DIFF
--- a/files/galaxy/tpv/destinations.yml.j2
+++ b/files/galaxy/tpv/destinations.yml.j2
@@ -183,7 +183,7 @@ destinations:
     inherits: pulsar_default
     runner: pulsar_eu_sk01
     max_accepted_cores: 8
-    max_accepted_mem: 16
+    max_accepted_mem: 31
     min_accepted_gpus: 0
     max_accepted_gpus: 0
     scheduling:


### PR DESCRIPTION
Added memory to exec nodes at SK01 to allow jobs to request 3.8G memory per core and use all cores.