### PR TITLE
fix telegraf conf for galaxy_monthly_active_users on the maintenance node

### DIFF
--- a/group_vars/maintenance.yml
+++ b/group_vars/maintenance.yml
@@ -323,7 +323,7 @@ telegraf_plugins_extra:
       - commands = ["{{ custom_telegraf_env }} /usr/bin/galaxy_monthly_active_users"]
       - timeout = "600s"
       - data_format = "influx"
-      - interval = "7d"
+      - interval = "168h"
   galaxy_user_file_source_utilisation:
     plugin: "exec"
     config:


### PR DESCRIPTION
Telegraf does not accept "7d" but "168h". Tested it locally. This will fix the CI and the telegraf on the maintenance node.