### PR TITLE
Enable path-based interactive tools

### DIFF
--- a/group_vars/sn06.yml
+++ b/group_vars/sn06.yml
@@ -233,6 +233,7 @@ gie_proxy_nodejs_version: "10.13.0"
 gie_proxy_virtualenv: "{{ galaxy_root }}/gie-proxy/venv"
 gie_proxy_setup_service: systemd
 gie_proxy_sessions_path: "{{ galaxy_mutable_data_dir }}/interactivetools_map.sqlite"
+gie_proxy_path_prefix: /interactivetool/ep
 gie_proxy_port: 8800
 gie_proxy_verbose: true
 

--- a/group_vars/sn07.yml
+++ b/group_vars/sn07.yml
@@ -287,6 +287,7 @@ gie_proxy_nodejs_version: "10.13.0"
 gie_proxy_virtualenv: "{{ galaxy_root }}/gie-proxy/venv"
 gie_proxy_setup_service: systemd
 gie_proxy_sessions_path: "{{ galaxy_mutable_data_dir }}/interactivetools_map.sqlite"
+gie_proxy_path_prefix: /interactivetool/ep
 gie_proxy_port: 8800
 gie_proxy_verbose: true
 

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -98,7 +98,7 @@ roles:
     src: https://github.com/usegalaxy-eu/ansible-update-hosts
     version: 0.2.0
   - name: usegalaxy_eu.gie_proxy
-    version: 0.0.2
+    version: 0.1.0
   - name: usegalaxy-eu.autofs
     src: https://github.com/usegalaxy-eu/ansible-autofs
     version: 1.0.0

--- a/templates/nginx/galaxy-ie-main.j2
+++ b/templates/nginx/galaxy-ie-main.j2
@@ -17,7 +17,7 @@ server {
 	access_log /var/log/nginx/interactive.log;
 
 	location / {
-		proxy_pass http://127.0.0.1:8800;
+		proxy_pass http://127.0.0.1:{{ gie_proxy_port }};
 		proxy_redirect off;
 		proxy_http_version 1.1;
 		proxy_set_header Host $host;

--- a/templates/nginx/galaxy-main.j2
+++ b/templates/nginx/galaxy-main.j2
@@ -181,6 +181,16 @@ server {
 		proxy_set_header Connection "upgrade";
 	}
 
+	# Route all path-based interactive tool requests to the InteractiveTool proxy application
+    location ~* ^/(interactivetool/.+)$ {
+        proxy_redirect off;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_pass http://127.0.0.1:{{ gie_proxy_port }};
+    }
 
 	location /.well-known/ {
 		proxy_set_header           Host $host:$server_port;


### PR DESCRIPTION
Enable access via path (e.g. `https://usegalaxy.eu/interactivetool/ep/3qg8nstfnl44r/fsjbqy66kln5`) to interactive tools that support it (those for which `requires_domain="False"` in the tool's xml file).

More information:
- nginx configuration: https://docs.galaxyproject.org/en/master/admin/special_topics/interactivetools.html#nginx-proxy-server-configuration-in-production
- interactive tools proxy configuration: https://github.com/galaxyproject/galaxy/pull/18481#issuecomment-2217313953, https://github.com/galaxyproject/gx-it-proxy/blob/v0.0.6/lib/proxy.js#L101-L141, https://github.com/galaxyproject/gx-it-proxy/blob/v0.0.6/lib/main.js#L16

Related commit: [usegalaxy-eu/galaxy@e216b45](https://github.com/usegalaxy-eu/galaxy/commit/e216b4549be02a12c16d50313935ad0dfa073b90#comments)