### PR TITLE
TPV: add host tmp file system to funannotate_predict as env

### DIFF
--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -1333,6 +1333,7 @@ tools:
     mem: 12
     env:
       GENEMARK_PATH: /usr/local/tools/genemark/etp.for_braker/bin/gmes/
+      _GALAXY_JOB_TMP_DIR: '/tmp'
     params:
       singularity_run_extra_arguments: "--env GENEMARK_PATH=/usr/local/tools/genemark/etp.for_braker/bin/gmes/"
     scheduling:


### PR DESCRIPTION
addresses user bug report (job id `11ac94870d0bb33ac6848a5701fb44d2`): "OSError: [Errno 16] Device or resource busy: .nfs000000000125e40200103e69'"
