### PR TITLE
fix python linting using venv

### DIFF
--- a/.github/requirements-python-lint.txt
+++ b/.github/requirements-python-lint.txt
@@ -1,0 +1,3 @@
+isort~=5.0
+flake8~=6.0
+flake8-docstrings~=1.0

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -8,13 +8,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-     - name: Setup Python
-       uses: actions/setup-python@v5
-
-      - run: pip install --upgrade pip
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+          cache-dependency-path: '.github/requirements-python-lint.txt'
 
       - id: pip_install
-        run: pip install --upgrade isort~=5.0 flake8~=6.0 flake8-docstrings~=1.0
+        run: pip install -r '.github/requirements-python-lint.txt'
 
       - name: isort
         run: isort . --check --diff

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Create venv
         run: python3 -m venv .venv
-        
+
       - name: Activate virtualenv
         run: |
           . .venv/bin/activate

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -8,6 +8,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Create venv
+        run: python3 -m venv .venv
+        
+      - name: Activate virtualenv
+        run: |
+          . .venv/bin/activate
+          echo PATH=$PATH >> $GITHUB_ENV
 
       - run: pip install --upgrade pip
 

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -8,13 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Create venv
-        run: python3 -m venv .venv
-
-      - name: Activate virtualenv
-        run: |
-          . .venv/bin/activate
-          echo PATH=$PATH >> $GITHUB_ENV
+     - name: Setup Python
+       uses: actions/setup-python@v5
 
       - run: pip install --upgrade pip
 


### PR DESCRIPTION
Should fix [this](https://github.com/usegalaxy-eu/infrastructure-playbook/actions/runs/11271096560/job/31343231487?pr=1330):
~~~
Run pip install --upgrade pip
error: externally-managed-environment

× This environment is externally managed
╰─> To install Python packages system-wide, try apt install
    python3-xyz, where xyz is the package you are trying to
    install.
    
    If you wish to install a non-Debian-packaged Python package,
    create a virtual environment using python3 -m venv path/to/venv.
    Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
    sure you have python3-full installed.
    
    If you wish to install a non-Debian packaged Python application,
    it may be easiest to use pipx install xyz, which will manage a
    virtual environment for you. Make sure you have pipx installed.
    
    See /usr/share/doc/python3.12/README.venv for more information.

note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
hint: See PEP 668 for the detailed specification.
Error: Process completed with exit code 1.
~~~