### PR TITLE
reorder the vars files in the maintenance playbook

### DIFF
--- a/maintenance.yml
+++ b/maintenance.yml
@@ -6,10 +6,10 @@
   vars_files:
     - secret_group_vars/db-main.yml
     - secret_group_vars/all.yml
+    - group_vars/all.yml    
     - mounts/dest/all.yml
     - mounts/mountpoints.yml
     - group_vars/maintenance.yml
-    - group_vars/all.yml
   collections:
     - devsec.hardening
   handlers:

--- a/maintenance.yml
+++ b/maintenance.yml
@@ -6,7 +6,7 @@
   vars_files:
     - secret_group_vars/db-main.yml
     - secret_group_vars/all.yml
-    - group_vars/all.yml    
+    - group_vars/all.yml
     - mounts/dest/all.yml
     - mounts/mountpoints.yml
     - group_vars/maintenance.yml


### PR DESCRIPTION
the autofs related testing.

I tried to run the playbook via Jenkins and looks like it is failing and I think because the `group_vars/all.yml` is coming after the mountpoints related vars file the values for [autofs_conf_files](https://github.com/usegalaxy-eu/infrastructure-playbook/blob/master/group_vars/all.yml#L170) are being overwritten and hence the below error 

```
18:54:01 
TASK [usegalaxy-eu.autofs : Copy mount point configuration file] ***************
18:54:02 
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ansible.errors.AnsibleUndefinedVariable: 'dict object' has no attribute 'cache'. 'dict object' has no attribute 'cache'
18:54:02 
failed: [maintenance.galaxyproject.eu] (item={'label': 'data', 'src': 'data.conf.j2', 'dest': '/etc/auto.data'}) => {"ansible_loop_var": "item", "changed": false, "item": {"dest": "/etc/auto.data", "label": "data", "src": "data.conf.j2"}, "msg": "AnsibleUndefinedVariable: 'dict object' has no attribute 'cache'. 'dict object' has no attribute 'cache'"}
```