### PR TITLE
Add a new custom_telegraf_env_without_gdpr_mode variable for fetching anonymous user jobs count per destination

### DIFF
--- a/group_vars/maintenance.yml
+++ b/group_vars/maintenance.yml
@@ -150,6 +150,7 @@ telegraf_agent_metric_buffer_limit: 20000
 telegraf_agent_hostname: "{{ hostname }}"
 telegraf_agent_version: 1.17.2
 custom_telegraf_env: "/usr/bin/env GDPR_MODE=1 PGUSER={{ galaxy_user.name }} PGHOST={{ postgres_host }} GALAXY_ROOT={{ galaxy_server_dir }} GALAXY_CONFIG_FILE={{ galaxy_config_file }} GXADMIN_PYTHON={{ galaxy_venv_dir }}/bin/python"
+# When GDPR_MODE=1 is set for the Telegraf ENV the galaxy_num_anonymous_jobs_by_destination.sh script returns empty. When this is enabled, gxadmin masks the user details, which is non-existent for anonymous users, leading to empty results.
 custom_telegraf_env_without_gdpr_mode: "/usr/bin/env GDPR_MODE=0 PGUSER={{ galaxy_user.name }} PGHOST={{ postgres_host }} GALAXY_ROOT={{ galaxy_server_dir }} GALAXY_CONFIG_FILE={{ galaxy_config_file }} GXADMIN_PYTHON={{ galaxy_venv_dir }}/bin/python"
 telegraf_plugins_extra:
   postgres:

--- a/group_vars/maintenance.yml
+++ b/group_vars/maintenance.yml
@@ -150,7 +150,7 @@ telegraf_agent_metric_buffer_limit: 20000
 telegraf_agent_hostname: "{{ hostname }}"
 telegraf_agent_version: 1.17.2
 custom_telegraf_env: "/usr/bin/env GDPR_MODE=1 PGUSER={{ galaxy_user.name }} PGHOST={{ postgres_host }} GALAXY_ROOT={{ galaxy_server_dir }} GALAXY_CONFIG_FILE={{ galaxy_config_file }} GXADMIN_PYTHON={{ galaxy_venv_dir }}/bin/python"
-custom_telegraf_env_without_gdpr_mode: "/usr/bin/env GDPR_MODE=1 PGUSER={{ galaxy_user.name }} PGHOST={{ postgres_host }} GALAXY_ROOT={{ galaxy_server_dir }} GALAXY_CONFIG_FILE={{ galaxy_config_file }} GXADMIN_PYTHON={{ galaxy_venv_dir }}/bin/python"
+custom_telegraf_env_without_gdpr_mode: "/usr/bin/env GDPR_MODE=0 PGUSER={{ galaxy_user.name }} PGHOST={{ postgres_host }} GALAXY_ROOT={{ galaxy_server_dir }} GALAXY_CONFIG_FILE={{ galaxy_config_file }} GXADMIN_PYTHON={{ galaxy_venv_dir }}/bin/python"
 telegraf_plugins_extra:
   postgres:
     plugin: "postgresql"

--- a/group_vars/maintenance.yml
+++ b/group_vars/maintenance.yml
@@ -150,6 +150,7 @@ telegraf_agent_metric_buffer_limit: 20000
 telegraf_agent_hostname: "{{ hostname }}"
 telegraf_agent_version: 1.17.2
 custom_telegraf_env: "/usr/bin/env GDPR_MODE=1 PGUSER={{ galaxy_user.name }} PGHOST={{ postgres_host }} GALAXY_ROOT={{ galaxy_server_dir }} GALAXY_CONFIG_FILE={{ galaxy_config_file }} GXADMIN_PYTHON={{ galaxy_venv_dir }}/bin/python"
+custom_telegraf_env_without_gdpr_mode: "/usr/bin/env GDPR_MODE=1 PGUSER={{ galaxy_user.name }} PGHOST={{ postgres_host }} GALAXY_ROOT={{ galaxy_server_dir }} GALAXY_CONFIG_FILE={{ galaxy_config_file }} GXADMIN_PYTHON={{ galaxy_venv_dir }}/bin/python"
 telegraf_plugins_extra:
   postgres:
     plugin: "postgresql"
@@ -298,7 +299,7 @@ telegraf_plugins_extra:
       - commands = [
         "{{ custom_telegraf_env }} /usr/bin/galaxy_failed_jobs_by_destination.sh",
         "{{ custom_telegraf_env }} /usr/bin/galaxy_most_used_tools_by_destination.sh",
-        "{{ custom_telegraf_env }} /usr/bin/galaxy_num_anonymous_jobs_by_destination.sh",
+        "{{ custom_telegraf_env_without_gdpr_mode }} /usr/bin/galaxy_num_anonymous_jobs_by_destination.sh",
         "{{ custom_telegraf_env }} /usr/bin/galaxy_unique_users_job_count_by_destination.sh",
         "{{ custom_telegraf_env }} /usr/bin/galaxy_longest_running_jobs_by_destination.sh",
         "{{ custom_telegraf_env }} /usr/bin/galaxy_num_user_running_jobs_count_by_destination.sh",


### PR DESCRIPTION
When `GDPR_MODE=1` is set for the Telegraf ENV the `galaxy_num_anonymous_jobs_by_destination.sh` script returns empty. When this is enabled, `gxadmin` masks the user details, which is non-existent for anonymous users, leading to empty results. 

Galaxy Job Radar telegraf tasks fix.