### PR TITLE
Temporarily disable gxadmin galaxy clean up cron task

### DIFF
--- a/group_vars/sn06/sn06.yml
+++ b/group_vars/sn06/sn06.yml
@@ -41,16 +41,16 @@ fsm_cron_tasks:
     dow: "*"
     job: ". {{ galaxy_root }}/.bashrc && docker system prune -f > /dev/null"
     user: "{{ fsm_galaxy_user.username }}"
-  gxadmin:
-    enable: true
-    name: "Gxadmin Galaxy clean up"
-    minute: 0
-    hour: 0
-    dom: "*/2"
-    month: "*"
-    dow: "*"
-    job: "{{ custom_telegraf_env }} /usr/bin/gxadmin galaxy cleanup 60"
-    user: "{{ fsm_galaxy_user.username }}"
+  # gxadmin:
+  #   enable: true
+  #   name: "Gxadmin Galaxy clean up"
+  #   minute: 0
+  #   hour: 0
+  #   dom: "*/2"
+  #   month: "*"
+  #   dow: "*"
+  #   job: "{{ custom_telegraf_env }} /usr/bin/gxadmin galaxy cleanup 60"
+  #   user: "{{ fsm_galaxy_user.username }}"
 
 # TIaaS
 tiaas_virtualenv_python: "python3.8"


### PR DESCRIPTION
Note: need to manually remove the cron task from the host.

Reason: Affecting Postgres server (`sn05`); high CPU load.