### PR TITLE
TPV: Configure tmp dir for funannotate_annotate tool

### DIFF
--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -1313,8 +1313,8 @@ tools:
     inherits: basic_docker_tool
     cores: 8
     mem: 42
-    params:
-      docker_run_extra_arguments: "--mount type=tmpfs,tmpfs-size=2147483648,destination=/tmp"
+    env:
+      _GALAXY_JOB_TMP_DIR: '/tmp'
     rules:
       - id: funannotate_annotate_large_input
         if: input_size > 3.2


### PR DESCRIPTION
Through this PR, I am trying to address a similar [issue](https://github.com/usegalaxy-eu/issues/issues/576) for `funannotate_annotate`.

A similar [fix](https://github.com/usegalaxy-eu/infrastructure-playbook/pull/1262) was deployed for the `squidpy_spatial` and worked.