### PR TITLE
fix subdomain switcher template

### DIFF
--- a/templates/galaxy/webhooks/subdomain_switcher/script.js.j2
+++ b/templates/galaxy/webhooks/subdomain_switcher/script.js.j2
@@ -8,7 +8,7 @@
         url: "https://{{ galaxy_instance_hostname }}",
       },
       {% for subdomain in galaxy_themes_subdomains %}
-      {% if 'hidden' not in subdomain or not subdomain.hidden %}
+      {% if 'hidden' not in subdomain.name or not subdomain.hidden %}
       {
         label: "{{ galaxy_config.galaxy.brand_by_host[subdomain.name ~ '.' ~ galaxy_instance_hostname] }}",
         url: "https://{{ subdomain.name }}.{{ galaxy_instance_hostname }}",


### PR DESCRIPTION
Jenkins failed with:
~~~
failed: [sn06.galaxyproject.eu] (item=/scratch/workspace/usegalaxy-eu/playbooks/sn06/templates/galaxy/webhooks//subdomain_switcher/script.js.j2) => {"ansible_loop_var": "item", "changed": false, "item": "/scratch/workspace/usegalaxy-eu/playbooks/sn06/templates/galaxy/webhooks//subdomain_switcher/script.js.j2", "msg": "AnsibleUndefinedVariable: 'dict object' has no attribute 'nanopore.usegalaxy.eu'. 'dict object' has no attribute 'nanopore.usegalaxy.eu'"}
~~~
I think the reason is that it tried to compare a string with a list item