### PR TITLE
increase object store (jwd05e) weight

### DIFF
--- a/templates/galaxy/config/object_store_conf.xml.j2
+++ b/templates/galaxy/config/object_store_conf.xml.j2
@@ -211,7 +211,7 @@ The storage consists of 16 Gen6 type A200 storage nodes and 16 Gen5 type X410 no
             <files_dir path="/data/dnb10/galaxy_db/files"/>
             <extra_dir type="job_work" path="/data/jwd02f/main"/>
         </backend>
-        <backend id="files28" type="disk" weight="2" store_by="uuid">
+        <backend id="files28" type="disk" weight="4" store_by="uuid">
             <badges>
                 <more_stable />
             </badges>


### PR DESCRIPTION
It seems that a few jobs using `jwd02f` are getting stuck in the `D` state. 

I see all the `query_tabular` jobs (from the micro galaxy hackathon) are using `jwd02f`, and they are stuck. Each of them is running on different compute nodes, and I also see several other jobs stuck in the D state that are also utilizing the same JWD NFS share (running on the same compute nodes as the others). It could be an NFS issue.

This is a temporary fix to shift the load to `jwd05e`. `jwd02f` is still active, though. I also see some jobs utilizing `jwd02f` running. 

@bgruening: Feel free to close this PR if you don't think this is ideal. 