### PR TITLE
Add Zenodo + sandbox

### DIFF
--- a/files/galaxy/config/user_preferences_extra_conf.yml
+++ b/files/galaxy/config/user_preferences_extra_conf.yml
@@ -64,11 +64,11 @@ preferences:
               # store: vault
               required: False
 
-    invenio_sandbox:
-        description: Your Invenio RDM Integration Settings
+    zenodo:
+        description: Your Zenodo Integration Settings
         inputs:
             - name: token
-              label: Personal Token used to create draft records and to upload files
+              label: Personal Access Token used to create draft records and to upload files. You can manage your tokens at https://zenodo.org/account/settings/applications/
               type: secret
               store: vault # Requires setting up vault_config_file in your galaxy.yml
               required: False

--- a/files/galaxy/config/user_preferences_extra_conf.yml
+++ b/files/galaxy/config/user_preferences_extra_conf.yml
@@ -77,6 +77,19 @@ preferences:
               type: text
               required: False
 
+    zenodo_sandbox:
+        description: Your Zenodo Sandbox Integration Settings (TESTING ONLY)
+        inputs:
+            - name: token
+              label: Personal Access Token used to create draft records and to upload files. You can manage your tokens at https://sandbox.zenodo.org/account/settings/applications/
+              type: secret
+              store: vault # Requires setting up vault_config_file in your galaxy.yml
+              required: False
+            - name: public_name
+              label: Creator name to associate with new records (formatted as "Last name, First name"). If left blank "Anonymous Galaxy User" will be used. You can always change this by editing your record directly.
+              type: text
+              required: False
+
     # Used in file_sources_conf.yml
     onedata:
         description: Your Onedata account

--- a/templates/galaxy/config/file_sources_conf.yml.j2
+++ b/templates/galaxy/config/file_sources_conf.yml.j2
@@ -262,12 +262,13 @@
   writable: true
 
 - type: inveniordm
-  id: invenio_sandbox
-  doc: Invenio RDM turn-key research data management repository (Sandbox)
-  label: Invenio RDM Demo Repository (Sandbox)
-  url: https://inveniordm.web.cern.ch/
-  token: ${user.preferences['invenio_sandbox|token']}
-  public_name: ${user.preferences['invenio_sandbox|public_name']}
+  id: zenodo
+  doc: Zenodo is an open-access digital repository created by CERN (the European Organization for Nuclear Research) to enable researchers to share, preserve, and cite research outputs across various disciplines.
+  label: Zenodo
+  url: https://zenodo.org
+  token: ${user.user_vault.read_secret('preferences/zenodo/token')}
+  # token: ${user.preferences['zenodo|token']} # Alternatively use this for retrieving the token from user preferences instead of the Vault
+  public_name: ${user.preferences['zenodo|public_name']}
   writable: true
 
 - type: onedata

--- a/templates/galaxy/config/file_sources_conf.yml.j2
+++ b/templates/galaxy/config/file_sources_conf.yml.j2
@@ -271,6 +271,16 @@
   public_name: ${user.preferences['zenodo|public_name']}
   writable: true
 
+- type: inveniordm
+  id: zenodo_sandbox
+  doc: This is the Sandbox instance of Zenodo. It is used for testing purposes only, content is NOT preserved. DOIs created in this instance are not real and will not resolve.
+  label: Zenodo Sandbox (TESTING ONLY)
+  url: https://sandbox.zenodo.org
+  token: ${user.user_vault.read_secret('preferences/zenodo_sandbox/token')}
+  # token: ${user.preferences['zenodo_sandbox|token']} # Alternatively use this for retrieving the token from user preferences instead of the Vault
+  public_name: ${user.preferences['zenodo_sandbox|public_name']}
+  writable: true
+
 - type: onedata
   id: onedata1
   label: Onedata


### PR DESCRIPTION
Replaces the current `invenio_sandbox` plugin for testing the integration with the real `zenodo` integration.

As a note, the way of properly setting up the different places to store or retrieve the token (Vault or User Preferences) in `file_sources_conf.yml` is as follows:
- User preferences:
  ```
  token: ${user.preferences['zenodo|token']}
  ```
- Vault:
  ```
  token: ${user.user_vault.read_secret('preferences/zenodo/token')}
  ```
At this point, there is an issue in the plugin that will force the use of the Vault, so this setting is currently ignored but must be present. It will be fixed upstream.