### PR TITLE
Workaround issue with RSpace file source template

### DIFF
--- a/group_vars/sn06/sn06.yml
+++ b/group_vars/sn06/sn06.yml
@@ -107,6 +107,7 @@ telegraf_plugins_extra:
 # Custom pip installer
 pip_venv_path: "{{ galaxy_venv_dir }}"
 pip_install_dependencies:
+  - rspace-client==2.6.1  # RSpace support for Galaxy (workaround for issue https://github.com/galaxyproject/galaxy/issues/20483, remove when fixed)
   # celery and flower
   - redis
   - flower


### PR DESCRIPTION
Galaxy does not declare the `rspace-client` dependency for the RSpace file source because it ignores file source templates when determining which conditional dependencies should be installed. See Galaxy issue https://github.com/galaxyproject/galaxy/issues/20483.

Install it to the Galaxy venv via the [`hxr.install-to-venv`](https://github.com/usegalaxy-eu/infrastructure-playbook/blob/50a6e61c0b1585a264a2c95f417963aa1fedeb33/roles/hxr.install-to-venv/tasks/main.yml) role as a workaround. Write comment referencing the issue and stating that the change can be reverted when the issue is fixed.

From the [second and fourth examples for the Ansible `ansible.builtin.pip` module](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/pip_module.html#examples), I expect version specifiers to work.