### PR TITLE
Enable and add user file sources and object store features to EU

### DIFF
--- a/group_vars/gxconfig.yml
+++ b/group_vars/gxconfig.yml
@@ -364,7 +364,7 @@ base_app_main: &BASE_APP_MAIN
   # Configured Object Store templates configuration file.
   # The value of this option will be resolved with respect to
   # <config_dir>.
-  # object_store_templates_config_file: 'object_store_templates.yml'
+  object_store_templates_config_file: '{{ galaxy_config_dir }}/object_store_templates.yml'
 
   # Configured Object Store templates embedded into Galaxy's config.
   #object_store_templates: null
@@ -372,7 +372,7 @@ base_app_main: &BASE_APP_MAIN
   # Configured user file source templates configuration file.
   # The value of this option will be resolved with respect to
   # <config_dir>.
-  # file_source_templates_config_file: 'file_source_templates.yml'
+  file_source_templates_config_file: '{{ galaxy_config_dir }}/file_source_templates.yml'
 
   # Configured user file source templates embedded into Galaxy's config.
   #file_source_templates: null
@@ -767,11 +767,11 @@ base_app_main: &BASE_APP_MAIN
   # for that object store entry.
   # The value of this option will be resolved with respect to
   # <cache_dir>.
-  #object_store_cache_path: object_store_cache
+  object_store_cache_path: '/data/jwd02f/s3_object_store_cache'
 
   # Default cache size for caching object stores if cache not configured
   # for that object store entry.
-  #object_store_cache_size: -1
+  object_store_cache_size: 10000
 
   # Set this to true to indicate in the UI that a user's object store
   # selection isn't simply a "preference" that job destinations often

--- a/group_vars/sn06.yml
+++ b/group_vars/sn06.yml
@@ -467,3 +467,7 @@ galaxy_config_templates:
     dest: "{{ tpv_mutable_dir }}/destinations.yml"
   - src: '{{ galaxy_config_template_src_dir }}/config/vault_conf.yml.j2'
     dest: '{{ galaxy_config_dir }}/vault_conf.yml'
+  - src: '{{ galaxy_config_template_src_dir }}/config/file_source_templates.yml.j2'
+    dest: "{{ galaxy_config['galaxy']['file_source_templates_config_file'] }}"
+  - src: '{{ galaxy_config_template_src_dir }}/config/object_store_templates.yml.j2'
+    dest: "{{ galaxy_config['galaxy']['object_store_templates_config_file'] }}"

--- a/templates/galaxy/config/file_source_templates.yml.j2
+++ b/templates/galaxy/config/file_source_templates.yml.j2
@@ -1,0 +1,6 @@
+# This is a catalog file for all the user file source templates that are offered by EU's Galaxy server.
+- include: "{{ galaxy_server_dir }}/lib/galaxy/files/templates/examples/production_azure.yml"
+- include: "{{ galaxy_server_dir }}/lib/galaxy/files/templates/examples/production_ftp.yml"
+- include: "{{ galaxy_server_dir }}/lib/galaxy/files/templates/examples/production_s3fs.yml"
+- include: "{{ galaxy_server_dir }}/lib/galaxy/files/templates/examples/production_aws_private_bucket.yml"
+- include: "{{ galaxy_server_dir }}/lib/galaxy/files/templates/examples/production_aws_public_bucket.yml"

--- a/templates/galaxy/config/object_store_templates.yml.j2
+++ b/templates/galaxy/config/object_store_templates.yml.j2
@@ -1,0 +1,5 @@
+# This is a catalog file for all the user object store templates that are offered by EU's Galaxy server.
+- include: "{{ galaxy_server_dir }}/lib/galaxy/objectstore/templates/examples/production_azure_blob.yml"
+- include: "{{ galaxy_server_dir }}/lib/galaxy/objectstore/templates/examples/production_aws_s3.yml"
+- include: "{{ galaxy_server_dir }}/lib/galaxy/objectstore/templates/examples/production_generic_s3.yml"
+- include: "{{ galaxy_server_dir }}/lib/galaxy/objectstore/templates/examples/production_gcp_s3.yml"


### PR DESCRIPTION
This PR:
1. Enables the user file source and object store features in usegalaxy.eu
2. Add the respective template catalogs
3. Configures the object store cache path and the size. The cache path is set to `/data/jwd02f/s3_object_store_cache`, and the size (in GiB) is set to `10000`. Both values are based on the object store conf we have [here](https://github.com/usegalaxy-eu/infrastructure-playbook/blob/master/templates/galaxy/config/object_store_conf.xml.j2#L234-L251).
4. sn06 group_vars is updated to copy the catalog files to the galaxy config directory

**Important**
1. We use the templates that are defined as "production" in the Galaxy codebase 
2. Only non-legacy (`boto3`) production templates are included in the catalog files (for an available list of templates, refer: [file source templates](https://github.com/usegalaxy-eu/galaxy/tree/release_24.1_europe/lib/galaxy/files/templates/examples), and [object store templates](https://github.com/usegalaxy-eu/galaxy/tree/release_24.1_europe/lib/galaxy/objectstore/templates/examples))
3. We do not copy or maintain a copy of these templates in our Galaxy conf; rather, in the catalog, we refer to/include the ones in the Galaxy code base (in EU `/opt/galaxy/server/`).

**To do on the venv:** I did the following on the ESG instance to get the non-legacy templates to work. The non-legacy templates depend on the `boto3` package, whereas the legacy templates depend on `boto version 2`.

1. To get the non-legacy templates to work, we must modify Galaxy's `venv` (ping @bgruening). Non-legacy templates need `boto3` to work, and `boto3` is installed as a [conditional dependency](https://github.com/galaxyproject/galaxy/blob/dev/lib/galaxy/dependencies/conditional-requirements.txt#L66) and gets installed only when a [`boto3` type object store](https://github.com/galaxyproject/galaxy/blob/dev/lib/galaxy/dependencies/__init__.py#L237-L238) is defined in the `object_store_conf` or when [`AWSBatchJobRunner`](https://github.com/galaxyproject/galaxy/blob/dev/lib/galaxy/dependencies/__init__.py#L213-L214) is used in the `job_conf`. We need to modify the dependencies in our fork. The below is just a couple of manual things I did for testing.

``` bash
# Activate the venv
. /opt/galaxy/venv/bin/activate

# Uninstall boto related packages
pip uninstall boto botocore aiobotocore

# Install boto3
pip install boto3 aiobotocore

# Restart handlers and gunicorns
```

Once this is done, we should be able to see two new features (like in the image below) in the `User` -> `Preferences`

![image](https://github.com/user-attachments/assets/9824e8db-7c4b-458f-a34f-3de9e75da64d)

and for the user object store, the non-legacy templates (ignore the legacy templates in the image below; this is from the ESG instance)

![image](https://github.com/user-attachments/assets/4758e0ed-f2c1-4e0b-aaaa-85618550e818)

and for the user file sources, 

![image](https://github.com/user-attachments/assets/aaf2608b-04a2-41e1-84aa-0f8fd98bd21f)


