### PR TITLE
add BYOD Dropbox OAuth2 client credentials to celery systemd env.

### DIFF
--- a/group_vars/celerycluster.yml
+++ b/group_vars/celerycluster.yml
@@ -41,6 +41,7 @@ galaxy_systemd_celery: true
 galaxy_systemd_celery_internal_max_tasks: 50
 galaxy_systemd_celery_beat_schedule_path: "/opt/galaxy/celery/celery-beat-schedule"
 galaxy_systemd_watchdog: true
+galaxy_systemd_celery_env: "GALAXY_DROPBOX_APP_CLIENT_ID={{ dropbox_app_client_id }} GALAXY_DROPBOX_APP_CLIENT_SECRET={{ dropbox_app_client_secret }}"
 
 galaxy_systemd_celery_internal_workers: 10
 galaxy_systemd_celery_external_workers: 2


### PR DESCRIPTION
Since exporting history is a Celery task, I think it is necessary to add the OAuth client credentials to the Celery system environment when exporting to Dropbox. 

_I see an error when exporting history to a file to my Dropbox._