### PR TITLE
add jwd07 to th eobject store conf and disable jwd02f by setting weight=0

### DIFF
--- a/templates/galaxy/config/object_store_conf.xml.j2
+++ b/templates/galaxy/config/object_store_conf.xml.j2
@@ -218,7 +218,7 @@ The storage consists of 16 Gen6 type A200 storage nodes and 16 Gen5 type X410 no
             <files_dir path="/data/dnb10/galaxy_db/files"/>
             <extra_dir type="job_work" path="/data/jwd05e/main"/>
         </backend>
-        <backend id="files29" type="disk" weight="2" store_by="uuid">
+        <backend id="files29" type="disk" weight="0" store_by="uuid">
             <badges>
                 <more_stable />
             </badges>
@@ -238,6 +238,13 @@ The storage consists of 16 Gen6 type A200 storage nodes and 16 Gen5 type X410 no
             </badges>
             <files_dir path="/data/dnb11/galaxy_db/files"/>
             <extra_dir type="job_work" path="/data/jwd06/main"/>
+        </backend>
+        <backend id="files32" type="disk" weight="2" store_by="uuid">
+            <badges>
+                <more_stable />
+            </badges>
+            <files_dir path="/data/dnb11/galaxy_db/files"/>
+            <extra_dir type="job_work" path="/data/jwd07/main"/>
         </backend>
         <backend id="secondary" type="disk" weight="0" store_by="id">
             <files_dir path="/data/0/galaxy_db/files"/>

--- a/templates/galaxy/config/object_store_conf.xml.j2
+++ b/templates/galaxy/config/object_store_conf.xml.j2
@@ -239,7 +239,7 @@ The storage consists of 16 Gen6 type A200 storage nodes and 16 Gen5 type X410 no
             <files_dir path="/data/dnb11/galaxy_db/files"/>
             <extra_dir type="job_work" path="/data/jwd06/main"/>
         </backend>
-        <backend id="files32" type="disk" weight="2" store_by="uuid">
+        <backend id="files32" type="disk" weight="2" store_by="uuid" device="dnb11">
             <badges>
                 <more_stable />
             </badges>


### PR DESCRIPTION
This PR adds the new `jwd07` to the Galaxy object store and disables `jwd02f` by setting `weight=0` so we can retire `jwd02f` in the next few days.

To Do in order:
1. Update workers to include new shares; manual task, use `pssh`.
2. Merge the mounts [PR](https://github.com/usegalaxy-eu/mounts/pull/18) to add new NFS shares `jwd07`, `cache07`, and `misc07`.
3. Run the CI for `sn06`, and `celery`.