### PR TITLE
Update and fix the condor cluster monitor GPU utilisation

### DIFF
--- a/roles/hxr.monitor-cluster/files/cluster_util-condor.sh
+++ b/roles/hxr.monitor-cluster/files/cluster_util-condor.sh
@@ -19,14 +19,14 @@ claimed_memory=$(condor_status -af Memory -constraint 'State == "Claimed"' | pas
 # Unclaimed memory
 unclaimed_memory=$(condor_status -af Memory -constraint 'State == "Unclaimed"' | paste -s -d'+' | bc)
 
-# Total number of GPU slots
-total_gpu_slots=$(condor_status -af Name -constraint 'CUDADeviceName =!= undefined' | wc -l)
+# Total number of GPU hosts
+total_gpu_slots=$(condor_status -af Name -constraint 'SlotType == "Partitionable" && TotalGPUs == 1' | wc -l)
 
-# Claimed GPUs slots
-claimed_gpus=$(condor_status -af Name -constraint 'State == "Claimed" && CUDADeviceName =!= undefined' | wc -l)
+# Claimed GPU hosts
+claimed_gpus=$( condor_status -af Name -constraint 'State == "Claimed" && TotalGPUs == 1' |  sed 's/slot[^@]*@//' | sort | uniq -c | wc -l)
 
-# Unclaimed GPUs slots
-unclaimed_gpus=$(condor_status -af Name -constraint 'State == "Unclaimed" && CUDADeviceName =!= undefined' | wc -l)
+# Unclaimed GPU hosts
+unclaimed_gpus=$((total_gpu_slots - claimed_gpus))
 
 # Total load average at the machine level
 total_loadavg=$(condor_status -af TotalLoadAvg -constraint 'SlotType == "Partitionable"' | paste -s -d'+' | bc)


### PR DESCRIPTION
Issue:
![image](https://github.com/user-attachments/assets/350852a7-4410-41e5-b092-e8cf2e003d93)

The GPU numbers have been zero since HTCondor was migrated to the latest version due to the change in the HTCondor `ClassAds` utilized. This PR fixes the snippets in retrieving and counting.