### PR TITLE
configure MQ to allow TLS v1.3 and v1.2 only 

### DIFF
--- a/group_vars/mq.yml
+++ b/group_vars/mq.yml
@@ -136,6 +136,9 @@ rabbitmq_config:
     keyfile: /etc/ssl/user/privkey-rabbitmq.pem
     verify: verify_peer
     fail_if_no_peer_cert: "false"
+    versions:
+      - tlsv1.3
+      - tlsv1.2
   management_agent:
     disable_metrics_collector: "false"
   management:

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -107,7 +107,7 @@ roles:
   - name: usegalaxy_eu.rustus
     version: 0.3.0
   - name: usegalaxy_eu.rabbitmqserver
-    version: 1.4.4
+    version: 1.4.5
   - name: usegalaxy_eu.influxdbserver
     version: 1.1.1
   - name: usegalaxy_eu.flower


### PR DESCRIPTION
Reconfigure MQ to disallow old TLS versions.

New role version: https://github.com/usegalaxy-eu/ansible-rabbitmq/pull/7

I am not 100% sure how this change will impact us. 

