### PR TITLE
flux GPUs

### DIFF
--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -461,7 +461,7 @@ tools:
     gpus: 1
     cores: 1
     params:
-      docker_run_extra_arguments: ' --gpus all '
+      docker_run_extra_arguments: ' --gpus all  --env CUDA_VISIBLE_DEVICES=$_CONDOR_AssignedGPUs '
     env:
       GPU_AVAILABLE: 1
 


### PR DESCRIPTION
@sanjaysrikakulam this seems to work for me.

We could also pass `$_CONDOR_AssignedGPUs` to `--gpus ...` but this seems to be very tricky for quoting.

https://github.com/docker/docs/issues/11010