### PR TITLE
add user file and object source utilisation monitoring scripts and telegraf tasks for grafana

### DIFF
--- a/group_vars/maintenance.yml
+++ b/group_vars/maintenance.yml
@@ -315,6 +315,20 @@ telegraf_plugins_extra:
       - timeout = "600s"
       - data_format = "influx"
       - interval = "24h"
+  galaxy_user_file_source_utilisation:
+    plugin: "exec"
+    config:
+      - commands = ["{{ custom_telegraf_env }} /usr/bin/galaxy_user_file_source_utilisation"]
+      - timeout = "10s"
+      - data_format = "influx"
+      - interval = "24h"
+  galaxy_user_object_store_utilisation:
+    plugin: "exec"
+    config:
+      - commands = ["{{ custom_telegraf_env }} /usr/bin/galaxy_user_object_store_utilisation"]
+      - timeout = "10s"
+      - data_format = "influx"
+      - interval = "24h"
 
 # Role: hxr.monitor-cluster
 monitor_condor: true

--- a/roles/hxr.monitor-galaxy/files/galaxy_user_file_source_utilisation.sh
+++ b/roles/hxr.monitor-galaxy/files/galaxy_user_file_source_utilisation.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Description: This script retrieves the count of distinct user file sources, grouped by template ID, that are currently in use within the Galaxy instance.
+
+gxadmin query q "COPY (select template_id, count(*) as user_count from user_file_source GROUP BY template_id) TO STDOUT WITH (FORMAT CSV, HEADER FALSE, DELIMITER ',');" | awk -F, '{printf "user_file_source_utilisation,template_id=%s user_count=%d\n", $1, $2}'

--- a/roles/hxr.monitor-galaxy/files/galaxy_user_object_store_utilisation.sh
+++ b/roles/hxr.monitor-galaxy/files/galaxy_user_object_store_utilisation.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Description: This script retrieves the count of distinct user object sources, grouped by template ID, that are currently in use within the Galaxy instance.
+
+gxadmin query q "COPY (select template_id, count(*) as user_count from user_object_store GROUP BY template_id) TO STDOUT WITH (FORMAT CSV, HEADER FALSE, DELIMITER ',');" | awk -F, '{printf "user_object_store_utilisation,template_id=%s user_count=%d\n", $1, $2}'

--- a/roles/hxr.monitor-galaxy/tasks/main.yml
+++ b/roles/hxr.monitor-galaxy/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: "Send Galaxy job queue states stats"
-  copy:
+  ansible.builtin.copy:
     src: "galaxy_job_queue_states.sh"
     dest: "/usr/bin/galaxy_job_queue_states_stats"
     owner: root
@@ -8,7 +8,7 @@
     mode: 0755
 
 - name: "Send Galaxy jobs per handler stats"
-  copy:
+  ansible.builtin.copy:
     src: "galaxy_jobs_per_handler.sh"
     dest: "/usr/bin/galaxy_jobs_per_handler_stats"
     owner: root
@@ -16,7 +16,7 @@
     mode: 0755
 
 - name: Copy the galaxy tool-usage script
-  copy:
+  ansible.builtin.copy:
     src: "galaxy_tool_usage.sh"
     dest: "/usr/bin/galaxy_tool_usage"
     owner: root
@@ -24,9 +24,25 @@
     mode: 0755
 
 - name: Copy the galaxy monthly active users script
-  copy:
+  ansible.builtin.copy:
     src: "galaxy_monthly_active_users.sh"
     dest: "/usr/bin/galaxy_monthly_active_users"
+    owner: root
+    group: root
+    mode: 0755
+
+- name: Copy the galaxy file source utilisation script
+  ansible.builtin.copy:
+    src: "galaxy_user_file_source_utilisation.sh"
+    dest: "/usr/bin/galaxy_user_file_source_utilisation"
+    owner: root
+    group: root
+    mode: 0755
+
+- name: Copy the galaxy file source utilisation script
+  ansible.builtin.copy:
+    src: "galaxy_user_object_store_utilisation.sh"
+    dest: "/usr/bin/galaxy_user_object_store_utilisation"
     owner: root
     group: root
     mode: 0755


### PR DESCRIPTION
This PR adds scripts and telegraph tasks, allowing us to create Grafana panels to get the distinct utilization count of each user file/object source. 