### PR TITLE
update sync-to-nfs script to sync shed_tools instead of shed-tools_local to the NFS

### DIFF
--- a/roles/usegalaxy-eu.rsync-to-nfs/tasks/main.yml
+++ b/roles/usegalaxy-eu.rsync-to-nfs/tasks/main.yml
@@ -16,11 +16,11 @@
                 echo "Skipping $dir"
             fi
         done;
-        if [ -d shed_tools-local ]; then
-            echo "Syncing shed_tools-local"
-            rsync -avr --delete --exclude .hg shed_tools-local/ {{ galaxy_nfs_location }}/shed_tools/
+        if [ -d shed_tools ]; then
+            echo "Syncing shed_tools"
+            rsync -avr --delete --exclude .hg shed_tools/ {{ galaxy_nfs_location }}/shed_tools/
         else
-            echo "Skipping shed_tools-local"
+            echo "Skipping shed_tools"
         fi
     dest: /usr/bin/galaxy-sync-to-nfs
     owner: root


### PR DESCRIPTION
The `shed_tools-local` symlink is interfering with a weird bug, leading to images not being displayed in the tool form in the EU. @bgruening found this bug, and removing the symlink was the only solution. The symlink will be manually deleted, so the sync to nfs script is being updated to handle the change. 