### PR TITLE
Disable cyfronet's S3 ObjectStore

### DIFF
--- a/templates/galaxy/config/object_store_conf.xml.j2
+++ b/templates/galaxy/config/object_store_conf.xml.j2
@@ -251,6 +251,7 @@ The storage consists of 16 Gen6 type A200 storage nodes and 16 Gen5 type X410 no
             <extra_dir type="temp" path="/data/jwd02f/tmp"/>
         </backend>
 
+        <!--
         <backend type="generic_s3" id="s3_cyfronet01" allow_selection="false" weight="0" store_by="uuid">
             <badges>
                 <less_stable />
@@ -265,6 +266,7 @@ The storage consists of 16 Gen6 type A200 storage nodes and 16 Gen5 type X410 no
             <extra_dir type="job_work" path="/data/jwd02f/main"/>
             <extra_dir type="temp" path="/data/jwd02f/tmp"/>
         </backend>
+        -->
 
     </backends>
 </object_store>


### PR DESCRIPTION
There were SSL certificate-related issues during the set metadata step of jobs. After communicating this with Cyfronet, enable it.

The error log: https://gist.github.com/bgruening/9fc669ab7922118ed4857ccdbfa3619f

Marius said, "The entire object store configuration is initialized when using extended metadata". Therefore, even when the ObjectStore's `weight` was set to `0`, the S3 store was initialized. 