### PR TITLE
Use role `grycap.htcondor` from usegalaxy-eu organization

### DIFF
--- a/requirements.yaml
+++ b/requirements.yaml
@@ -92,7 +92,7 @@ roles:
   - name: usegalaxy_eu.htcondor
     version: 1.0.1
   - name: grycap.htcondor
-    src: https://github.com/kysrpex/grycap-ansible-role-htcondor
+    src: https://github.com/usegalaxy-eu/ansible-htcondor-grycap
     version: d9a4aab0052dfb31d48c986d39a7f5e3692abba4
   - name: usegalaxy-eu.update-hosts
     src: https://github.com/usegalaxy-eu/ansible-update-hosts


### PR DESCRIPTION
As part of the migration to HTCondor 23, the role managing HTCondor was switched from `usegalaxy_eu.htcondor` to `grycap.htcondor`. I forked it and added linting and a couple of tests on top, and that fork is what useGalaxy.eu is running today.

However, the entry for `grycap.htcondor` in requirements.yaml still points to that fork https://github.com/kysrpex/grycap-ansible-role-htcondor on my personal account. This is wrong for many reasons.

This commit changes the source URL of the role to a [fork on the usegalaxy-eu organization](https://github.com/usegalaxy-eu/ansible-htcondor-grycap).

Useful information from the GitHub docs: [What happens to forks when a repository is deleted or changes visibility?](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/what-happens-to-forks-when-a-repository-is-deleted-or-changes-visibility#deleting-a-public-repository)