### PR TITLE
Remove grafana-gitter-bridge

### DIFF
--- a/grafana.yml
+++ b/grafana.yml
@@ -82,8 +82,6 @@
     - grafana
     - role: pgs
       become: true
-    - role: hxr.grafana-gitter-bridge
-      become: true
     - role: geerlingguy.docker
       become: true
       vars:

--- a/group_vars/grafana/vars.yml
+++ b/group_vars/grafana/vars.yml
@@ -255,10 +255,3 @@ galaxy_nagios_urls:
       url: "https://usegalaxy.eu/phinch/index.html"
       code: 200
 
-
-# Grafana Gitter Bridge
-ggb_create_user: true
-ggb_create_group: true
-bridge_token: "{{ vault_grafana_gitter_bridge_token }}"
-gitter_auth_token: "{{ vault_grafana_gitter_bridge_auth_token }}"
-gitter_room_id: "{{ vault_grafana_gitter_room_id }}"

--- a/group_vars/grafana/vars.yml
+++ b/group_vars/grafana/vars.yml
@@ -254,4 +254,3 @@ galaxy_nagios_urls:
     - name: phinch
       url: "https://usegalaxy.eu/phinch/index.html"
       code: 200
-


### PR DESCRIPTION
As discussed with @hexylena this is not used anymore and can go.
Maybe we can also delete the role and archive the [repo](https://github.com/usegalaxy-eu/grafana-gitter-bridge), if we decide to not maintain this anymore (there are also similar, maintained projects afaik)