### PR TITLE
Set interactive tools proxy restart mode to `always`

### DIFF
--- a/group_vars/sn06/sn06.yml
+++ b/group_vars/sn06/sn06.yml
@@ -232,6 +232,8 @@ gie_proxy_virtualenv_command: "{{ conda_prefix }}/envs/_galaxy_/bin/python -m ve
 gie_proxy_nodejs_version: "14.21.3"
 gie_proxy_virtualenv: "{{ galaxy_root }}/gie-proxy/venv"
 gie_proxy_setup_service: systemd
+gie_proxy_service_restart_mode: always
+gie_proxy_service_restartsec: 2s
 gie_proxy_sessions_path: "{{ interactivetools_db_connection }}"
 gie_proxy_path_prefix: /interactivetool/ep
 gie_proxy_port: 8800

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -113,7 +113,7 @@ roles:
     src: https://github.com/usegalaxy-eu/ansible-update-hosts
     version: 0.2.0
   - name: usegalaxy_eu.gie_proxy
-    version: 0.1.2
+    version: 0.2.0
   - name: usegalaxy-eu.autofs
     src: https://github.com/usegalaxy-eu/ansible-autofs
     version: 1.0.0


### PR DESCRIPTION
Update role `usegalaxy_eu.gie_proxy` to new `0.2.0` release, which allows configuring the restart mode and amount of seconds between restarts. Set the restart mode to `always` and the interval to `2s`.