### PR TITLE
add explicit become method to fix the CI deployment of celery playbook

### DIFF
--- a/celery.yml
+++ b/celery.yml
@@ -3,6 +3,7 @@
   hosts: celerycluster
   become: true
   become_user: root
+  become_method: sudo
   vars_files:
     - "secret_group_vars/all.yml"
     - "secret_group_vars/pulsar.yml"

--- a/celery.yml
+++ b/celery.yml
@@ -38,4 +38,6 @@
     ## Filesystems
     - usegalaxy-eu.autofs # Set up the mount points which will be needed later
     - usegalaxy_eu.flower
-    - usegalaxy-eu.logrotate # Rotate logs
+    - role: usegalaxy-eu.logrotate # Rotate logs
+      become: true
+      become_user: root


### PR DESCRIPTION
CI error: 

```
09:20:24 TASK [usegalaxy-eu.logrotate : Create logrotate files] *************************
09:20:36 fatal: [celery-0.galaxyproject.eu]: FAILED! => {"msg": "Timeout (12s) waiting for privilege escalation prompt: "}
```
Not sure if this will fix it; it's just an attempt since I don't have a local deployment setup to test it.