### PR TITLE
fix bashrc redundancy by walle

### DIFF
--- a/group_vars/maintenance.yml
+++ b/group_vars/maintenance.yml
@@ -347,6 +347,12 @@ walle_extra_env_vars:
       This means your jobs were terminated and you can not login anymore.
       However it is possible to restore the account and its data.
       If you think your account was deleted due to an error, please contact contact@usegalaxy.eu
+walle_envs_database:
+  MALWARE_LIB: "{{ walle_malware_database_location }}/{{ walle_database_file }}"
+  PGPASSFILE: "{{ walle_pgpass_file }}"
+  PGUSER: galaxy
+  PGDATABASE: galaxy
+  GXADMIN_PATH: /usr/local/bin/gxadmin
 walle_cron_day: "*"
 walle_cron_hour: "*"
 walle_cron_minute: "0"


### PR DESCRIPTION
I observed these exports piling up, and I think this is because WALLE exports them without the quoted paths and the bashrc ansible role exports the same but with quotes
This PR overwrites [this](https://github.com/usegalaxy-eu/WallE/blob/7e960212dc54c58bce5a5fea3f62e39598f2d790/defaults/main.yml#L24-L33) dict and therefore removes the doubled exports
~~~
export GXADMIN_PATH="/usr/local/bin/gxadmin"
export GALAXY_CONFIG_DIR=/opt/galaxy/config
export GALAXY_CONFIG_FILE="/opt/galaxy/config/galaxy.yml"
export GALAXY_PULSAR_APP_CONF="/opt/galaxy/config/pulsar_app.yml"
export GALAXY_LOG_DIR="/var/log/galaxy"
export GALAXY_CONFIG_FILE="/opt/galaxy/config/galaxy.yml"
export GALAXY_LOG_DIR="/var/log/galaxy"
export GALAXY_PULSAR_APP_CONF="/opt/galaxy/config/pulsar_app.yml"
export GALAXY_CONFIG_FILE=/opt/galaxy/config/galaxy.yml
export GALAXY_LOG_DIR=/var/log/galaxy
export GALAXY_PULSAR_APP_CONF=/opt/galaxy/config/pulsar_app.yml

~~~