### PR TITLE
switch tusd to use the new misc shares

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -1,7 +1,7 @@
 ---
 # Upload dirs
-upload_dir_test: "{{ jwd.jwd04.path }}/tus_upload/test"
-upload_dir_main: "{{ jwd.jwd04.path }}/tus_upload/main"
+upload_dir_test: "{{ misc.misc06.path }}/tus_upload/test"
+upload_dir_main: "{{ misc.misc06.path }}/tus_upload/main"
 # Galaxy user and group
 galaxy_user:
   name: galaxy

--- a/group_vars/gxconfig.yml
+++ b/group_vars/gxconfig.yml
@@ -1305,7 +1305,7 @@ base_app_main: &BASE_APP_MAIN
   # The upload store is a temporary directory in which files uploaded by
   # the tus middleware or server for user uploads will be placed.
   # Defaults to new_file_path if not set.
-  tus_upload_store: "/data/jwd04/tus_upload/main"
+  tus_upload_store: "/data/misc06/tus_upload/main"
 
   # The upload store is a temporary directory in which files uploaded by
   # the tus middleware or server for remote job files (Pulsar) will be


### PR DESCRIPTION
This PR switches `rustus`/`tusd` to use the new `misc06` share.

Before merging and deploying:
1. Ensure that the `/data/misc06` is mounted in all nodes (workers, upload, celery, head node)
2. Not sure whether the `tusd` role would automatically create the necessary directories, so ensure the directories (`/data/misc06/tus_upload/test`, `/data/misc06/tus_upload/main`) are created.

**Not for Friday**