### PR TITLE
Upgrade collection `grafana.grafana` to v5.3.0

### DIFF
--- a/grafana.yml
+++ b/grafana.yml
@@ -88,25 +88,6 @@
           - "{{ ansible_ssh_user }}"
 
   post_tasks:
-    # The `[unified_alerting]` section of grafana.ini is not populated by the
-    # `grafana.grafana.grafana` role yet. It will be when PR [1] is merged. In
-    # the meantime, it is populated with this post-task.
-    #
-    # References:
-    # - [1] https://github.com/grafana/grafana-ansible-collection/pull/215
-    - name: Write Grafana unified alerting settings to grafana.ini (grafana.grafana.grafana)
-      become: true
-      community.general.ini_file:
-        path: /etc/grafana/grafana.ini
-        section: unified_alerting
-        option: "{{ item.key }}"
-        value: "{{ item.value }}"
-        state: present
-        owner: "root"  # copied from `grafana.grafana.grafana` v5.2.0
-        group: "grafana"  # copied from `grafana.grafana.grafana` v5.2.0
-        mode: "0640"  # copied from `grafana.grafana.grafana` v5.2.0
-      loop: "{{ grafana_unified_alerting | default({}) | dict2items }}"
-
     - name: Open nginx ports
       become: true
       ansible.posix.firewalld:

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -19,9 +19,7 @@ collections:
     # Therefore, they have to be included in this file. @kysrpex opened an issue on the repository of the Grafana Ansible collection
     # https://github.com/grafana/grafana-ansible-collection/issues/222
     # notifying the developers of this issue.
-    version: cc9f61c0ae30c12eecf2af4696d95a84ea4565e1  # (from branch `main`)
-    source: https://github.com/usegalaxy-eu/ansible-grafana-collection-grafana.git
-    type: git
+    version: 5.3.0
   # - name: community.general  # required by `grafana.grafana` (already specified above)
   #   source: https://github.com/ansible-collections/community.general.git
   #   version: 9.0.1


### PR DESCRIPTION
Upgrade `grafana.grafana` from
[git+https://github.com/usegalaxy-eu/ansible-grafana-collection-grafana.git/,cc9f61c0ae30c12eecf2af4696d95a84ea4565e1](https://github.com/usegalaxy-eu/ansible-grafana-collection-grafana) ([usegalaxy-eu/ansible-grafana-collection](https://github.com/usegalaxy-eu/ansible-grafana-collection-grafana) fork) to latest official release, reason for change https://github.com/usegalaxy-eu/issues/issues/558#issuecomment-2248069738. Please note that, although it is not a problem because we are not using them anymore, this involves tasks "Import grafana dashboards via api" breaking and "Ensure datasources exist (via API)" not taking UIDs anymore.

Version 5.3.0 fixed the role `grafana.grafana.grafana` not populating the `[unified_alerting]` section of grafana.ini (https://github.com/grafana/grafana-ansible-collection/pull/215). Therefore, remove the post_task from the grafana.yml playbook that worked the issue around.

This fixes playbooks not working in Jenkins (e.g. [usegalaxy-eu/playbooks/sn06#1984](https://build.galaxyproject.eu/job/usegalaxy-eu/job/playbooks/job/sn06/1984/)).