### PR TITLE
Increase the time for Galaxy cleanup again

### DIFF
--- a/roles/usegalaxy-eu.galaxy-cleanup/tasks/main.yml
+++ b/roles/usegalaxy-eu.galaxy-cleanup/tasks/main.yml
@@ -5,9 +5,9 @@
         plugin: "exec"
         config:
           - commands = ["{{ custom_telegraf_env }} /usr/bin/gxadmin galaxy cleanup 60"]
-          - timeout = "1h"
+          - timeout = "6h"
           - data_format = "influx"
-          - interval = "6h"
+          - interval = "48h"
 
 - set_fact:
         telegraf_plugins_extra: "{{ telegraf_plugins_extra | combine(plugin_config_galaxy_cleanup) }}"


### PR DESCRIPTION
I don't know why we decreased it 5 years ago.

If we purge datasets older than 60days, I think we can do it less frequently and maybe avoid the long-running, maybe overlapping transactions. 

A counterargument would be that once every 2 days more datasets need to be deleted at once, producing more IO spikes? I don't know.

@sanjaysrikakulam this job should run on the maintenance node.