### PR TITLE
Use higher memory and cores for all FragPipe jobs

### DIFF
--- a/files/galaxy-test/tpv/tools.yml
+++ b/files/galaxy-test/tpv/tools.yml
@@ -817,14 +817,5 @@ tools:
         - conda
 
   toolshed.g2.bx.psu.edu/repos/galaxyp/fragpipe/fragpipe/.*:
-    cores: 8
-    mem: 56
-    rules:
-      - id: fragpipe_memory
-        if: |
-          parameters = {p.name: p.value for p in job.parameters}
-          parameters = tool.params_from_strings(parameters, app)
-          high_memory = parameters.get("high_memory", False)
-          high_memory
-        mem: 256
-        cores: 12
+    cores: 12
+    mem: 256


### PR DESCRIPTION
Until the corresponding Galaxy tool PR (https://github.com/galaxyproteomics/tools-galaxyp/pull/770) is merged, we'd like to increase resources across the board for FragPipe. Once the parameter is available on the tool, we can revert this PR and re-add the rule.