### PR TITLE
Add galaxy tool-usage gxadmin query to telegraf to monitor the tool usage

### DIFF
--- a/group_vars/maintenance.yml
+++ b/group_vars/maintenance.yml
@@ -227,7 +227,7 @@ telegraf_plugins_extra:
       - commands = ["{{ custom_telegraf_env }} /usr/bin/gxadmin iquery tool-usage"]
       - timeout = "360s"
       - data_format = "influx"
-      - interval = "12h"
+      - interval = "24h"
   galaxy_job_queue_states_stats:
     plugin: "exec"
     config:

--- a/group_vars/maintenance.yml
+++ b/group_vars/maintenance.yml
@@ -221,6 +221,13 @@ telegraf_plugins_extra:
       - timeout = "15s"
       - data_format = "influx"
       - interval = "1m"
+  galaxy_tool_usage:
+    plugin: "exec"
+    config:
+      - commands = ["{{ custom_telegraf_env }} /usr/bin/gxadmin iquery tool-usage"]
+      - timeout = "360s"
+      - data_format = "influx"
+      - interval = "12h"
   galaxy_job_queue_states_stats:
     plugin: "exec"
     config:


### PR DESCRIPTION
For this dashboard: https://stats.galaxyproject.eu/d/DYDPhX-Sk/tool-usage-stats?orgId=1

_Note: Interval is set to 12hrs._ 