### PR TITLE
Influxdb is an internal host, the galaxyproject subdomain points to traefik

### DIFF
--- a/hosts
+++ b/hosts
@@ -9,7 +9,7 @@ build.galaxyproject.eu ansible_ssh_user=root
 beacon.galaxyproject.eu ansible_ssh_user=root
 
 [influxdb]
-influxdb.galaxyproject.eu
+influxdb.bi.privat
 
 [mq]
 mq02.galaxyproject.eu

--- a/templates/nginx/influxdb-ssl.j2
+++ b/templates/nginx/influxdb-ssl.j2
@@ -3,7 +3,7 @@ server {
     listen 443 ssl default_server;
     listen [::]:443 ssl default_server;
 
-    server_name {{ inventory_hostname }};
+    server_name {{ hostname }};
 
     location / {
     }

--- a/templates/nginx/influxdb.j2
+++ b/templates/nginx/influxdb.j2
@@ -2,7 +2,7 @@ server {
     listen 80 default_server;
     listen [::]:80 default_server;
 
-    server_name {{ inventory_hostname }};
+    server_name {{ hostname }};
 
     location /.well-known/ {
         root {{ certbot_well_known_root }};


### PR DESCRIPTION
according to the [Ansible manual](https://docs.ansible.com/ansible/latest/inventory_guide/intro_inventory.html#inventory-aliases) you should not rely on `inventory_hostname` so I choose to not use an `alias` and set `ansible_host` but rather change the nginx templates, the seed for cron can stay the same.

`influxdb.galaxyproject.eu` → `traefik.galaxyproject.eu`
`influxdb.bi.privat` → the actual machine

(I noticed that late and the initial deployment was successful because I circumvented DNS propagation times by adding a line to Jenkins `/etc/hosts` which is removed now)