### PR TITLE
add gxadmin destination queue run time query to telegraf for TPV Broker/API

### DIFF
--- a/group_vars/maintenance.yml
+++ b/group_vars/maintenance.yml
@@ -290,6 +290,13 @@ telegraf_plugins_extra:
       - timeout = "60s"
       - data_format = "influx"
       - interval = "2m"
+  galaxy_destination_queue_run_time: # This is used for the TPV Broker.
+    plugin: "exec"
+    config:
+      - commands = ["{{ custom_telegraf_env }} /usr/bin/gxadmin iquery destination-queue-run-time --seconds --older-than=90"]
+      - timeout = "30m"
+      - data_format = "influx"
+      - interval = "24h"
 
 
 # Role: hxr.monitor-cluster


### PR DESCRIPTION
To deploy the [TPV Broker](https://github.com/usegalaxy-eu/tpv-broker), we need to have additional data about the queue runtime per tool per destination to make decision on which destination to pick for each job.

Example output:
```
destination-queue-run-time,destination_id=condor_tpv,tool_id=toolshed.g2.bx.psu.edu/repos/iuc/metaphlan/metaphlan/3.0.8+galaxy0 count=56,avg_queue=254.4464285714285714,min_queue=5,median_queue=50,perc_95_queue=1071.5,perc_99_queue=1534.7000000000014,max_queue=   2477 1802,avg_run=764.1964285714285714,min_run=159,median_run=628.5,perc_95_run=2183.25,perc_99_run=2947.5,max_run=2953
destination-queue-run-time,destination_id=condor_tpv,tool_id=toolshed.g2.bx.psu.edu/repos/iuc/metaphlan/metaphlan/3.0.9+galaxy0 count=16,avg_queue=150.8750000000000000,min_queue=8,median_queue=76.5,perc_95_queue=470,perc_99_queue=719.5999999999999,max_queue=78   2478 2,avg_run=994.1875000000000000,min_run=70,median_run=377.5,perc_95_run=3093.25,perc_99_run=4639.449999999999,max_run=5026 
```

I ran the added `gxadmin` query (on the maintenance node), which took around 9 minutes; this query is configured to run once every 24 hours via this PR.

FYI @pauldg