### PR TITLE
Allow Galaxy headnode to connect to 'gxitproxy' database as user 'galaxy'

### DIFF
--- a/group_vars/sn05.yml
+++ b/group_vars/sn05.yml
@@ -88,6 +88,7 @@ postgresql_pg_hba_conf:
   - "host    tiaas           tiaas           132.230.223.239/32      md5"
   - "host    tiaas           tiaas           132.230.223.238/32      md5"
   - "host    tiaas           tiaas           10.5.68.237/32          md5"
+  - "host    gxitproxy       galaxy          132.230.223.239/32      md5"
   - "host    galaxy-test     galaxy-test     132.230.223.239/32      md5"
   - "host    galaxy-test     galaxy-test     10.5.68.0/24            md5"
   - "host    galaxy          galaxyftp       132.230.224.107/32      md5"


### PR DESCRIPTION
To complete the migration to a high-availability setup for the interactive tools proxy, which allows a [redundant setup with several headnodes](https://github.com/usegalaxy-eu/issues/issues/352), a separate database 'gxitproxy' for the proxy is needed.

@jdavcs [explained the reasoning behind this need](https://github.com/galaxyproject/galaxy/pull/18481#issuecomment-2218493956):
> I assume the gxitproxy table is meant to be part of the main galaxy's database (as per https://github.com/usegalaxy-eu/infrastructure-playbook/pull/1251)? If so, that may break things. Galaxy does not assume the existence of tables in its database that are not defined in its model (except for this one case). Thus, db schema migration logic may break, now or in the future when we add some feature that scans the database).

Merging this commit is not enough. In addition, it is needed to complete step (1) of the [migration procedure](https://github.com/usegalaxy-eu/infrastructure-playbook/pull/1251#issue-2390832112).

> On Postgres, create the database gxitproxy and set the galaxy user as its owner. Create also the table gxitproxy on beforehand (gx-it-proxy refuses to run without it). For greater details you may have a look at the [updated GTN training](https://github.com/usegalaxy-eu/infrastructure-playbook/pull/galaxyproject/training-material/pull/5179).

@sj213 Would you mind creating this DB and table?