### PR TITLE
increase database_engine_option_pool_size

### DIFF
--- a/group_vars/gxconfig.yml
+++ b/group_vars/gxconfig.yml
@@ -52,12 +52,12 @@ base_app_main: &BASE_APP_MAIN
   # If the server logs errors about not having enough database pool
   # connections, you will want to increase these values, or consider
   # running more Galaxy processes.
-  database_engine_option_pool_size: 20
+  database_engine_option_pool_size: 30
 
   # If the server logs errors about not having enough database pool
   # connections, you will want to increase these values, or consider
   # running more Galaxy processes.
-  database_engine_option_max_overflow: 20
+  database_engine_option_max_overflow: 40
 
   # If using MySQL and the server logs the error "MySQL server has gone
   # away", you will want to set this to some positive value (7200 should


### PR DESCRIPTION
I see those errors in the log of 24.0 https://gist.github.com/bgruening/867f6feab9a97c0112188ca9a6014865

sqlalchemy.exc.TimeoutError: QueuePool limit of size 20 overflow 20 reached, connection timed out, timeout 30.00 (Background on this error at: https://sqlalche.me/e/14/3o7r)