### PR TITLE
Run hicexplorer_hicinfo in Singularity

### DIFF
--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -1421,3 +1421,8 @@ tools:
       require:
         - conda
         - singularity
+
+  toolshed.g2.bx.psu.edu/repos/bgruening/hicexplorer_hicinfo/hicexplorer_hicinfo/.*:
+    scheduling:
+      require:
+        - singularity


### PR DESCRIPTION
@lldelisle Reported that hicexplorer_hicinfo is not working on useGalaxy.eu due to [this issue](https://github.com/deeptools/HiCExplorer/issues/853) and suggested running it, instead of conda, in a container, which works fine.