### PR TITLE
Increase memory for cat_bins

### DIFF
--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -340,6 +340,12 @@ tools:
   toolshed.g2.bx.psu.edu/repos/iuc/fgsea/fgsea/.*:
     # any container should work
     inherits: basic_docker_tool
+  toolshed.g2.bx.psu.edu/repos/iuc/cat_bins/cat_bins/.*:
+    rules:
+      - if: input_size >= 0.03
+        mem: 48
+      - if: input_size >= 0.06
+        mem: 72
   toolshed.g2.bx.psu.edu/repos/iuc/chewbbaca.*:
     inherits: basic_docker_tool
   toolshed.g2.bx.psu.edu/repos/recetox/recetox_msfinder/recetox_msfinder/.*:

--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -342,9 +342,11 @@ tools:
     inherits: basic_docker_tool
   toolshed.g2.bx.psu.edu/repos/iuc/cat_bins/cat_bins/.*:
     rules:
-      - if: input_size >= 0.03
+      - id: cat_bins_medium_input_rule
+        if: input_size >= 0.03
         mem: 48
-      - if: input_size >= 0.06
+      - id: cat_bins_large_input_rule
+        if: input_size >= 0.06
         mem: 72
   toolshed.g2.bx.psu.edu/repos/iuc/chewbbaca.*:
     inherits: basic_docker_tool


### PR DESCRIPTION
Some of our cat_bin jobs were failing, most probably due to memory issues. I was looking for a while to find a logic that allows to define how to improve the rool for this (and other) tools. That's what I came up with: 

A) Query the tool-memory-per-inputs, but include the job state. Will try to add this option to gxadmin !

```sql
WITH job_cte AS (
    SELECT
        j.id,
        j.tool_id,
        j.state -- Include job state in the CTE
    FROM
        job j
    WHERE
        j.tool_id LIKE 'toolshed.g2.bx.psu.edu/repos/iuc/cat_bins/cat_bins/5.2.3+galaxy0'
        -- Removed the state filter to include all states
),
mem_cte AS (
    SELECT
        j.id,
        jmn.metric_value AS memory_used
    FROM
        job_cte j
    JOIN
        job_metric_numeric jmn ON j.id = jmn.job_id
    WHERE
        jmn.plugin = 'cgroup'
        AND
        jmn.metric_name = 'memory.memsw.max_usage_in_bytes'
),
data_cte AS (
    SELECT
        j.id,
        COUNT(jtid.id) AS input_count,
        SUM(d.total_size) AS total_input_size,
        AVG(d.total_size) AS mean_input_size,
        PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY d.total_size) AS median_input_size
    FROM
        job_cte j
    JOIN
        job_to_input_dataset jtid ON j.id = jtid.job_id
    JOIN
        history_dataset_association hda ON jtid.dataset_id = hda.id
    JOIN
        dataset d ON hda.dataset_id = d.id
    GROUP BY
        j.id
)
SELECT
    j.id,
    j.tool_id,
    j.state, -- Include job state in the output
    d.input_count,
    (d.total_input_size / 1024 / 1024)::bigint AS total_input_size_mb,
    (d.mean_input_size / 1024 / 1024)::bigint AS mean_input_size_mb,
    (d.median_input_size / 1024 / 1024)::bigint AS median_input_size_mb,
    (m.memory_used / 1024 / 1024)::bigint AS memory_used_mb,
    (m.memory_used / NULLIF(d.total_input_size, 0))::bigint AS memory_used_per_input_mb,
    (m.memory_used / NULLIF(d.mean_input_size, 0))::bigint AS memory_mean_input_ratio,
    (m.memory_used / NULLIF(d.median_input_size, 0))::bigint AS memory_median_input_ratio
FROM
    job_cte j
JOIN
    mem_cte m ON j.id = m.id
JOIN
    data_cte d ON j.id = d.id
ORDER BY
    j.id DESC;
```

B) Plot memory vs total input for all states:

![image](https://github.com/user-attachments/assets/d9dd3ddf-cd7d-46ae-b265-557bea790dc8)

10 % quantile threshold for the error states: 31.0 mb
Percentage below threshold of error state jobs: 0.125
Percentage below threshold of ok state jobs: 0.723

It is clear that many of the error states have higher input size. 

![image](https://github.com/user-attachments/assets/e5c9e42a-b7af-4099-92da-a72047b233c7)

With the new rule. > 70% of the ok state jobs would have run with the default 24 GB memory. But for almost 90 % of the failed states, the memory would have been increase - giving them a better chance to succeed. But surely some of them could fail due to other reasons.

If that makes sense I will increase some more tool memory based on the same logic. 

One question I got is, that I cannot observe jobs with higher memory for all failed jobs - so I guess the increasing memory for failed jobs rule is not in place after all, or am I missing something ? 