### PR TITLE
Add TMP and singularity params to SK01.

### DIFF
--- a/files/galaxy/tpv/destinations.yml.j2
+++ b/files/galaxy/tpv/destinations.yml.j2
@@ -194,6 +194,12 @@ destinations:
     max_accepted_mem: 31
     min_accepted_gpus: 0
     max_accepted_gpus: 0
+    params:
+      singularity_volumes: '$job_directory:rw,$tool_directory:ro,$job_directory/outputs:rw,$working_directory:rw,/cvmfs/data.galaxyproject.org:ro'
+    env:
+      TMP: $_GALAXY_JOB_TMP_DIR
+      TEMP: $_GALAXY_JOB_TMP_DIR
+      TMPDIR: $_GALAXY_JOB_TMP_DIR
     scheduling:
       require:
         - sk-pulsar


### PR DESCRIPTION
FastQC tool is failing at SK01 pulsar endpoint with error: java.nio.file.FileSystemException: /tmp/imageio16923715180390984020.tmp: Read-only file system. Please add TMP and singularity params to SK01 TPV destination.