### PR TITLE
TPV: add params into PXE-GPU destinations to test multi GPU jobs distribution

### DIFF
--- a/files/galaxy/tpv/destinations.yml.j2
+++ b/files/galaxy/tpv/destinations.yml.j2
@@ -540,8 +540,10 @@ destinations:
         - pxe-gpu
     env:
       GPU_AVAILABLE: 1
+      CUDA_VISIBLE_DEVICES: "$_CONDOR_AssignedGPUs"
     params:
       requirements: 'GalaxyGroup == "training-pxe-test-gpu"'
+      request_gpus: "{gpus or 0}"
 
   condor_singularity_gpu_pxe:
     inherits: basic_singularity_destination
@@ -557,5 +559,7 @@ destinations:
         - pxe-gpu
     env:
       GPU_AVAILABLE: 1
+      CUDA_VISIBLE_DEVICES: "$_CONDOR_AssignedGPUs"
     params:
       requirements: 'GalaxyGroup == "training-pxe-test-gpu"'
+      request_gpus: "{gpus or 0}"

--- a/files/galaxy/tpv/destinations.yml.j2
+++ b/files/galaxy/tpv/destinations.yml.j2
@@ -540,7 +540,6 @@ destinations:
         - pxe-gpu
     env:
       GPU_AVAILABLE: 1
-      CUDA_VISIBLE_DEVICES: "$_CONDOR_AssignedGPUs"
     params:
       requirements: 'GalaxyGroup == "training-pxe-test-gpu"'
       request_gpus: "{gpus or 0}"
@@ -559,7 +558,6 @@ destinations:
         - pxe-gpu
     env:
       GPU_AVAILABLE: 1
-      CUDA_VISIBLE_DEVICES: "$_CONDOR_AssignedGPUs"
     params:
       requirements: 'GalaxyGroup == "training-pxe-test-gpu"'
       request_gpus: "{gpus or 0}"

--- a/files/galaxy/tpv/roles.yml
+++ b/files/galaxy/tpv/roles.yml
@@ -9,7 +9,7 @@ roles:
   training-pxe-test*:
     rules:
       - id: gpu_pxe_test
-        if: tool.gpus > 0
+        if: entity.gpus > 0
         scheduling:
           require:
             - pxe-gpu


### PR DESCRIPTION
This PR is my first attempt at distributing GPU jobs to individual GPUs on a multi-GPU host, rather than all of them targeting only GPU index 0. 

For further details: https://github.com/usegalaxy-eu/issues/issues/742

_I have already added `ENVIRONMENT_FOR_AssignedGPUs = CUDA_VISIBLE_DEVICES` to the multi-GPU host (the new PXE node) and restarted the condor service_