### PR TITLE
Use cpus for small genomes with Helixer

### DIFF
--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -747,12 +747,14 @@ tools:
   toolshed.g2.bx.psu.edu/repos/genouest/helixer/helixer/.*:
     cores: 4
     mem: 30
-    gpus: 1
-    params:
-      singularity_run_extra_arguments: ' --nv '
     scheduling:
       require:
         - singularity
+    rules:
+      - if: input_size >= 0.2
+        gpus: 1
+        params:
+          singularity_run_extra_arguments: ' --nv '
 
   toolshed.g2.bx.psu.edu/repos/iuc/cherri_eval/cherri_eval/.*:
     inherits: basic_docker_tool


### PR DESCRIPTION
Hello, I hope it's ok to add this here. Please let me know if I've done something incorrect or out of place

Added case to helixer where it will only run using the gpu if the genome size is larger than 200Mb

These jobs can sit in the queue for a long time (sometimes days) as they require a gpu. I tested on budding yeast (12Mb --lineage fungi) using 4 cores and running Helixer in cpu mode and it ran pretty smoothly:

State: COMPLETED (exit code 0)
Nodes: 1
Cores per node: 4
CPU Utilized: 00:25:29
CPU Efficiency: 73.65% of 00:34:36 core-walltime
Job Wall-clock time: 00:08:39
Memory Utilized: 2.15 GB
Memory Efficiency: 7.16% of 30.00 GB

and for drosophila (140Mb --lineage invertebrate):

State: COMPLETED (exit code 0)
Nodes: 1
Cores per node: 4
CPU Utilized: 16:19:19
CPU Efficiency: 78.32% of 20:50:24 core-walltime
Job Wall-clock time: 05:12:36
Memory Utilized: 26.54 GB
Memory Efficiency: 88.46% of 30.00 GB
