### PR TITLE
Galaxy-sync.to-nfs: add check and ensure galaxy user

### DIFF
--- a/roles/usegalaxy-eu.rsync-to-nfs/tasks/main.yml
+++ b/roles/usegalaxy-eu.rsync-to-nfs/tasks/main.yml
@@ -3,6 +3,10 @@
   copy:
     content: |
         #!/bin/bash
+        if [ "$(whoami)" != "galaxy" ]; then
+          exec sudo -u galaxy bash "$0" "$@"
+          exit
+        fi
         cd {{ galaxy_root }};
         for dir in {config,custom-tools,mutable-config,mutable-data,server,venv,tool-data}; do
             if [ -d $dir ]; then


### PR DESCRIPTION
because we sometimes have this file permission error, when we forget and run the script as root user 