### PR TITLE
add dnb10 to the galaxy object store and disable (weight="0") dnb09

### DIFF
--- a/templates/galaxy/config/object_store_conf.xml.j2
+++ b/templates/galaxy/config/object_store_conf.xml.j2
@@ -170,7 +170,7 @@ The storage consists of 16 Gen6 type A200 storage nodes and 16 Gen5 type X410 no
             <!-- this is ws02 on the Netapp side and should not be used anymore, oo -->
             <extra_dir type="job_work" path="/data/jwd03f/main"/>
         </backend>
-        <backend id="files23" type="disk" weight="2" store_by="uuid">
+        <backend id="files23" type="disk" weight="0" store_by="uuid">
             <badges>
                 <more_stable />
                 <!--backed_up></backed_up-->
@@ -183,7 +183,7 @@ The storage consists of 16 Gen6 type A200 storage nodes and 16 Gen5 type X410 no
             <files_dir path="/data/dnb09/galaxy_db/files"/>
             <extra_dir type="job_work" path="/data/jwd02f/main"/>
         </backend>
-        <backend id="files24" type="disk" weight="2" store_by="uuid">
+        <backend id="files24" type="disk" weight="0" store_by="uuid">
             <badges>
                 <more_stable />
             </badges>
@@ -197,6 +197,26 @@ The storage consists of 16 Gen6 type A200 storage nodes and 16 Gen5 type X410 no
         <backend id="files26" type="disk" weight="0" store_by="uuid">
             <files_dir path="/data/dnb09/galaxy_db/files"/>
             <extra_dir type="job_work" path="/data/jwd04/main"/>
+        </backend>
+        <backend id="files27" type="disk" weight="2" store_by="uuid">
+            <badges>
+                <more_stable />
+                <!--backed_up></backed_up-->
+                <!--faster /-->
+                <!--less_stable /-->
+                <!--not_backed_up /-->
+                <!--less_secure>University of Freiburg enterprise level data security policies and montioring have not yet been integrated with this storage.</less_secure-->
+                <!--short_term>The data stored here is purged after a month.</short_term-->
+            </badges>
+            <files_dir path="/data/dnb10/galaxy_db/files"/>
+            <extra_dir type="job_work" path="/data/jwd02f/main"/>
+        </backend>
+        <backend id="files28" type="disk" weight="2" store_by="uuid">
+            <badges>
+                <more_stable />
+            </badges>
+            <files_dir path="/data/dnb10/galaxy_db/files"/>
+            <extra_dir type="job_work" path="/data/jwd05e/main"/>
         </backend>
 
         <backend id="secondary" type="disk" weight="0" store_by="id">
@@ -213,7 +233,7 @@ The storage consists of 16 Gen6 type A200 storage nodes and 16 Gen5 type X410 no
 
         <backend type="generic_s3" id="s3_netapp01" allow_selection="false" weight="0" store_by="uuid" name="Short term storage for method development">
             <description>S3 based objetct storage matained by the compute center of the University of Freiburg.
-                         This storage is purged weekly and so it is only appropriate for short term methods development and such. 
+                         This storage is purged weekly and so it is only appropriate for short term methods development and such.
                          The rapid deletion of stored data enables us to provide this storage without a quota.
                          More information about our storage offerings can be found [here](https://galaxyproject.org/eu/).
             </description>


### PR DESCRIPTION
Before deploying this:
1. Make sure to merge this (https://github.com/usegalaxy-eu/mounts/pull/13) first.
2. Run the sn06 Jenkins project and test the mount works on sn06.
3. Add the new mount to all the running VMs in Galaxy's compute cluster; use `pssh`
4. Finally, merge this PR and run the sn06 Jenkins project to update the object store

This PR will disable the object stores that are currently active (`weight>0`) and use `dnb09` by setting `weight="0"` and adding new `files27` and `files28` object stores and are configured to use `dnb10`. We are migrating from `dnb09` because we have used `>900TiB` and the limit is `1PiB`