### PR TITLE
Add OpenAI API key field to user_preferences_extra_conf.yml

### DIFF
--- a/files/galaxy/config/user_preferences_extra_conf.yml
+++ b/files/galaxy/config/user_preferences_extra_conf.yml
@@ -303,7 +303,7 @@ preferences:
               required: False
 
     chatgpt:
-        description: Your ChatGPT API settings
+        description: Your OpenAI API key. This will be used for example for ChatGPT.
         inputs:
             - name: api_key
               label: API Key

--- a/files/galaxy/config/user_preferences_extra_conf.yml
+++ b/files/galaxy/config/user_preferences_extra_conf.yml
@@ -301,3 +301,11 @@ preferences:
               label: API Read Access Token
               type: password
               required: False
+
+    chatgpt:
+        description: Your ChatGPT API settings
+        inputs:
+            - name: api_key
+              label: API Key
+              type: password
+              required: False


### PR DESCRIPTION
Add OpenAI API key field as part of the ChatGPT tool (https://github.com/usegalaxy-eu/usegalaxy-eu-tools/pull/771).