### PR TITLE
define resource for the tool falco in TPV

### DIFF
--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -1411,3 +1411,7 @@ tools:
 
   toolshed.g2.bx.psu.edu/repos/iuc/humann/humann/.*:
     cores: 12
+
+  # Tool is same as fastqc so setting the same resources
+  toolshed.g2.bx.psu.edu/repos/iuc/falco/falco/.*:
+    cores: 3


### PR DESCRIPTION
@DeeptiVarshney had issues running this tool with default resources. So, I am allocating the same resources as `fastqc`. 