### PR TITLE
Uncomment the gxadmin fsm_maintenance cron task but disable it

### DIFF
--- a/group_vars/sn06/sn06.yml
+++ b/group_vars/sn06/sn06.yml
@@ -41,16 +41,16 @@ fsm_cron_tasks:
     dow: "*"
     job: ". {{ galaxy_root }}/.bashrc && docker system prune -f > /dev/null"
     user: "{{ fsm_galaxy_user.username }}"
-  # gxadmin:
-  #   enable: true
-  #   name: "Gxadmin Galaxy clean up"
-  #   minute: 0
-  #   hour: 0
-  #   dom: "*/2"
-  #   month: "*"
-  #   dow: "*"
-  #   job: "{{ custom_telegraf_env }} /usr/bin/gxadmin galaxy cleanup 60"
-  #   user: "{{ fsm_galaxy_user.username }}"
+  gxadmin:
+    enable: false
+    name: "Gxadmin Galaxy clean up"
+    minute: 0
+    hour: 0
+    dom: "*/2"
+    month: "*"
+    dow: "*"
+    job: "{{ custom_telegraf_env }} /usr/bin/gxadmin galaxy cleanup 60"
+    user: "{{ fsm_galaxy_user.username }}"
 
 # TIaaS
 tiaas_virtualenv_python: "python3.8"


### PR DESCRIPTION
This should fix the failing CI.

The [cron task](https://github.com/usegalaxy-eu/ansible-fs-maintenance/blob/main/tasks/cron.yml#L13-L14) in the fsm ansible role expects this `gxadmin` variables to exist. Hence, the CI failed. Now I have uncommented and disabled it, so this cron task will not get deployed. 