### PR TITLE
Fix gpu pxe test by creating an additional GalaxyGroup

### DIFF
--- a/files/galaxy/tpv/destinations.yml.j2
+++ b/files/galaxy/tpv/destinations.yml.j2
@@ -537,9 +537,11 @@ destinations:
     scheduling:
       require:
         - docker
-        - pxe
+        - pxe-gpu
     env:
       GPU_AVAILABLE: 1
+    params:
+      requirements: 'GalaxyGroup == "training-pxe-test-gpu"'
 
   condor_singularity_gpu_pxe:
     inherits: basic_singularity_destination
@@ -552,6 +554,8 @@ destinations:
     scheduling:
       require:
         - singularity
-        - pxe
+        - pxe-gpu
     env:
       GPU_AVAILABLE: 1
+    params:
+      requirements: 'GalaxyGroup == "training-pxe-test-gpu"'

--- a/files/galaxy/tpv/roles.yml
+++ b/files/galaxy/tpv/roles.yml
@@ -9,11 +9,10 @@ roles:
   training-pxe-test*:
     rules:
       - id: gpu_pxe_test
-        if: gpus > 0
+        if: tool.gpus > 0
         scheduling:
           require:
-            - pxe
-
+            - pxe-gpu
   rstudio-poweruser*:
     rules:
       - id: rstudio_poweruser


### PR DESCRIPTION
To keep it a bit simpler, I kept the `GalaxyGroup == "training-pxe-test"` if gpus == 0 so, we don't need to create a copy of all possible other condor destinations.
only the gpu pxe jobs will get a new `GalaxyGroup == "training-pxe-test-gpu"