### PR TITLE
Add logrotate to celery host to rotate /var/log/messages

### DIFF
--- a/celery.yml
+++ b/celery.yml
@@ -37,3 +37,4 @@
     ## Filesystems
     - usegalaxy-eu.autofs # Set up the mount points which will be needed later
     - usegalaxy_eu.flower
+    - usegalaxy-eu.logrotate # Rotate logs

--- a/group_vars/celerycluster.yml
+++ b/group_vars/celerycluster.yml
@@ -68,15 +68,15 @@ lp_logrotate_confd:
   - path: rsyslogd-messages
     conf: |
       /var/log/messages {
-      daily
-      rotate 7
-      compress
-      delaycompress
-      missingok
-      notifempty
-      dateext
-      maxage 7
-      postrotate
-        /usr/bin/systemctl reload rsyslog >/dev/null 2>&1 || true
-      endscript
+        daily
+        rotate 7
+        compress
+        delaycompress
+        missingok
+        notifempty
+        dateext
+        maxage 7
+        postrotate
+          /usr/bin/systemctl reload rsyslog >/dev/null 2>&1 || true
+        endscript
       }

--- a/group_vars/celerycluster.yml
+++ b/group_vars/celerycluster.yml
@@ -62,3 +62,21 @@ flower_broker_api: "https://flower:{{ rabbitmq_password_flower }}@{{ rabbitmq_ur
 flower_broker_url: "amqp://flower:{{ rabbitmq_password_flower }}@{{ rabbitmq_url }}:5671/galaxy?ssl=true"
 
 tailscale_authkey: "{{ tailacale_auth_key_usegalaxy_eu }}"
+
+# Role: usegalaxy-eu.logrotate
+lp_logrotate_confd:
+  - path: rsyslogd-messages
+    conf: |
+      /var/log/messages {
+      daily
+      rotate 7
+      compress
+      delaycompress
+      missingok
+      notifempty
+      dateext
+      maxage 7
+      postrotate
+        /usr/bin/systemctl reload rsyslog >/dev/null 2>&1 || true
+      endscript
+      }


### PR DESCRIPTION
The celery host only has 12 GiB of root disk space, and the `/var/log/messages` does not seem to be rotated, filling up the space. Even though we use `journaled` logs for celery and services, sometimes it is useful to have the `/var/log/messages`. So this PR will add the log rotation. It will rotate daily and keep the logs of the last 7 days in compressed format, and anything older than that will be deleted. 

Please double-check the conf (just in case, it's been a while for me). 