### PR TITLE
Add `ssh-host-sign` and `dev-sec.ssh-hardening` roles to grafana.yml playbook

### DIFF
--- a/grafana.yml
+++ b/grafana.yml
@@ -40,6 +40,10 @@
         hostname: "{{ grafana_domain }}"
         enable_hostname: true
         enable_powertools: true         # geerlingguy.repo-epel role doesn't enable PowerTools repository
+    - role: ssh-host-sign
+      become: true
+    - role: dev-sec.ssh-hardening
+      become: true
     - role: geerlingguy.repo-epel     # Install EPEL repository
       become: true
     - role: usegalaxy-eu.autoupdates  # keep all of our packages up to date


### PR DESCRIPTION
Sign stats ssh host keys with ca and advertise them to clients. Should fix the [stats-grafana Jenkins project](https://build.galaxyproject.eu/job/usegalaxy-eu/job/playbooks/job/stats-grafana/1296/) (prev. manual run of course).