### PR TITLE
Raise PG statement log threshold to 1500 ms

### DIFF
--- a/group_vars/sn05.yml
+++ b/group_vars/sn05.yml
@@ -69,7 +69,7 @@ postgresql_conf:
 #  - shared_preload_libraries: "'pg_stat_statements'"
 #  - log_line_prefix: "'%t:%r:%u@%d:[%p]<%m>: '"
   - log_checkpoints: "on"
-  - log_min_duration_statement: 500
+  - log_min_duration_statement: 1500
   - track_activity_query_size: 4096
 postgresql_pg_hba_conf:
   - "host    postgres        galaxy          132.230.223.239/32      md5"


### PR DESCRIPTION
This PR sets `log_min_duration_statement = 1500` for PG.

Rationale: looking at the PG logs I found that it is a small number of distinct queries which all take 500 - ~1300 ms that makes for the *vast majority* of entries in the PG log file. Since PG works just fine as it currently is, all those entries provide no really useful information but will tend to obscure truely interesting info. I thus propose to brisky raise the statement log threshold for PG to 1500 ms.