### PR TITLE
remove unused gitter bridge

### DIFF
--- a/grafana.yml
+++ b/grafana.yml
@@ -82,8 +82,6 @@
     - grafana
     - role: pgs
       become: true
-    - role: hxr.grafana-gitter-bridge
-      become: true
     - role: geerlingguy.docker
       become: true
       vars:


### PR DESCRIPTION
When I tried to figure out why jenkins is failing, I stumbled over this role
and I think we can safely remove it now