### PR TITLE
Enable SSL verification for all our OIDC backends

### DIFF
--- a/templates/galaxy/config/oidc_config.xml
+++ b/templates/galaxy/config/oidc_config.xml
@@ -13,7 +13,7 @@ built-in type, which could be any of the following types: int; long; float; str;
 Note that the values of these attributes are case-sensitive.
 -->
 <OIDC>
-    <Setter Property="VERIFY_SSL" Value="False" Type="bool"/>
+    <Setter Property="VERIFY_SSL" Value="True" Type="bool"/>
     <Setter Property="REQUESTS_TIMEOUT" Value="3600" Type="float"/>
     <!-- The unit of value is seconds -->
     <Setter Property="ID_TOKEN_MAX_AGE" Value="3600" Type="float"/>


### PR DESCRIPTION
We often see the following warnings in the Gunicorn logs. I hope enabling SSL verification in the OIDC conf will fix this warning.

```
Oct 29 15:28:54 sn06.galaxyproject.eu gunicorn[460911]: /opt/galaxy/venv/lib/python3.11/site-packages/urllib3/connectionpool.py:1061: InsecureRequestWarning: Unverified HTTPS request is being made to host '*******'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings
Oct 29 15:28:54 sn06.galaxyproject.eu gunicorn[460911]:   warnings.warn(
```