### PR TITLE
Rebalance object store weights

### DIFF
--- a/templates/galaxy/config/object_store_conf.xml.j2
+++ b/templates/galaxy/config/object_store_conf.xml.j2
@@ -218,21 +218,21 @@ The storage consists of 16 Gen6 type A200 storage nodes and 16 Gen5 type X410 no
             <files_dir path="/data/dnb10/galaxy_db/files"/>
             <extra_dir type="job_work" path="/data/jwd05e/main"/>
         </backend>
-        <backend id="files29" type="disk" weight="1" store_by="uuid">
+        <backend id="files29" type="disk" weight="2" store_by="uuid">
             <badges>
                 <more_stable />
             </badges>
             <files_dir path="/data/dnb11/galaxy_db/files"/>
             <extra_dir type="job_work" path="/data/jwd02f/main"/>
         </backend>
-        <backend id="files30" type="disk" weight="1" store_by="uuid">
+        <backend id="files30" type="disk" weight="2" store_by="uuid">
             <badges>
                 <more_stable />
             </badges>
             <files_dir path="/data/dnb11/galaxy_db/files"/>
             <extra_dir type="job_work" path="/data/jwd05e/main"/>
         </backend>
-        <backend id="files31" type="disk" weight="2" store_by="uuid">
+        <backend id="files31" type="disk" weight="1" store_by="uuid">
             <badges>
                 <more_stable />
             </badges>


### PR DESCRIPTION
JWD06 performance dropped to 44MB/s, so rebalancing (weight `1` to `jwd06`, and `2` to `jwd02f`, and `jwd05e`) to avoid increased number of unprocessed jobs.