### PR TITLE
update ansible-autofs role version

### DIFF
--- a/requirements.yaml
+++ b/requirements.yaml
@@ -116,7 +116,7 @@ roles:
     version: 0.2.0
   - name: usegalaxy-eu.autofs
     src: https://github.com/usegalaxy-eu/ansible-autofs
-    version: 1.2.0
+    version: 1.3.0
   - name: usegalaxy_eu.fs_maintenance
     version: 0.0.7
   - name: usegalaxy_eu.rustus


### PR DESCRIPTION
So, what's changed:
1. In the autofs conf: we have removed the restriction of `nfsvers=3` to make way for the latest ZFS shares (e.g., jwd06, cache06, misc06, etc.) through the [PR](https://github.com/usegalaxy-eu/ansible-autofs/pull/5)
2. To avoid surprises, we have added `vers=3` to the `nfs_options` of all the shares we had until now through the [PR](https://github.com/usegalaxy-eu/mounts/pull/17) (this PR should be merged first before merging this one)

