### PR TITLE
Update autofs to deploy/add new cache and misc NFS shares and update the autofs role version

### DIFF
--- a/group_vars/celerycluster.yml
+++ b/group_vars/celerycluster.yml
@@ -34,6 +34,8 @@ autofs_mount_points:
   - jwd
   - usrlocal
   - usrlocal_celerycluster
+  - cache
+  - misc
 
 # SystemD
 galaxy_systemd_mode: ""

--- a/group_vars/maintenance.yml
+++ b/group_vars/maintenance.yml
@@ -76,6 +76,8 @@ autofs_mount_points:
   - gxkey
   - jwd
   - usrlocal
+  - cache
+  - misc
 
 # Role: usegalaxy-eu.bashrc
 galaxy_pulsar_app_conf: "{{ galaxy_config_dir }}/pulsar_app.yml"

--- a/group_vars/sn06/sn06.yml
+++ b/group_vars/sn06/sn06.yml
@@ -24,6 +24,8 @@ autofs_mount_points:
   - gxkey
   - jwd
   - usrlocal
+  - cache
+  - misc
 
 # Miniconda role variables (galaxyproject.miniconda)
 conda_prefix: /opt/miniconda

--- a/group_vars/sn07.yml
+++ b/group_vars/sn07.yml
@@ -24,6 +24,8 @@ autofs_mount_points:
   - gxkey
   - jwd
   - usrlocal
+  - cache
+  - misc
 
 # Miniconda role variables (galaxyproject.miniconda)
 conda_prefix: /opt/miniconda

--- a/group_vars/upload.yml
+++ b/group_vars/upload.yml
@@ -70,6 +70,8 @@ autofs_mount_points:
   - gxtest
   - gxkey
   - jwd
+  - cache
+  - misc
 
 # usegalaxy_eu.handy.os_setup
 ## packages

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -116,7 +116,7 @@ roles:
     version: 0.2.0
   - name: usegalaxy-eu.autofs
     src: https://github.com/usegalaxy-eu/ansible-autofs
-    version: 1.0.0
+    version: 1.2.0
   - name: usegalaxy_eu.fs_maintenance
     version: 0.0.7
   - name: usegalaxy_eu.rustus


### PR DESCRIPTION
Related PRs:
1. https://github.com/usegalaxy-eu/mounts/pull/16
2. https://github.com/usegalaxy-eu/ansible-autofs/pull/4

This PR will update the [ansible-autofs role](https://github.com/usegalaxy-eu/ansible-autofs) version and add the new `misc` and `cache` NFS shares to service nodes and the head nodes.

_Once this is merged and deployed, I will run a `pssh` command to add these NFS shares (including the new `jwd06`) to the respective autofs conf on all workers_
 