### PR TITLE
TPV: Add a new rule for braker tool to fail if the input assembly file has more than 100K sequences

### DIFF
--- a/.github/workflows/tpv.yml
+++ b/.github/workflows/tpv.yml
@@ -409,7 +409,7 @@ jobs:
                   comparison[key] = yaml.safe_load(open(playbooks[key].parent / file, 'r')).get("tools", {})
                   comparison[key] = {
                     key: hashlib.sha256(yaml.dump(value, sort_keys=True).encode('utf-8')).hexdigest()
-                    for key, value in comparison[key].items()
+                    for key, value in comparison[key].items() if not value.get("abstract", False) # ignore abstract tools
                   }
               changed |= set(comparison['new']) - set(comparison['old'])
               changed |= {key for key in set(comparison['new']) & set(comparison['old']) if comparison['new'][key] != comparison['old'][key]}

--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -1223,7 +1223,19 @@ tools:
       require:
         - singularity
 
+  braker_tool:
+    abstract: true
+    rules:
+      - id: braker_genome_sequence_length_rule
+        if: |
+          options = job.get_param_values(app)
+          sequences = options["query_type"]["genome"].metadata.get("sequences")
+          sequences > 100000
+        fail: |
+          The number of sequences in your genome file is too large (>100K) for this tool.
+
   toolshed.g2.bx.psu.edu/repos/genouest/braker3/braker3/3.0.6.*:
+    inherits: braker_tool
     mem: 4
     cores: 6
     params:
@@ -1233,6 +1245,7 @@ tools:
         - singularity
 
   toolshed.g2.bx.psu.edu/repos/genouest/braker3/braker3/3.0.7.*:
+    inherits: braker_tool
     mem: 4
     cores: 6
     env:
@@ -1246,6 +1259,7 @@ tools:
         - singularity
 
   toolshed.g2.bx.psu.edu/repos/genouest/braker3/braker3/3.0.8.*:
+    inherits: braker_tool
     cores: 6
     mem: 4
     params:
@@ -1257,6 +1271,7 @@ tools:
         - singularity
 
   toolshed.g2.bx.psu.edu/repos/genouest/braker3/braker3/3.0.3.*:
+    inherits: braker_tool
     mem: 4
     cores: 6
     params:
@@ -1267,6 +1282,7 @@ tools:
 
   # GeneMark is a pain and needs special casing
   toolshed.g2.bx.psu.edu/repos/genouest/braker/braker/.*:
+    inherits: braker_tool
     mem: 4
     cores: 6
     env:

--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -1229,8 +1229,9 @@ tools:
       - id: braker_genome_sequence_count_rule
         if: |
           options = job.get_param_values(app)
-          sequences = options["query_type"]["genome"].metadata.get("sequences")
-          sequences > 100000
+          genome = options.get("query_type", {}).get("genome", {})
+          sequences = genome.get("metadata", {}).get("sequences")
+          sequences is not None and sequences > 100000
         fail: |
           The number of sequences in your genome file is too large (>100K) for this tool.
 

--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -1229,9 +1229,8 @@ tools:
       - id: braker_genome_sequence_count_rule
         if: |
           options = job.get_param_values(app)
-          genome = options.get("query_type", {}).get("genome", {})
-          sequences = genome.get("metadata", {}).get("sequences")
-          sequences is not None and sequences > 100000
+          sequences = options["genome"].metadata.get("sequences")
+          sequences > 100000
         fail: |
           The number of sequences in your genome file is too large (>100K) for this tool.
 

--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -1226,7 +1226,7 @@ tools:
   braker_tool:
     abstract: true
     rules:
-      - id: braker_genome_sequence_length_rule
+      - id: braker_genome_sequence_count_rule
         if: |
           options = job.get_param_values(app)
           sequences = options["query_type"]["genome"].metadata.get("sequences")


### PR DESCRIPTION
We recently encountered cases where the input assembly file (`--genome` option) had sequences of two million or more, and the resulting effect broke our underlying storage systems as the tool started creating millions of files (that too in a single directory). So, we are applying a new TPV rule so the tool will automatically apply if the genome file has more than 100K sequences. 

Xref: https://github.com/usegalaxy-eu/issues/issues/673

To derive this rule, I tried to look up the Galaxy DB and the `job`, `job_parameter`, and `history_dataset_association` tables in addition to [this](https://github.com/galaxyproject/usegalaxy-playbook/blob/ef4656c01c9df4d57f6a90650fe9f71c8e259f63/env/common/templates/galaxy/config/tpv/tools.yaml.j2#L1266-L1272). I hope the metadata extraction works correctly, as no exact documentation exists for such. 

