### PR TITLE
Add conda scheduling tags for the tool psortb

### DIFF
--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -1415,3 +1415,9 @@ tools:
   # Tool is same as fastqc so setting the same resources
   toolshed.g2.bx.psu.edu/repos/iuc/falco/falco/.*:
     cores: 3
+
+  toolshed.g2.bx.psu.edu/repos/peterjc/tmhmm_and_signalp/Psortb/.*:
+    scheduling:
+      require:
+        - conda
+        - singularity


### PR DESCRIPTION
@jennaj reported that the tool is not working, and there is also a discussion of the same in the [Galaxy help](https://help.galaxyproject.org/t/psortb-error-on-usegalaxy-eu/12639/3).

This PR adds the scheduling tags `conda` and `singularity` as the tool is available in a conda env.

After activating the environment, I tested the version print, which seems "to work" (the tool is printing the usage instead of the version; I also ran the command `psort` directly, and even that is printing only the usage and not the version).  

```
galaxy@sn06:~$ . '/usr/local/tools/_conda/bin/activate' '/usr/local/tools/_conda/envs/__psortb@_uv_'/

__psortb@_uv_) galaxy@sn06:~$ python /opt/galaxy/shed_tools/toolshed.g2.bx.psu.edu/repos/peterjc/tmhmm_and_signalp/e1996f0f4e85/tmhmm_and_signalp/tools/protein_analysis/psortb.py --version
Usage: _psort [-p|-n] [OPTIONS] [SEQFILE]
Runs _psort on the sequence file SEQFILE .  If SEQFILE isn't provided
then sequences will be read from STDIN.
  --help, -h        Displays usage information
  --positive, -p    Gram positive bacteria
  --negative, -n    Gram negative bacteria
  --archaea, -a     Archaea
  --cutoff, -c      Sets a cutoff value for reported results
  --divergent, -d   Sets a cutoff value for the multiple
                    localization flag
  --matrix, -m      Specifies the path to the pftools instalation.  If
                    not set, defaults to the value of the PSORT_PFTOOLS
                    environment variable.
  --format, -f      Specifies sequence format (default is FASTA)
  --exact, -e       Skip SCLBLASTe (useful for batch runs of data
                    against itself in SCLBLAST)
  --output, -o      Specifies the format for the output (default is
                    'normal'  Value can be one of: terse, long or normal
  --root, -r        Specify PSORT_ROOT for running local copies.  If
                    not set, defaults to the value of the PSORT_ROOT
                    environment variable.
  --server, -s      Specifies the PSort server to use
  --verbose, -v     Be verbose while running
  --x-skip-localization
  --version         Print the version of PSortb
```