### PR TITLE
pin gx-it-proxy codebase version

### DIFF
--- a/group_vars/sn06.yml
+++ b/group_vars/sn06.yml
@@ -226,7 +226,7 @@ galaxy_systemd_memory_limit_workflow: 15
 
 # gie_proxy
 gie_proxy_dir: "{{ galaxy_root }}/gie-proxy/proxy"
-gie_proxy_git_version: main
+gie_proxy_git_version: "v0.0.6"
 gie_proxy_setup_nodejs: nodeenv
 gie_proxy_virtualenv_command: "{{ conda_prefix }}/envs/_galaxy_/bin/python -m venv --copies" #"{{ pip_virtualenv_command }}"
 gie_proxy_nodejs_version: "10.13.0"


### PR DESCRIPTION
There are two repos,
1. Ansible role repo: https://github.com/usegalaxy-eu/ansible-gie-proxy
2. gx-it-proxy codebase: https://github.com/galaxyproject/gx-it-proxy

The codebase's default version is omitted in the Ansible repo; in EU, we set the branch's version of the codebase to `main`. This PR will put it to the release tag `v0.0.6` to fix the broken sn06 build.

Broken build error:
```
gyp: Call to 'which pg_config || find /usr/bin /usr/local/bin /usr/pg* /opt -executable -name pg_config -print -quit' returned exit status 1 while in binding.gyp. while trying to load binding.gyp\nnpm ERR! gyp ERR! configure error 
```

Why `v0.0.6`? It is the last release that we were using before the release of `v0.1.0`. The `v0.1.0` introduces the Postgres-based deployment code. 