### PR TITLE
Increase telegraf  metric buffer limit to 100K on the maintenance node

### DIFF
--- a/group_vars/maintenance.yml
+++ b/group_vars/maintenance.yml
@@ -146,7 +146,7 @@ fsm_scripts:
 fsm_htcondor_enable: true
 
 # Role: dj-wasabi.telegraf
-telegraf_agent_metric_buffer_limit: 20000
+telegraf_agent_metric_buffer_limit: 100000
 telegraf_agent_hostname: "{{ hostname }}"
 telegraf_agent_version: 1.17.2
 custom_telegraf_env: "/usr/bin/env GDPR_MODE=1 PGUSER={{ galaxy_user.name }} PGHOST={{ postgres_host }} GALAXY_ROOT={{ galaxy_server_dir }} GALAXY_CONFIG_FILE={{ galaxy_config_file }} GXADMIN_PYTHON={{ galaxy_venv_dir }}/bin/python"


### PR DESCRIPTION
I see the following in the telegraf logs on the maintenance node

```
May 04 18:00:00 maintenance.galaxyproject.eu telegraf[359091]: 2025-05-04T16:00:00Z W! [outputs.influxdb] Metric buffer overflow; 16915 metrics have been dropped
```

To ensure no metrics are dropped I am increasing the metric buffer limit from 20K to 100K.