### PR TITLE
TPV: bind mount host /tmp into the Singularity contianer of the funannotate_predict tool to avoid no space on device errors

### DIFF
--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -1461,7 +1461,7 @@ tools:
       GENEMARK_PATH: /usr/local/tools/genemark/etp.for_braker/bin/gmes/
       _GALAXY_JOB_TMP_DIR: '/tmp'
     params:
-      singularity_run_extra_arguments: "--env GENEMARK_PATH=/usr/local/tools/genemark/etp.for_braker/bin/gmes/"
+      singularity_run_extra_arguments: "--env GENEMARK_PATH=/usr/local/tools/genemark/etp.for_braker/bin/gmes/ -B /tmp:/tmp"
       singularity_no_mount: null
     scheduling:
       require:


### PR DESCRIPTION
Bug report of job `11ac94870d0bb33a6002a85ec10dca10`

```
[Jun 23 03:54 AM]: Loading genome assembly and parsing soft-masked repetitive sequences
[Jun 23 03:56 AM]: Genome loaded: 10,329 scaffolds; 14,439,915 bp; 100.00% repeats masked
[Jun 23 03:56 AM]: Mapping 557,291 proteins to genome using tblastn and exonerate
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/funannotate/aux_scripts/funannotate-p2g.py", line 322, in <module>
    outfile.write('>{}\n{}\n'.format(x[0], lib.softwrap(str(genome_dict[x[0]].seq))))
OSError: [Errno 28] No space left on device
Traceback (most recent call last):
  File "/usr/local/bin/funannotate", line 10, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.8/site-packages/funannotate/funannotate.py", line 716, in main
    mod.main(arguments)
  File "/usr/local/lib/python3.8/site-packages/funannotate/predict.py", line 1558, in main
    lib.exonerate2hints(Exonerate, hintsP)
  File "/usr/local/lib/python3.8/site-packages/funannotate/library.py", line 4600, in exonerate2hints
    with open(file, "r") as input:
FileNotFoundError: [Errno 2] No such file or directory: '/data/jwd06/main/085/085/85085446/working/output/predict_misc/protein_alignments.gff3'
```

So, inside the Singularity container the `/tmp` is only 64MB and hence the tools that automatically use the `/tmp` inside the Singularity containers fail with `No space left on device`. For some tools we don't want to use the `tmp` in the JWD (NFS) due to NFS related issues and for them we want these tools to use the systems `/tmp` and at the same time to avoid space related issues we should ensure we actually bind mount the localhost's `/tmp` directory into the containers.

Here is the output of `df -h` inside the running Singularity container of the tool `funannotate_predict`.
```
Filesystem                Size      Used Available Use% Mounted on
overlay                  64.0M     12.0K     64.0M   0% /
tmpfs                    64.0M     12.0K     64.0M   0% /dev
tmpfs                   198.9G         0    198.9G   0% /dev/shm
devtmpfs                  4.0M         0      4.0M   0% /dev/tty
devtmpfs                  4.0M         0      4.0M   0% /dev/null
devtmpfs                  4.0M         0      4.0M   0% /dev/zero
devtmpfs                  4.0M         0      4.0M   0% /dev/random
devtmpfs                  4.0M         0      4.0M   0% /dev/urandom
/dev/vda1                49.9G      8.5G     41.5G  17% /etc/hosts
/dev/vda1                49.9G      8.5G     41.5G  17% /etc/localtime
zfs06.bi.privat:/export/jwd06/main/085/085/85085446/home   100.0T     39.9T     60.1T  40% /data/jwd06/main/085/085/85085446/home
tmpfs                    64.0M     12.0K     64.0M   0% /tmp
tmpfs                    64.0M     12.0K     64.0M   0% /var/tmp
tmpfs                    64.0M     12.0K     64.0M   0% /etc/resolv.conf
tmpfs                    64.0M     12.0K     64.0M   0% /etc/passwd
tmpfs                    64.0M     12.0K     64.0M   0% /etc/group
```