### PR TITLE
block two email domains

### DIFF
--- a/files/galaxy/config/email_domain_blocklist.conf
+++ b/files/galaxy/config/email_domain_blocklist.conf
@@ -912,6 +912,7 @@ e-mail.com
 e-mail.igg.biz
 e-mail.org
 e-marketstore.ru
+e-record.com
 e-tomarigi.com
 e3z.de
 e4ward.com
@@ -927,6 +928,7 @@ ecallheandi.com
 ecolo-online.fr
 edgex.ru
 edinburgh-airporthotels.com
+edny.net
 edv.to
 ee1.pl
 ee2.pl


### PR DESCRIPTION
AU found users using disposable emails from these domains doing prohibited activity.

In the EU I found 65 new registrations from `edny.net` all between 2025-02-15-2025-02-17, and all are running the following ITs 

```
galaxy=> select distinct tool_id from job where user_id in (select id from galaxy_user where email ilike '%edny.net%');
                 tool_id
------------------------------------------
 interactive_tool_climate_notebook
 interactive_tool_jupytergis_notebook
 interactive_tool_jupyter_notebook
 interactive_tool_mgnify_notebook
 interactive_tool_ml_jupyter_notebook
 interactive_tool_pyiron
 interactive_tool_qiskit_jupyter_notebook
```
