### PR TITLE
use C.UTF-8

### DIFF
--- a/files/galaxy/tpv/tool_defaults.yml
+++ b/files/galaxy/tpv/tool_defaults.yml
@@ -19,7 +19,7 @@ tools:
       - name: AWS_REQUEST_CHECKSUM_CALCULATION
         value: "when_required"
       - name: LC_ALL
-        value: C
+        value: C.UTF-8
       - name: SINGULARITYENV_LC_ALL
         value: $LC_ALL
       - name: TERM


### PR DESCRIPTION
Let's try C.UTF-8. We merge this and tomorrow @Sch-Da and @wm75 testing their use-cases. If this works, we talk to ORG and AU if they can adopt this as well.

The only problem that might arise is that the singularity containers maybe don't have this locale installed :(