### PR TITLE
update grafana

### DIFF
--- a/group_vars/grafana/vars.yml
+++ b/group_vars/grafana/vars.yml
@@ -41,7 +41,7 @@ grafana_on_call: true
 grafana_on_call_domain: oncall.galaxyproject.eu
 grafana_on_call_path: /data/grafana-on-call
 # Grafana
-grafana_version: 11.0.0
+grafana_version: "11.2.2+security-01"
 
 grafana_address: "127.0.0.1"
 grafana_domain: stats.galaxyproject.eu


### PR DESCRIPTION
https://grafana.com/blog/2024/10/17/grafana-security-release-critical-severity-fix-for-cve-2024-9264/