### PR TITLE
Revert "Add TPV rule for climate strike feb 2025"

### DIFF
--- a/files/galaxy/tpv/tool_defaults.yml
+++ b/files/galaxy/tpv/tool_defaults.yml
@@ -67,28 +67,6 @@ tools:
           retval
         fail: |
           Invalid 'Remote resources id' selected in the config menu under 'User -> Preferences -> Manage Information -> Use distributed compute resources'. Please reselect either 'default' or an appropriate remote resource then click 'Save' and rerun your job.
-      - id: climate_strike
-        # delay jobs using HTCondor's job deferral feature
-        # https://htcondor.readthedocs.io/en/latest/users-manual/time-scheduling-for-job-execution.html
-        if: True
-        execute: |
-          from datetime import datetime
-
-          strike_start = datetime(2025,2,14,7,0)
-          strike_end = datetime(2025,2,14,20,0)
-
-          training_roles = (
-              [r.name for r in user.all_roles()
-              if not r.deleted and r.name in
-              ("training-master2025", "training-metap-intro")]
-              if user is not None else []
-          )
-
-          now = datetime.now()
-          if strike_start <= now < strike_end and not training_roles:
-              entity.params["deferral_time"] = f"{int(strike_end.timestamp())}"
-              entity.params["deferral_prep_time"] = "60"
-              entity.params["deferral_window"] = "864000"  # 10 days
     rank: |
       final_destinations = helpers.weighted_random_sampling(candidate_destinations)
       final_destinations


### PR DESCRIPTION
Reverts usegalaxy-eu/infrastructure-playbook#1400

The rule does not work if I join the training as a non-admin user. When I join as a non-admin user and submit jobs, they are deferred. So, I have split the hosts into two and assigned them to the training groups.

For future reference:
```
pssh -h /tmp/training-metap-intro-group -l centos 'sudo sed -i '\''s/"compute"/"training-metap-intro"/g'\'' /etc/condor/config.d/99-cloud-init.conf; sudo sed -i '\''s/GalaxyTraining = False/GalaxyTraining = True/g'\'' /etc/condor/config.d/99-cloud-init.conf; sudo systemctl reload condor'

pssh -h /tmp/training-master2025-group -l centos 'sudo sed -i '\''s/"compute"/"training-master2025"/g'\'' /etc/condor/config.d/99-cloud-init.conf; sudo sed -i '\''s/GalaxyTraining = False/GalaxyTraining = True/g'\'' /etc/condor/config.d/99-cloud-init.conf; sudo systemctl reload condor'
```


_I have removed the rule manually on the local file system_