### PR TITLE
Change mq playbook for mq02

### DIFF
--- a/group_vars/mq.yml
+++ b/group_vars/mq.yml
@@ -1,5 +1,5 @@
 ---
-hostname: mq.galaxyproject.eu
+hostname: mq-proxy.galaxyproject.eu
 
 # create_user task
 handy_groups:
@@ -14,7 +14,8 @@ handy_users:
 # Certbot
 certbot_admin_email: security@usegalaxy.eu
 certbot_agree_tos: --agree-tos
-certbot_auth_method: --webroot
+certbot_dns_provider: route53
+certbot_auth_method: --standalone
 certbot_auto_renew: true
 certbot_auto_renew_user: root
 certbot_auto_renew_hour: "{{ 23 |random(seed=inventory_hostname)  }}"
@@ -27,6 +28,12 @@ certbot_share_key_users:
   - nginx
   - rabbitmq
 
+aws_cli_credentials:
+  - access_key: "{{ aws_credentials.certbot.AWS_ACCESS_KEY }}"
+    secret_key: "{{ aws_credentials.certbot.AWS_SECRET_KEY }}"
+    homedir: /root
+    owner: root
+    group: root
 certbot_post_renewal: |
   systemctl restart nginx || true
   systemctl restart docker || true

--- a/group_vars/mq.yml
+++ b/group_vars/mq.yml
@@ -1,14 +1,14 @@
 ---
-hostname: mq-proxy.galaxyproject.eu
+hostname: mq.galaxyproject.eu
 
 # create_user task
 handy_groups:
   - group_name: rabbitmq
-    group_gid: 999
+    group_gid: 101
 
 handy_users:
   - user_name: rabbitmq
-    user_uid: 999
+    user_uid: 100
     user_group: rabbitmq
 
 # Certbot
@@ -153,7 +153,7 @@ rabbitmq_config:
 
 rabbitmq_container:
   name: rabbit_hole
-  image: rabbitmq:3.9.11
+  image: rabbitmq:4.0.6-alpine
   hostname: "{{ inventory_hostname }}"
 
 # Redis

--- a/group_vars/mq.yml
+++ b/group_vars/mq.yml
@@ -22,6 +22,7 @@ certbot_auto_renew_hour: "{{ 23 |random(seed=inventory_hostname)  }}"
 certbot_auto_renew_minute: "{{ 59 |random(seed=inventory_hostname)  }}"
 certbot_domains:
   - "{{ hostname }}"
+  - "{{ inventory_hostname }}"
 certbot_environment: "production" # change to production when ready to go
 certbot_install_method: virtualenv
 certbot_share_key_users:
@@ -153,7 +154,7 @@ rabbitmq_config:
 
 rabbitmq_container:
   name: rabbit_hole
-  image: rabbitmq:4.0.6-alpine
+  image: rabbitmq:4.0.6-management-alpine
   hostname: "{{ inventory_hostname }}"
 
 # Redis

--- a/hosts
+++ b/hosts
@@ -15,7 +15,7 @@ beacon-import.galaxyproject.eu
 influxdb.galaxyproject.eu
 
 [mq]
-mq.galaxyproject.eu
+mq02.galaxyproject.eu
 
 [incoming]
 incoming.galaxyproject.eu

--- a/mq.yml
+++ b/mq.yml
@@ -2,23 +2,22 @@
 - name: MQ
   hosts: mq
   become: true
-  vars:
-    hostname: mq.galaxyproject.eu
   vars_files:
     - secret_group_vars/all.yml
+    - secret_group_vars/aws.yml # AWS creds
     - secret_group_vars/pulsar.yml     # Pulsar + MQ Connections
   collections:
     - devsec.hardening
   pre_tasks:
-    - name: Set default version of Python
-      alternatives:
-        name: python
-        path: /usr/bin/python3
+    #    - name: Set default version of Python
+    #      alternatives:
+    #        name: python
+    #        path: /usr/bin/python3
     - name: Install docker pip package
       ansible.builtin.pip:
         name: docker
     - name: Set docker_users (Docker role)
-      set_fact:
+      ansible.builtin.set_fact:
         docker_users: "centos"
     - name: Configure SELinux
       ansible.posix.seboolean:
@@ -51,13 +50,23 @@
         - amqps
         - https
         - http
-    - name: Create redis db dir
-      ansible.builtin.file:
-        path: /var/lib/redis
-        owner: redis
+    - name: Create redis group
+      ansible.builtin.group:
+        name: redis
+    - name: Create redis user
+      ansible.builtin.user:
+        name: redis
         group: redis
-        state: directory
-        mode: 755
+        home: /var/lib/redis
+        create_home: true
+        shell: /bin/false
+        #    - name: Create redis db dir
+        #      ansible.builtin.file:
+        #        path: /var/lib/redis
+        #        owner: redis
+        #        group: redis
+        #        state: directory
+        #        mode: 755
     - name: Create redis log dir
       ansible.builtin.file:
         path: /var/log/redis
@@ -85,6 +94,7 @@
     - influxdata.chrony         # Keep our time in sync.
     # Applications
     - geerlingguy.docker
+    - hxr.aws-cli # Setup the AWS client that will be needed for route53 authentication of certbot. MUST come before nginx role
     - galaxyproject.nginx
     - usegalaxy_eu.rabbitmqserver
     - geerlingguy.redis


### PR DESCRIPTION
- Changed hostname
- Changed ACME to `DNS-01`, because of internal network (webroot not reachable)
- Redis Dir is created as homedirectory when the `redis` user is created
- update RabbitMQ to `4.0.6` and use management container for stats
- remap `rabbitmq` user to 100 and group 101 because new container is alpine and has differend UID/GID

**this is already deployed**