### PR TITLE
Allow hosts stats, sn06, maintenance to access the grafana DB in PG

### DIFF
--- a/group_vars/sn05.yml
+++ b/group_vars/sn05.yml
@@ -96,4 +96,7 @@ postgresql_pg_hba_conf:
   - "host    apollo          apollo          10.5.67.0/24            md5"
   - "host    chado           apollo          10.5.67.0/24            md5"
   - "host    grt             grt             10.5.68.0/24            md5"
+  - "host    grafana         grafana         192.52.32.145/32        md5"
+  - "host    grafana         grafana         132.230.223.239/32      md5"
+  - "host    grafana         grafana         10.5.67.211/32          md5"
 postgresql_pgdump_dir: "/var/lib/pgsql/pgdump2"


### PR DESCRIPTION
Updates pg_hba.conf to grant access to the grafana DB in PG to all currently Grafana-related hosts.