### PR TITLE
add new jwd06 to object store and readjust weights

### DIFF
--- a/templates/galaxy/config/object_store_conf.xml.j2
+++ b/templates/galaxy/config/object_store_conf.xml.j2
@@ -218,19 +218,26 @@ The storage consists of 16 Gen6 type A200 storage nodes and 16 Gen5 type X410 no
             <files_dir path="/data/dnb10/galaxy_db/files"/>
             <extra_dir type="job_work" path="/data/jwd05e/main"/>
         </backend>
-        <backend id="files29" type="disk" weight="1" store_by="uuid">
+        <backend id="files29" type="disk" weight="2" store_by="uuid">
             <badges>
                 <more_stable />
             </badges>
             <files_dir path="/data/dnb11/galaxy_db/files"/>
             <extra_dir type="job_work" path="/data/jwd02f/main"/>
         </backend>
-        <backend id="files30" type="disk" weight="1" store_by="uuid">
+        <backend id="files30" type="disk" weight="2" store_by="uuid">
             <badges>
                 <more_stable />
             </badges>
             <files_dir path="/data/dnb11/galaxy_db/files"/>
             <extra_dir type="job_work" path="/data/jwd05e/main"/>
+        </backend>
+        <backend id="files31" type="disk" weight="1" store_by="uuid">
+            <badges>
+                <more_stable />
+            </badges>
+            <files_dir path="/data/dnb11/galaxy_db/files"/>
+            <extra_dir type="job_work" path="/data/jwd06/main"/>
         </backend>
         <backend id="secondary" type="disk" weight="0" store_by="id">
             <files_dir path="/data/0/galaxy_db/files"/>


### PR DESCRIPTION
This PR adds the new `jwd06` to the Galaxy object store, with a weight set to 1 and the weights of `jwd02f` and `jwd05e` increased to 2. 

Before merging this PR, the following should be done:

We need to propagate the changes part of these PRs: [PR1](https://github.com/usegalaxy-eu/mounts/pull/17), [PR2](https://github.com/usegalaxy-eu/ansible-autofs/pull/5) to all the worker nodes
1. Remove string `nfsvers=3` if present in `/etc/auto.master.d/data.autofs`
```
pssh -h /tmp/cloud_workers -l centos -i "sudo sed -i 's/,*nfsvers=3//g' /etc/auto.master.d/data.autofs"
```
2. Add `vers=3` to everything in `/etc/auto.data` except if the line starts with jwd06, or misc06, or cache06
```
pssh -h /tmp/cloud_workers -l centos -i 'sudo sed -i -E "/^(jwd06|misc06|cache06)/!s/^([^\t ]+[ \t]+-[^,]+),/\1,vers=3,/" /etc/auto.data'

# and

pssh -h /tmp/cloud_workers -l centos -i 'sudo sed -i -E "/^(jwd06|misc06|cache06)/!s/^([^\t ]+[ \t]+-[^,]+),/\1,vers=3,/" /etc/auto.usrlocal'

```
3. restart autofs
```
pssh -h /tmp/cloud_workers -l centos -i "sudo systemctl restart autofs"
```

Similarly, for the Galaxy, and service nodes, ensure their playbooks are run to deploy these changes. 