### PR TITLE
Add special rule for quast with large ref genome

### DIFF
--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -136,6 +136,16 @@ tools:
               if not (tag.value == 'singularity' and tag.tag_type == TagType.REQUIRE)
           ])
 
+  toolshed.g2.bx.psu.edu/repos/iuc/quast/quast/.*:
+    cores: 10
+    rules:
+      - id: quast_memory
+        # Quast has a vastly greater memory requirement when it generates alignments between scaffolds and a user-
+        # provided reference. This is particularly true if the ref genome is large.
+        if: |
+          helpers.job_args_match(job, app, {"assembly": {"ref": {"use_ref": "true"}}, "large": True})
+        mem: 250
+
   toolshed.g2.bx.psu.edu/repos/bgruening/hifiasm/hifiasm/.*:
     cores: 10
     rules:


### PR DESCRIPTION
I hope I'm doing this correctly and if the condition is not matched tpv will fall back to the shared-database settings for Quast?

I'm also not 100% sure whether `True` is the param dict's value for an enabled boolean param?