### PR TITLE
set database_engine_option_pool_recycle to some positive value

### DIFF
--- a/group_vars/gxconfig.yml
+++ b/group_vars/gxconfig.yml
@@ -62,7 +62,8 @@ base_app_main: &BASE_APP_MAIN
   # If using MySQL and the server logs the error "MySQL server has gone
   # away", you will want to set this to some positive value (7200 should
   # work).
-  #database_engine_option_pool_recycle: -1
+  # We enabled this to circumvent some installation issues of tools, should be reverted when we update PG from version 13
+  database_engine_option_pool_recycle: 360
 
   # If large database query results are causing memory or response time
   # issues in the Galaxy process, leave the result on the server


### PR DESCRIPTION
We enabled this to circumvent some installation issues of tools, should be reverted when we update PG from version 13