### PR TITLE
Disable provisioning Grafana dashboards from usegalaxy-eu/grafana-dashboards

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "mounts"]
 	path = mounts
 	url = https://github.com/usegalaxy-eu/mounts
-[submodule "files/grafana"]
-	path = files/grafana
-	url = https://github.com/usegalaxy-eu/grafana-dashboards.git


### PR DESCRIPTION
Remove [usegalaxy-eu/grafana-dashboards](https://github.com/usegalaxy-eu/grafana-dashboards) Git submodule. This is [one of the tasks from usegalaxy-eu/issues#558](https://github.com/usegalaxy-eu/issues/issues/558#issuecomment-2216917962). At the moment all dashboards have been saved to PostgreSQL.