### PR TITLE
optimize stop-ITs.sh.j2

### DIFF
--- a/roles/usegalaxy-eu.fix-stop-ITs/templates/stop-ITs.sh.j2
+++ b/roles/usegalaxy-eu.fix-stop-ITs/templates/stop-ITs.sh.j2
@@ -3,7 +3,7 @@ TODAY=$(date +"%d-%m-%y %H:%M:%S")
 DAY=86400
 . {{ galaxy_root }}/.bashrc
 cd ~
-for job in $(gxadmin query queue-detail --all | grep running | grep interactive_tool | awk '{print $3}')
+for job in $(gxadmin query queue-detail | grep running | grep interactive_tool | awk '{print $3}')
 do
     # Get job working directory
     JWD=$(python3 /usr/local/bin/galaxy_jwd get $job)


### PR DESCRIPTION
The --all is not needed, as we do not need the jobs in new state.