### PR TITLE
Raise Postgres parameter 'track_activity_query_size' to 4 KiB

### DIFF
--- a/group_vars/sn05.yml
+++ b/group_vars/sn05.yml
@@ -70,6 +70,7 @@ postgresql_conf:
 #  - log_line_prefix: "'%t:%r:%u@%d:[%p]<%m>: '"
   - log_checkpoints: "on"
   - log_min_duration_statement: 500
+  - track_activity_query_size: 4096
 postgresql_pg_hba_conf:
   - "host    postgres        galaxy          132.230.223.239/32      md5"
   - "host    postgres        galaxy          10.5.68.237/32          md5"


### PR DESCRIPTION
This change should allow to see the full text of even our most complex queries in full in `pg_stat_activity(query)` after the next server restart which would often help a lot in debugging/optimizing slow queries. By default, the query text is truncated to 1 KiB.

Since we have more than enough RAM on sn05, I see no problem with raising this limit 4-fold.
