### PR TITLE
TPV: Set tmp dir for episcanpy_build_matrix tool

### DIFF
--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -1453,3 +1453,12 @@ tools:
   toolshed.g2.bx.psu.edu/repos/galaxyp/fragpipe/fragpipe/.*:
     cores: 12
     mem: 256
+
+  toolshed.g2.bx.psu.edu/repos/iuc/episcanpy_build_matrix/episcanpy_build_matrix/.*:
+    env:
+      _GALAXY_JOB_TMP_DIR: '/tmp'
+    params:
+      singularity_no_mount: null
+    scheduling:
+      require:
+        - singularity


### PR DESCRIPTION
Issue: https://github.com/usegalaxy-eu/issues/issues/597

We applied the same solution in the past
1. https://github.com/usegalaxy-eu/infrastructure-playbook/pull/1302
2. https://github.com/usegalaxy-eu/infrastructure-playbook/pull/1284
3. https://github.com/usegalaxy-eu/infrastructure-playbook/pull/1262
4. https://github.com/usegalaxy-eu/infrastructure-playbook/pull/1263