### PR TITLE
Enable Gxadmin Galaxy clean up cron task

### DIFF
--- a/group_vars/sn06/sn06.yml
+++ b/group_vars/sn06/sn06.yml
@@ -61,7 +61,7 @@ fsm_cron_tasks:
     job: ". {{ galaxy_root }}/.bashrc && docker system prune -f > /dev/null"
     user: "{{ fsm_galaxy_user.username }}"
   gxadmin:
-    enable: false
+    enable: true
     name: "Gxadmin Galaxy clean up"
     minute: 0
     hour: 0


### PR DESCRIPTION
This was disabled via: 
1. https://github.com/usegalaxy-eu/infrastructure-playbook/pull/1388,
2. https://github.com/usegalaxy-eu/infrastructure-playbook/pull/1391