### PR TITLE
migrate upload to zfs07

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -7,8 +7,8 @@ short_term_web_storage_dir: "{{ misc.misc06.path }}/short_term_web_storage/"
 ftp_upload_dir: "{{ misc.misc06.path }}/incoming"
 
 # Upload dirs
-upload_dir_test: "{{ misc.misc06.path }}/tus_upload/test"
-upload_dir_main: "{{ misc.misc06.path }}/tus_upload/main" # tus_upload_store
+upload_dir_test: "{{ misc.misc07.path }}/tus_upload/test"
+upload_dir_main: "{{ misc.misc07.path }}/tus_upload/main" # tus_upload_store
 nginx_upload_dir: "{{ misc.misc06.path }}/nginx_upload/"
 
 galaxy_config:


### PR DESCRIPTION
This migration is being carried out since we have `ZFS07` and want to avoid moving everything to `ZFS06`. 