### PR TITLE
Remove GDPR_MODE=0 for the custom_telegraf_env_without_gdpr_mode variable on the maintenance playbook

### DIFF
--- a/group_vars/maintenance.yml
+++ b/group_vars/maintenance.yml
@@ -150,8 +150,8 @@ telegraf_agent_metric_buffer_limit: 20000
 telegraf_agent_hostname: "{{ hostname }}"
 telegraf_agent_version: 1.17.2
 custom_telegraf_env: "/usr/bin/env GDPR_MODE=1 PGUSER={{ galaxy_user.name }} PGHOST={{ postgres_host }} GALAXY_ROOT={{ galaxy_server_dir }} GALAXY_CONFIG_FILE={{ galaxy_config_file }} GXADMIN_PYTHON={{ galaxy_venv_dir }}/bin/python"
-# When GDPR_MODE=1 is set for the Telegraf ENV the galaxy_num_anonymous_jobs_by_destination.sh script returns empty. When this is enabled, gxadmin masks the user details, which is non-existent for anonymous users, leading to empty results.
-custom_telegraf_env_without_gdpr_mode: "/usr/bin/env GDPR_MODE=0 PGUSER={{ galaxy_user.name }} PGHOST={{ postgres_host }} GALAXY_ROOT={{ galaxy_server_dir }} GALAXY_CONFIG_FILE={{ galaxy_config_file }} GXADMIN_PYTHON={{ galaxy_venv_dir }}/bin/python"
+# When GDPR_MODE is set for the Telegraf ENV the galaxy_num_anonymous_jobs_by_destination.sh script returns empty. When this is enabled, gxadmin masks the user details, which is non-existent for anonymous users, leading to empty results.
+custom_telegraf_env_without_gdpr_mode: "/usr/bin/env PGUSER={{ galaxy_user.name }} PGHOST={{ postgres_host }} GALAXY_ROOT={{ galaxy_server_dir }} GALAXY_CONFIG_FILE={{ galaxy_config_file }} GXADMIN_PYTHON={{ galaxy_venv_dir }}/bin/python"
 telegraf_plugins_extra:
   postgres:
     plugin: "postgresql"


### PR DESCRIPTION
Even when using `GDPR_MODE=0` the script does not output anything, so totally removing the `GDPR_MODE` ENV set for the custom telegraf ENV.