### PR TITLE
disable sourcemaps

### DIFF
--- a/sn06.yml
+++ b/sn06.yml
@@ -258,6 +258,7 @@
         galaxy_manage_gravity: false
         galaxy_fetch_dependencies: true
         galaxy_build_client: true
+        galaxy_client_make_target: client-production
 
 
     - usegalaxy_eu.tpv_auto_lint


### PR DESCRIPTION
Currently our client is huge, 40MB.

![grafik](https://github.com/user-attachments/assets/231749f5-bd98-4b9f-866d-0ef021932483)

ORGs is much smaller. I assume they have disabled the sourcemap builds, following one of the chats (somewhere).

But I have a few questions, we are using ansible-galaxy, but there is also ansible-collection-galaxy. What is the difference?

I hope this change will work.