### PR TITLE
Enable `offline_access` scope for Elixir OIDC provider

### DIFF
--- a/templates/galaxy/config/oidc_backends_config.xml
+++ b/templates/galaxy/config/oidc_backends_config.xml
@@ -63,7 +63,7 @@ Please mind `http` and `https`.
         <prompt>consent</prompt>
         <icon>https://lifescience-ri.eu/fileadmin/lifescience-ri/media/Images/button-login-small.png</icon>
         <!-- (Optional) Extra scopes you need to request for your implementation -->
-        <!-- <extra_scopes>offline_access,something-else</extra_scopes> -->
+        <extra_scopes>offline_access</extra_scopes>
 
     </provider>
     <provider name="Keycloak">


### PR DESCRIPTION
This scope is required to obtain refresh tokens from Elixir (LSAAI). Additionally, the `offline_access` scope in the service registration must be allowed registration on LSAAI's side (https://services.aai.lifescience-ri.eu/spreg/auth/facilities/detail/3686) (they already did that for us).