### PR TITLE
Add Traefik configuration for new private IP RabbitMQ

### DIFF
--- a/files/traefik/rules/mq-router.yml
+++ b/files/traefik/rules/mq-router.yml
@@ -1,7 +1,7 @@
 tcp:
   routers:
     mq-rtr:
-      rule: "HostSNI(`mq-proxy.galaxyproject.eu`)"
+      rule: "HostSNI(`mq-proxy.galaxyproject.eu`) || ClientIP(`132.230.224.103`)" # Add the IP for every host
       service: "mq"
       entryPoints:
         - amqps

--- a/files/traefik/rules/mq-router.yml
+++ b/files/traefik/rules/mq-router.yml
@@ -1,0 +1,11 @@
+tcp:
+  routers:
+    mq-rtr:
+      rule: "HostSNI(`mq-proxy.galaxyproject.eu`)"
+      service: "mq"
+      entryPoints:
+        - amqps
+      tls:
+        certResolver: "route53"
+        domains:
+          - main: "mq-proxy.galaxyproject.eu"

--- a/files/traefik/rules/mq-router.yml
+++ b/files/traefik/rules/mq-router.yml
@@ -1,11 +1,9 @@
 tcp:
   routers:
     mq-rtr:
-      rule: "HostSNI(`mq-proxy.galaxyproject.eu`) || ClientIP(`132.230.224.103`)" # Add the IP for every host
+      rule: "HostSNI(`*`)" # || ClientIP(`132.230.224.103`)" Allow by host IP
       service: "mq"
       entryPoints:
         - amqps
       tls:
-        certResolver: "route53"
-        domains:
-          - main: "mq-proxy.galaxyproject.eu"
+        passthrough: true

--- a/files/traefik/rules/mq-service.yml
+++ b/files/traefik/rules/mq-service.yml
@@ -1,0 +1,6 @@
+tcp:
+  services:
+    mq:
+      loadBalancer:
+        servers:
+          - address: "10.5.68.232:5671" #replace once mq02 is in playbook

--- a/group_vars/traefik.yml
+++ b/group_vars/traefik.yml
@@ -71,6 +71,7 @@ traefik_containers:
       - --global.checkNewVersion=false
       - --entryPoints.web.address=:80
       - --entryPoints.websecure.address=:443
+      - --entryPoints.amqps.address=:5671
       - --entryPoints.web.http.redirections.entryPoint.to=websecure
       - --entryPoints.web.http.redirections.entryPoint.scheme=https
       - --entryPoints.metrics.address=:8082
@@ -146,6 +147,10 @@ traefik_containers:
         mode: host
       - target_port: 443
         published_port: 443
+        protocol: tcp
+        mode: host
+      - target_port: 5671
+        published_port: 5671
         protocol: tcp
         mode: host
       - target_port: 8082

--- a/traefik-proxy.yml
+++ b/traefik-proxy.yml
@@ -17,6 +17,18 @@
         - policycoreutils-python-utils
         - python3-pip
 
+    - name: Configure Firewall
+      ansible.builtin.firewalld:
+        service: "{{ item }}"
+        permanent: true
+        zone: public
+      with_items:
+        - ssh
+        - amqps
+        - http
+        - https
+        - ntp
+
     - name: Install python docker
       become: true
       ansible.builtin.pip:

--- a/traefik-proxy.yml
+++ b/traefik-proxy.yml
@@ -18,10 +18,11 @@
         - python3-pip
 
     - name: Configure Firewall
-      ansible.builtin.firewalld:
+      ansible.posix.firewalld:
         service: "{{ item }}"
         permanent: true
         zone: public
+        state: enabled
       with_items:
         - ssh
         - amqps


### PR DESCRIPTION
- Creates Entrypoint for amqps port (5671)
- Creates TCP router, that catches all traffic on 5671 and doesn't terminate TLS
- Creates TCP service + loadbalancer for mq02 (10.5.68.232), which is only possible by IP
- add firewalld config to playbook

**This is already deployed**