### PR TITLE
Revert "Disable memory overcommit for influx"

### DIFF
--- a/influxdb.yml
+++ b/influxdb.yml
@@ -44,7 +44,6 @@
   roles:
     ## Starting configuration of the operating system
     - geerlingguy.swap
-    - usegalaxy_eu.disable_memory_overcommit
     - role: usegalaxy_eu.firewall
       become: true
     - role: usegalaxy_eu.handy.os_setup

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -170,6 +170,3 @@ roles:
     version: main
   - name: geerlingguy.swap
     version: 1.2.0
-  - name: usegalaxy_eu.disable_memory_overcommit
-    version: 0.0.1
-    src: https://github.com/usegalaxy-eu/ansible-disable-memory-overcommit


### PR DESCRIPTION
Influx crashes after enabling this. So we go the way by using swap space and increasing the memory.