### PR TITLE
Tweak pulsar fr01 conf

### DIFF
--- a/files/galaxy/tpv/destinations.yml.j2
+++ b/files/galaxy/tpv/destinations.yml.j2
@@ -242,12 +242,18 @@ destinations:
         - it03-pulsar
 
   pulsar_fr01_tpv:
-    runner: pulsar_eu_fr01
     inherits: pulsar_default
+    runner: pulsar_eu_fr01
     max_accepted_cores: 8
     max_accepted_mem: 63
     min_accepted_gpus: 0
     max_accepted_gpus: 0
+    params:
+      singularity_volumes: '$job_directory:rw,$tool_directory:ro,$job_directory/outputs:rw,$working_directory:rw,/cvmfs/data.galaxyproject.org:ro'
+    env:
+      TMP: $_GALAXY_JOB_TMP_DIR
+      TEMP: $_GALAXY_JOB_TMP_DIR
+      TMPDIR: $_GALAXY_JOB_TMP_DIR
     scheduling:
       require:
         - fr-pulsar


### PR DESCRIPTION
Syncing the fr01 pulsar conf with other configs, I suspect the error we get with fastqc on [the monitoring page](https://monitor.usegalaxy.it/index/report_2025-03-30_23%3A25.html#fr-pulsar-usegalaxy_eu) come from the missing tmp env vars