### PR TITLE
update celery DNS entry in the ansible inventory file

### DIFF
--- a/hosts
+++ b/hosts
@@ -51,7 +51,7 @@ cvmfs-stratum0-test.galaxyproject.eu
 plausible.galaxyproject.eu
 
 [celerycluster]
-celery-0.galaxyproject.eu
+celery-1.galaxyproject.eu
 
 # Baremetal
 [galaxyservers]


### PR DESCRIPTION
This PR fixes the failing Celery CI. 

The DNS was changed as part of the redeployment and migration of celery from cloud to the KVM https://github.com/usegalaxy-eu/infrastructure/pull/232