### PR TITLE
Add a script to process galaxy tool-usage output from gxadmin to the influx line protocol

### DIFF
--- a/group_vars/maintenance.yml
+++ b/group_vars/maintenance.yml
@@ -149,6 +149,7 @@ fsm_scripts:
 fsm_htcondor_enable: true
 
 # Role: dj-wasabi.telegraf
+telegraf_agent_metric_buffer_limit: 20000
 telegraf_agent_hostname: "{{ hostname }}"
 telegraf_agent_version: 1.17.2
 custom_telegraf_env: "/usr/bin/env GDPR_MODE=1 PGUSER={{ galaxy_user.name }} PGHOST={{ postgres_host }} GALAXY_ROOT={{ galaxy_server_dir }} GALAXY_CONFIG_FILE={{ galaxy_config_file }} GXADMIN_PYTHON={{ galaxy_venv_dir }}/bin/python"
@@ -224,7 +225,7 @@ telegraf_plugins_extra:
   galaxy_tool_usage:
     plugin: "exec"
     config:
-      - commands = ["{{ custom_telegraf_env }} /usr/bin/gxadmin iquery tool-usage"]
+      - commands = ["{{ custom_telegraf_env }} /usr/bin/galaxy_tool_usage"]
       - timeout = "360s"
       - data_format = "influx"
       - interval = "24h"

--- a/roles/hxr.monitor-galaxy/files/galaxy_tool_usage.sh
+++ b/roles/hxr.monitor-galaxy/files/galaxy_tool_usage.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Description: This script will collect the usage of galaxy tools and formats the output to influxdb line protocol
+
+gxadmin csvquery tool-usage | awk -F, '{split($1, a, "/"); if (length(a) > 1) {tool_id = a[length(a)-1]; version = a[length(a)]} else {tool_id = $1; version = "unknown"}; gsub(/ /, "\\ ", tool_id); gsub(/ /, "\\ ", version); print "tool-usage,tool_id=" tool_id ",version=" version " count=" $2 " " systime() "000000000"}'

--- a/roles/hxr.monitor-galaxy/tasks/main.yml
+++ b/roles/hxr.monitor-galaxy/tasks/main.yml
@@ -14,3 +14,11 @@
     owner: root
     group: root
     mode: 0755
+
+- name: Copy the galaxy tool-usage script
+  copy:
+    src: "galaxy_tool_usage.sh"
+    dest: "/usr/bin/galaxy_tool_usage"
+    owner: root
+    group: root
+    mode: 0755


### PR DESCRIPTION
1. Adds a bash script and an ansible copy task to the `hxr.monitor-galaxy` role.
2. Updates the "metric_buffer_limit" to 20000 [(default is 10000)](https://github.com/dj-wasabi/ansible-telegraf/blob/master/defaults/main.yml#L36) so there will not be an overflow error/warning from telegraf like seen below.

```
2024-06-10T07:41:17Z W! [outputs.influxdb] Metric buffer overflow; 410 metrics have been dropped
2024-06-10T07:41:28Z W! [agent] ["outputs.influxdb"] did not complete within its flush interval
```

The [dashboard](https://stats.galaxyproject.eu/d/DYDPhX-Sk/tool-usage-stats?orgId=1) will be updated to handle the updated values (It was initially not designed to use only the last entry).