### PR TITLE
update telegraf tool usage over time script and the task interval

### DIFF
--- a/group_vars/maintenance.yml
+++ b/group_vars/maintenance.yml
@@ -234,7 +234,7 @@ telegraf_plugins_extra:
       - commands = ["{{ custom_telegraf_env }} /usr/bin/galaxy_tool_usage_over_time"]
       - timeout = "360s"
       - data_format = "influx"
-      - interval = "24h"
+      - interval = "720h"
   galaxy_job_queue_states_stats:
     plugin: "exec"
     config:

--- a/roles/hxr.monitor-galaxy/files/galaxy_tool_usage_over_time.sh
+++ b/roles/hxr.monitor-galaxy/files/galaxy_tool_usage_over_time.sh
@@ -2,6 +2,4 @@
 # Description: This script will collect the usage of galaxy tools over time for the last two years and output it in a format suitable for ingestion into the influxdb.
 # Also the tool_id is cleaned up to remove the last part (such as version info) of the path and replace spaces with underscores.
 
-gxadmin query q "COPY (SELECT date_trunc('month', create_time)::date AS month, REPLACE(regexp_replace(tool_id, '/[^/]+$', ''), ' ', '_') AS tool_id, COUNT(*) AS
-usage_count FROM job  WHERE create_time >= date_trunc('month', NOW()) - INTERVAL '2 years' GROUP BY month, tool_id) TO STDOUT WITH (FORMAT CSV, HEADER FALSE, DELIMITER ',');" | awk -F, '{p
-rintf "galaxy_tool_usage_over_time,tool_id=%s,month=%s usage_count=%d\n", $2, $1, $3}'
+gxadmin query q "COPY (SELECT date_trunc('month', create_time)::date AS month, REPLACE(regexp_replace(tool_id, '/[^/]+$', ''), ' ', '_') AS tool_id_no_version, COUNT(*) AS usage_count FROM job  WHERE create_time >= date_trunc('month', NOW()) - INTERVAL '2 years' GROUP BY month, tool_id_no_version) TO STDOUT WITH (FORMAT CSV, HEADER FALSE, DELIMITER ',');" | awk -F, '{printf "tool_usage_over_time,tool_id=%s,month=%s usage_count=%d\n", $2, $1, $3}'


### PR DESCRIPTION
Some fixes and updates based on the deployment and manual testing.

The interval is now set to approximately once every 30 days.

Based on the testing, I have created a panel that shows the usage over time in the existing [dashboard](https://stats.galaxyproject.eu/d/DYDPhX-Sk/tool-usage-stats?orgId=1&from=2023-05-31T22:00:00.000Z&to=2025-05-31T22:00:00.000Z&timezone=browser&var-tool_id=rna_star)