### PR TITLE
add back favicon and robots.txt

### DIFF
--- a/templates/nginx/galaxy-main.j2
+++ b/templates/nginx/galaxy-main.j2
@@ -147,7 +147,6 @@ server {
 		root /opt;
 	}
 
-
 	location /static/vgcn {
 		expires 24h;
 		autoindex on;
@@ -158,7 +157,6 @@ server {
 		autoindex on;
 		alias /data/dnb01/share/;
 	}
-
 
 	location ~ ^/plugins/(?<plug_type>[^/]+?)/((?<vis_d>[^/_]*)_?)?(?<vis_name>[^/]*?)/static/(?<static_file>.*?)$ {
 		alias /opt/galaxy/config/plugins/$plug_type/;
@@ -182,15 +180,15 @@ server {
 	}
 
 	# Route all path-based interactive tool requests to the InteractiveTool proxy application
-    location ~* ^/(interactivetool/.+)$ {
-        proxy_redirect off;
-        proxy_http_version 1.1;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "upgrade";
-        proxy_pass http://127.0.0.1:{{ gie_proxy_port }};
-    }
+	location ~* ^/(interactivetool/.+)$ {
+	        proxy_redirect off;
+	        proxy_http_version 1.1;
+	        proxy_set_header Host $host;
+	        proxy_set_header X-Real-IP $remote_addr;
+	        proxy_set_header Upgrade $http_upgrade;
+	        proxy_set_header Connection "upgrade";
+	        proxy_pass http://127.0.0.1:{{ gie_proxy_port }};
+    	}
 
 	location /.well-known/ {
 		proxy_set_header           Host $host:$server_port;
@@ -278,6 +276,14 @@ server {
 	}
 	location /terms {
 		return 301 https://galaxyproject.eu/gdpr;
+	}
+
+	location /favicon.ico {
+		alias {{ galaxy_server_dir }}/static/favicon.ico;
+	}
+
+	location /robots.txt {
+		alias {{ galaxy_server_dir }}/static/robots.txt;
 	}
 
 	resolver 8.8.8.8 8.8.4.4 valid=300s;


### PR DESCRIPTION
It was removed in https://github.com/usegalaxy-eu/infrastructure-playbook/pull/1011/files#diff-69c8912ce79b44913deefa2e4800760675b520ff92b8b5fb7f06805650d57491

I don't know why. ping @mira-miracoli 