### PR TITLE
TPV: configure ppanggolin_all tool to use singularity and non-NFS tmp

### DIFF
--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -1523,3 +1523,11 @@ tools:
   toolshed.g2.bx.psu.edu/repos/iuc/optitype/optitype/.*:
     cores: 12
     mem: 256
+
+  # ppanggolin all tries to remove TMP folders, on NFS this does not always work, so we run this tool in singularity with internal (non-NFS) TMP
+  toolshed.g2.bx.psu.edu/repos/iuc/ppanggolin_all/ppanggolin_all/.*:
+    scheduling:
+      require:
+        - singularity
+    env:
+      _GALAXY_JOB_TMP_DIR: '/tmp'


### PR DESCRIPTION
`pangolin all`, when run with GenBank files, uses a different approach than when used with fasta files as input. When GenBank format files are used, it attempts to clean up `tmp` directories. On NFS, this does not always work, so we run this tool in singularity with internal (non-NFS) TMP.

_Attempting to see if everything works with singularity instead of docker._