### PR TITLE
Update plausible domain value to start tracking the user demographic info on EU

### DIFF
--- a/group_vars/gxconfig.yml
+++ b/group_vars/gxconfig.yml
@@ -928,7 +928,7 @@ base_app_main: &BASE_APP_MAIN
 
   # Please enter the URL for the Galaxy server so this can be used for
   # tracking with Plausible (https://plausible.io/).
-  plausible_domain: https://usegalaxy.eu
+  plausible_domain: usegalaxy.eu
 
   # Please enter the URL for the Matomo server (including https) so this
   # can be used for tracking with Matomo (https://matomo.org/).


### PR DESCRIPTION
Tested the same with the ESG instance, and without `https` in the domain var value works.