### PR TITLE
Apollo in traefik

### DIFF
--- a/files/traefik/rules/apollo-mw.yml
+++ b/files/traefik/rules/apollo-mw.yml
@@ -1,0 +1,5 @@
+http:
+  middlewares:
+    apollo-mw:
+      buffering:
+        maxRequestBodyBytes: 2000000

--- a/files/traefik/rules/apollo-router.yml
+++ b/files/traefik/rules/apollo-router.yml
@@ -18,9 +18,6 @@ http:
       service: apollo
       entryPoints:
         - websecure
-      serversTransport:
-        forwardingTimeouts:
-          idleConnTimeout: 300s
       tls:
         certResolver: "route53"
         domains:

--- a/files/traefik/rules/apollo-router.yml
+++ b/files/traefik/rules/apollo-router.yml
@@ -1,0 +1,18 @@
+http:
+  routers:
+    apollo-api-rtr:
+      rule: "(Host(`usegalaxy.eu`) || HostRegexp(`^.+\\.usegalaxy\\.eu`)) && PathPrefix(`/apollo_api`)"
+      middleware:
+        - apollo-mw
+      service: apollo
+      entryPoints:
+        - websecure
+      serversTransport:
+        forwardingTimeouts:
+          idleConnTimeout: 300s
+      tls:
+        certResolver: "route53"
+        domains:
+          - main: "usegalaxy.eu"
+            sans:
+              - "*.ep.interactivetool.usegalaxy.eu"

--- a/files/traefik/rules/apollo-router.yml
+++ b/files/traefik/rules/apollo-router.yml
@@ -9,6 +9,8 @@ http:
         certResolver: "route53"
         domains:
           - main: "usegalaxy.eu"
+            sans:
+              - "*.usegalaxy.eu"
     apollo-api-rtr:
       rule: "(Host(`usegalaxy.eu`) || HostRegexp(`^.+\\.usegalaxy\\.eu`)) && PathPrefix(`/apollo_api`)"
       middleware:
@@ -23,3 +25,5 @@ http:
         certResolver: "route53"
         domains:
           - main: "usegalaxy.eu"
+            sans:
+              - "*.usegalaxy.eu"

--- a/files/traefik/rules/apollo-router.yml
+++ b/files/traefik/rules/apollo-router.yml
@@ -1,5 +1,14 @@
 http:
   routers:
+    apollo-rtr:
+      rule: "(Host(`usegalaxy.eu`) || HostRegexp(`^.+\\.usegalaxy\\.eu`)) && (PathPrefix(`/apollo`) || PathPrefix(`/apollo-permapol`))"
+      service: apollo
+      entryPoints:
+        - websecure
+      tls:
+        certResolver: "route53"
+        domains:
+          - main: "usegalaxy.eu"
     apollo-api-rtr:
       rule: "(Host(`usegalaxy.eu`) || HostRegexp(`^.+\\.usegalaxy\\.eu`)) && PathPrefix(`/apollo_api`)"
       middleware:
@@ -14,5 +23,3 @@ http:
         certResolver: "route53"
         domains:
           - main: "usegalaxy.eu"
-            sans:
-              - "*.ep.interactivetool.usegalaxy.eu"

--- a/files/traefik/rules/apollo-router.yml
+++ b/files/traefik/rules/apollo-router.yml
@@ -1,21 +1,10 @@
 http:
   routers:
     apollo-rtr:
-      rule: "(Host(`usegalaxy.eu`) || HostRegexp(`^.+\\.usegalaxy\\.eu`)) && (PathPrefix(`/apollo`) || PathPrefix(`/apollo-permapol`))"
+      rule: "(Host(`usegalaxy.eu`) || HostRegexp(`^.+\\.usegalaxy\\.eu`)) && (PathPrefix(`/apollo`) || PathPrefix(`/apollo-permapol`) || PathPrefix(`/apollo_api`))"
       service: apollo
-      entryPoints:
-        - websecure
-      tls:
-        certResolver: "route53"
-        domains:
-          - main: "usegalaxy.eu"
-            sans:
-              - "*.usegalaxy.eu"
-    apollo-api-rtr:
-      rule: "(Host(`usegalaxy.eu`) || HostRegexp(`^.+\\.usegalaxy\\.eu`)) && PathPrefix(`/apollo_api`)"
-      middleware:
+      middlewares:
         - apollo-mw
-      service: apollo
       entryPoints:
         - websecure
       tls:

--- a/files/traefik/rules/apollo-service.yml
+++ b/files/traefik/rules/apollo-service.yml
@@ -3,4 +3,4 @@ http:
     apollo:
       loadBalancer:
         servers:
-          - address: apollo.internal.galaxyproject.eu #replace once mq02 is in playbook
+          - address: apollo.internal.galaxyproject.eu

--- a/files/traefik/rules/apollo-service.yml
+++ b/files/traefik/rules/apollo-service.yml
@@ -1,6 +1,11 @@
 http:
+  serversTransports:
+    apollo-transport:
+      forwardingTimeouts:
+        idleConnTimeout: 300s
   services:
     apollo:
       loadBalancer:
+        serversTransport: apollo-transport
         servers:
-          - address: apollo.internal.galaxyproject.eu
+          - url: "http://apollo.internal.galaxyproject.eu"

--- a/files/traefik/rules/apollo-service.yml
+++ b/files/traefik/rules/apollo-service.yml
@@ -1,0 +1,6 @@
+http:
+  services:
+    apollo:
+      loadBalancer:
+        servers:
+          - address: apollo.internal.galaxyproject.eu #replace once mq02 is in playbook


### PR DESCRIPTION
Add router for directly routing `/apollo_api` with mentioned middleware and timeout settings 
- https://github.com/usegalaxy-eu/issues/issues/652#issuecomment-2725170247

Additionally add a router for `/apollo` and `/apollo-permapol` which use `apollo.internal.galaxyproject.eu` as service directly (without nginx). This way we do not need to debug/reconfigure 2 proxies.

Before we merge this, I would deploy it manually and test it