### PR TITLE
bump firewall role 1.0.1→2.0.0

### DIFF
--- a/requirements.yaml
+++ b/requirements.yaml
@@ -156,7 +156,7 @@ roles:
     version: 2.0.0
   - src: https://github.com/usegalaxy-eu/ansible-fw-glxeu-generic
     name: usegalaxy_eu.firewall
-    version: 1.0.1
+    version: 2.0.0
   - name: usegalaxy_eu.dnbd3
     src: https://github.com/usegalaxy-eu/ansible-dnbd3
     version: main


### PR DESCRIPTION
add new networks 10.4.68.0/24 and 132.230.68.0/24 to trusted zone