### PR TITLE
WIP: Cleanup, we should move users to user-based files sources

### DIFF
--- a/files/galaxy/config/user_preferences_extra_conf.yml
+++ b/files/galaxy/config/user_preferences_extra_conf.yml
@@ -33,49 +33,49 @@ preferences:
                   - [日本語, ja]
 
     # Used in file_sources_conf.yml
-    dropbox:
-        description: Your Dropbox account
-        inputs:
-            - name: access_token
-              label: Dropbox access token
-              type: password
-              required: False
+    #dropbox:
+    #    description: Your Dropbox account
+    #    inputs:
+    #        - name: access_token
+    #          label: Dropbox access token
+    #          type: password
+    #          required: False
 
     # Used in file_sources_conf.yml
-    nextcloud:
-        description: Your Personal Nextcloud / ownCloud account
-        inputs:
-            - name: url
-              label: Server Domain (e.g. https://myowncloud.org)
-              type: text
-              required: False
-            - name: root
-              label: Server Path (should end with /remote.php/webdav, e.g. /a/sub/path/remote.php/webdav)
-              type: text
-              required: False
-            - name: username
-              label: Username
-              type: text
-              required: False
-            - name: password
-              label: Password
-              type:  password
-              # for storing the password in a vault (instead of plaintext in the DB)
-              # store: vault
-              required: False
+    #nextcloud:
+    #    description: Your Personal Nextcloud / ownCloud account
+    #    inputs:
+    #        - name: url
+    #          label: Server Domain (e.g. https://myowncloud.org)
+    #          type: text
+    #          required: False
+    #        - name: root
+    #          label: Server Path (should end with /remote.php/webdav, e.g. /a/sub/path/remote.php/webdav)
+    #          type: text
+    #          required: False
+    #        - name: username
+    #          label: Username
+    #          type: text
+    #          required: False
+    #        - name: password
+    #          label: Password
+    #          type:  password
+    #          # for storing the password in a vault (instead of plaintext in the DB)
+    #          # store: vault
+    #          required: False
 
-    invenio:
-        description: Your Invenio RDM Integration Settings
-        inputs:
-            - name: token
-              label: Personal Token used to create draft records and to upload files
-              type: secret
-              store: vault # Requires setting up vault_config_file in your galaxy.yml
-              required: False
-            - name: public_name
-              label: Creator name to associate with new records (formatted as "Last name, First name"). If left blank "Anonymous Galaxy User" will be used. You can always change this by editing your record directly.
-              type: text
-              required: False
+    #invenio:
+    #    description: Your Invenio RDM Integration Settings
+    #    inputs:
+    #        - name: token
+    #          label: Personal Token used to create draft records and to upload files
+    #          type: secret
+    #          store: vault # Requires setting up vault_config_file in your galaxy.yml
+    #          required: False
+    #        - name: public_name
+    #          label: Creator name to associate with new records (formatted as "Last name, First name"). If left blank "Anonymous Galaxy User" will be used. You can always change this by editing your record directly.
+    #          type: text
+    #          required: False
 
     zenodo:
         description: Your Zenodo Integration Settings
@@ -104,22 +104,22 @@ preferences:
               required: False
 
     # Used in file_sources_conf.yml
-    onedata:
-        description: Your Onedata account
-        inputs:
-            - name: onezone_domain
-              label: Domain of the Onezone service (e.g. datahub.egi.eu). The minimal supported Onezone version is 21.02.4.
-              type: text
-              required: False
-            - name: access_token
-              label: Your access token, suitable for REST API access in a Oneprovider service
-              type: password
-              required: False
-            - name: disable_tls_certificate_validation
-              label: Allow connection to Onedata servers that do not present trusted SSL certificates. SHOULD NOT be used unless you really know what you are doing.
-              type: boolean
-              required: False
-              value: False
+    #onedata:
+    #    description: Your Onedata account
+    #    inputs:
+    #        - name: onezone_domain
+    #          label: Domain of the Onezone service (e.g. datahub.egi.eu). The minimal supported Onezone version is 21.02.4.
+    #          type: text
+    #          required: False
+    #        - name: access_token
+    #          label: Your access token, suitable for REST API access in a Oneprovider service
+    #          type: password
+    #          required: False
+    #        - name: disable_tls_certificate_validation
+    #          label: Allow connection to Onedata servers that do not present trusted SSL certificates. SHOULD NOT be used unless you really know what you are doing.
+    #          type: boolean
+    #          required: False
+    #          value: False
 
     distributed_arc_compute:
         description: The URL to your ARC remote HPC compute resource.
@@ -208,25 +208,25 @@ preferences:
               required: False
               value: https://auth.quantum-computing.ibm.com/api
 
-    generic_s3:
-        description: Your personal S3 account for data import
-        inputs:
-            - name: endpoint_url
-              label: Server Domain (e.g. byos.vm.fedcloud.eu)
-              type: text
-              required: False
-            - name: bucket
-              label: S3 Bucket (e.g. my-s3-bucket)
-              type: text
-              required: False
-            - name: secret
-              label: S3 secret (e.g. SuPerP4ssWord)
-              type: password
-              required: False
-            - name: key
-              label: S3 access key (e.g. project01)
-              type: password
-              required: False
+    #generic_s3:
+    #    description: Your personal S3 account for data import
+    #    inputs:
+    #        - name: endpoint_url
+    #         label: Server Domain (e.g. byos.vm.fedcloud.eu)
+    #         type: text
+    #         required: False
+    #       - name: bucket
+    #         label: S3 Bucket (e.g. my-s3-bucket)
+    #         type: text
+    #         required: False
+    #       - name: secret
+    #         label: S3 secret (e.g. SuPerP4ssWord)
+    #         type: password
+    #         required: False
+    #       - name: key
+    #         label: S3 access key (e.g. project01)
+    #         type: password
+    #         required: False
 
     # Require to attach pulsar endpoint to the Pulsar Network
     byoc_pulsar:

--- a/templates/galaxy/config/file_sources_conf.yml.j2
+++ b/templates/galaxy/config/file_sources_conf.yml.j2
@@ -1,30 +1,30 @@
-- type: dropbox
-  id: dropbox
-  label: Your Dropbox Files
-  doc: Your Dropbox files - configure an access token via the user preferences
-  accessToken: ${user.preferences['dropbox|access_token']}
+#- type: dropbox
+#  id: dropbox
+#  label: Your Dropbox Files
+#  doc: Your Dropbox files - configure an access token via the user preferences
+#  accessToken: ${user.preferences['dropbox|access_token']}
 
-- type: webdav
-  id: b2drop
-  doc: B2Drop WebDAV server
-  url: https://b2drop.eudat.eu
-  root: /remote.php/dav/files/${user.preferences['b2drop|username']}/
-  use_temp_files: true
-  temp_path: /data/jwd04/tmp
-  login: ${user.preferences['b2drop|username']} 
-  password: ${user.preferences['b2drop|password']}
+#- type: webdav
+#  id: b2drop
+#  doc: B2Drop WebDAV server
+#  url: https://b2drop.eudat.eu
+#  root: /remote.php/dav/files/${user.preferences['b2drop|username']}/
+#  use_temp_files: true
+#  temp_path: /data/jwd04/tmp
+#  login: ${user.preferences['b2drop|username']} 
+#  password: ${user.preferences['b2drop|password']}
 
-- type: webdav
-  id: generic_nextcloud
-  label: Nextcloud/ownCloud
-  doc: You personal Cloud files
-  writable: true
-  url: ${user.preferences['nextcloud|url']}
-  root: ${user.preferences['nextcloud|root']}
-  use_temp_files: true
-  temp_path: /data/jwd04/tmp
-  login: ${user.preferences['nextcloud|username']}
-  password: ${user.preferences['nextcloud|password']}
+#- type: webdav
+#  id: generic_nextcloud
+#  label: Nextcloud/ownCloud
+#  doc: You personal Cloud files
+#  writable: true
+#  url: ${user.preferences['nextcloud|url']}
+#  root: ${user.preferences['nextcloud|root']}
+#  use_temp_files: true
+#  temp_path: /data/jwd04/tmp
+#  login: ${user.preferences['nextcloud|username']}
+#  password: ${user.preferences['nextcloud|password']}
 
 - type: webdav
   id: erga_nextcloud
@@ -111,15 +111,15 @@
   config_path: ""
   port: 2222
 
-- type: s3fs
-  label: Generic S3 instance
-  id: generic_s3
-  doc: Access to a generic S3 endpoint.
-  endpoint_url: ${user.preferences['generic_s3|endpoint_url']}
-  bucket: ${user.preferences['generic_s3|bucket']}
-  writable: true
-  secret: ${user.preferences['generic_s3|secret']}
-  key: ${user.preferences['generic_s3|key']}
+#- type: s3fs
+#  label: Generic S3 instance
+#  id: generic_s3
+#  doc: Access to a generic S3 endpoint.
+#  endpoint_url: ${user.preferences['generic_s3|endpoint_url']}
+#  bucket: ${user.preferences['generic_s3|bucket']}
+#  writable: true
+#  secret: ${user.preferences['generic_s3|secret']}
+#  key: ${user.preferences['generic_s3|key']}
 
 - type: s3fs
   label: Genome Ark
@@ -288,12 +288,12 @@
   public_name: ${user.preferences['zenodo_sandbox|public_name']}
   writable: true
 
-- type: onedata
-  id: onedata1
-  label: Onedata
-  doc: Your Onedata files - configure an access token via user preferences
-  accessToken: ${user.preferences['onedata|access_token']}
-  onezoneDomain: ${user.preferences['onedata|onezone_domain']}
+#- type: onedata
+#  id: onedata1
+#  label: Onedata
+#  doc: Your Onedata files - configure an access token via user preferences
+#  accessToken: ${user.preferences['onedata|access_token']}
+#  onezoneDomain: ${user.preferences['onedata|onezone_domain']}
 
 - type: onedata
   id: gtn_public_onedata


### PR DESCRIPTION
@davelopez do we need an invenio and a zenodo file source template? The Zenodo template could be a URL-hardcoded invenio one, plus a boolean for the sandbox option.

What do you think?

xref: https://github.com/usegalaxy-eu/infrastructure-playbook/pull/1396

I think we can at first merge #1396 and then this one a week or two later.