### PR TITLE
Add a separate playbook for subdomains, reduce deployment time

### DIFF
--- a/sn06.yml
+++ b/sn06.yml
@@ -238,7 +238,7 @@
         galaxy_manage_static_setup: true
         galaxy_manage_mutable_setup: true
         galaxy_manage_database: true
-        galaxy_manage_subdomain_static: true
+        galaxy_manage_subdomain_static: false
         galaxy_manage_host_filters: false # test when themes work
         galaxy_manage_systemd: false # switch to gravity(?)
         galaxy_manage_gravity: false

--- a/subdomains.yml
+++ b/subdomains.yml
@@ -1,0 +1,49 @@
+---
+- name: UseGalaxy.eu
+  hosts: sn06
+  become: true
+  become_user: root
+  vars:
+    hostname: sn06.galaxyproject.eu
+
+  vars_files:
+    # Just keep the same as sn06, so nothing gets messed up ;)
+    - group_vars/sn06/sn06.yml
+    - group_vars/sn06/themes_conf.yml
+    - group_vars/sn06/subdomains.yml
+    - group_vars/tiaas.yml # All of the training infrastructure
+    - group_vars/gxconfig.yml # The base galaxy configuration
+    - group_vars/toolbox.yml # User controlled toolbox
+    - secret_group_vars/sentry.yml # Sentry SDK init url
+    - secret_group_vars/aws.yml # AWS creds
+    - secret_group_vars/pulsar.yml # Pulsar + MQ Connections
+    - secret_group_vars/oidc.yml # OIDC credentials (ELIXIR, keycloak)
+    - secret_group_vars/object_store.yml # Object Store credentils (S3 etc ...)
+    - secret_group_vars/db-main.yml # DB URL + some postgres stuff
+    - secret_group_vars/file_sources.yml # file_sources_conf.yml creds
+    - secret_group_vars/all.yml # All of the other assorted secrets...
+    - secret_group_vars/keys.yml # SSH keys
+    - templates/galaxy/config/job_conf.yml
+    - mounts/dest/all.yml
+    - mounts/mountpoints.yml
+  handlers:
+    - name: Restart Galaxy
+      shell: |
+        cd /opt/galaxy/ && source /opt/galaxy/.bashrc  && /usr/bin/gxadmin gunicorn handler-restart && sudo -u galaxy /usr/bin/galaxy-sync-to-nfs
+  roles:
+    - role: galaxyproject.galaxy
+      vars:
+        galaxy_create_user: false
+        galaxy_manage_clone: false
+        galaxy_manage_cleanup: false # we should use this
+        galaxy_manage_download: false
+        galaxy_manage_existing: false
+        galaxy_manage_paths: false
+        galaxy_manage_static_setup: false
+        galaxy_manage_mutable_setup: false
+        galaxy_manage_database: false
+        galaxy_manage_subdomain_static: true
+        galaxy_fetch_dependencies: false
+        galaxy_build_client: false
+        galaxy_manage_systemd: false # switch to gravity(?)
+        galaxy_manage_gravity: false


### PR DESCRIPTION
Current runtime in jenkins is 1h18min, this is not very handy for quick fixes or deployments.
This is related to the [symlink strategy](https://github.com/galaxyproject/ansible-galaxy/pull/198) we are using in the `galaxyproject.galaxy` role. It saves ~ 16G disk space for EU by symlinking static files instead of duplicating them for each subdomain's static directory. Because ansible tasks are quite slow and there is a task for each file in each subdomain this scales quite badly with $159 \cdot 38 = 6042$ Tasks