### PR TITLE
Add Telegraf script and task for galaxy job stats for GJR project

### DIFF
--- a/group_vars/maintenance.yml
+++ b/group_vars/maintenance.yml
@@ -308,6 +308,15 @@ telegraf_plugins_extra:
       - timeout = "300s"
       - data_format = "influx"
       - interval = "1h"
+  galaxy_job_radar_visualization_job_stats:
+    plugin: "exec"
+    config:
+      - commands = [
+        "{{ custom_telegraf_env }} /usr/bin/galaxy_jobs_stats.sh",
+        ]
+      - timeout = "60s"
+      - data_format = "influx"
+      - interval = "4h"
   galaxy_monthly_active_users:
     plugin: "exec"
     config:

--- a/roles/usegalaxy-eu.job-radar-stats-influxdb/files/galaxy_jobs_stats.sh
+++ b/roles/usegalaxy-eu.job-radar-stats-influxdb/files/galaxy_jobs_stats.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Description: This script retrieves job metadata, resource usage metrics, and compute start and finish times from the Galaxy server using gxadmin and outputs the data in InfluxDB line protocol format.
+
+# Set the time interval for the query
+hours=4
+
+# This query retrieves the job metadata
+gxadmin query q "COPY (SELECT id AS job_id, EXTRACT(EPOCH FROM create_time)::BIGINT AS job_create_time, destination_id, tool_id FROM job WHERE state IN ('ok', 'error') AND update_time >= NOW() - INTERVAL '${hours} hour' AND tool_id != '__DATA_FETCH__') TO STDOUT WITH (FORMAT CSV, HEADER FALSE, DELIMITER ',');" | awk -F',' '{job_id = $1;job_create_time = $2;destination_id = $3;tool_id = $4;gsub(/[ ,=]/, "_", tool_id);printf"galaxy_job_metadata,job_id=%s,tool_id=%s,destination_id=%s job_create_time=%ds\n", job_id, tool_id, destination_id, job_create_time;}'
+
+# This query retrieves the job resource and usage metrics
+gxadmin query q "COPY (SELECT job_id, metric_name, metric_value FROM job_metric_numeric WHERE job_id IN (SELECT id FROM job WHERE state IN ('ok', 'error') AND update_time >= NOW() - INTERVAL '${hours} hour' AND tool_id != '__DATA_FETCH__') AND metric_name IN ('galaxy_slots', 'galaxy_memory_mb', 'memory.peak')) TO STDOUT WITH (FORMAT CSV, HEADER FALSE, DELIMITER ',');" | awk -F, '{printf "galaxy_job_metrics,job_id=%s metric_name=\"%s\",metric_value=%s\n", $1, $2, $3}'
+
+# This query retrieves the jobs compute start time and final state time
+gxadmin query q "COPY (SELECT job_id, EXTRACT(EPOCH FROM MIN(CASE WHEN state = 'running' THEN create_time END))::BIGINT AS running_start_time, EXTRACT(EPOCH FROM MAX(CASE WHEN state IN ('ok', 'error') THEN create_time END))::BIGINT AS final_state_time FROM job_state_history WHERE job_id IN (SELECT id FROM job WHERE state IN ('ok', 'error') AND update_time >= NOW() - INTERVAL '${hours} hour' AND tool_id != '__DATA_FETCH__') AND state IN ('running', 'ok', 'error') GROUP BY job_id) TO STDOUT WITH (FORMAT CSV, HEADER FALSE, DELIMITER ',');" | awk -F, '{printf "galaxy_job_state,job_id=%s running_start_time=%d final_state_time=%d\n", $1, $2, $3}'

--- a/roles/usegalaxy-eu.job-radar-stats-influxdb/tasks/main.yml
+++ b/roles/usegalaxy-eu.job-radar-stats-influxdb/tasks/main.yml
@@ -13,3 +13,4 @@
     - 'galaxy_unique_users_job_count_by_destination.sh'
     - 'galaxy_longest_running_jobs_by_destination.sh'
     - 'galaxy_num_user_running_jobs_count_by_destination.sh'
+    - 'galaxy_jobs_stats.sh'


### PR DESCRIPTION
Xref: https://github.com/usegalaxy-eu/infrastructure-playbook/issues/1465

FYI @TomasVondrak

The newly added queries are not bad (see run time below). I tried several other approaches to joining them into one large query, but all the resulting ones were complex and took time to complete, so I decided to split them into three separate measurements. They can be retrieved and joined during the post-processing in the GJR.


```
time bash /tmp/test.sh      # copied the script to the maintenance node and tested it

real    0m0.332s
user    0m0.108s
sys     0m0.159s
```