### PR TITLE
Add xas section to tool_conf.xml.j2

### DIFF
--- a/templates/galaxy/config/tool_conf.xml.j2
+++ b/templates/galaxy/config/tool_conf.xml.j2
@@ -404,6 +404,8 @@
   </section>
   <section id="muon_spectroscopy" name="Muon Spectroscopy">
   </section>
+  <section id="xas" name="XAS (X-ray Absorption Spectroscopy)">
+  </section>
 
   <label id="other_and_toolsuites_label" text="Miscellaneous Tools" />
   <!--section id="regional_variation" name="Regional Variation">


### PR DESCRIPTION
From the conversation on https://github.com/usegalaxy-eu/usegalaxy-eu-tools/pull/800, we're hoping to get the XAS tools to show on https://materials.usegalaxy.eu/. Despite being added to [`global_host_filters.py.j2`](https://github.com/usegalaxy-eu/infrastructure-playbook/commit/738e18dd7648a33bc617e2cc8c56fb2deac9e36b) (thanks again to @bgruening ), it still  isn't showing up. Looking at other examples, including when the muon_spectroscopy section was added, I was wondering if we also needed to add to the xml in `tool_conf,xml.j2`?

If this isn't what's required then any help would be greatly appreciated.