### PR TITLE
Galaxy Nginx conf: set and increase timeouts for dataset_collection download endpoint.

### DIFF
--- a/templates/nginx/galaxy-main.j2
+++ b/templates/nginx/galaxy-main.j2
@@ -63,13 +63,7 @@ server {
 		add_header X-Clacks-Overhead 'GNU James Taylor (@jxtx) Simon Gladman (@slugger70) Jim Johnson (@jj-umn)';
 	}
 	location ~ ^/api/dataset_collections/([^/]+)/download/?$ {
-		client_header_timeout 600s;
-		client_body_timeout 600s;
-		send_timeout 600s;
-
-		proxy_connect_timeout 600s;
-		proxy_send_timeout 600s;
-		proxy_read_timeout 600s;
+		proxy_read_timeout 1200s;
 
 		proxy_buffering off;
 		proxy_pass http://galaxy;

--- a/templates/nginx/galaxy-main.j2
+++ b/templates/nginx/galaxy-main.j2
@@ -63,6 +63,14 @@ server {
 		add_header X-Clacks-Overhead 'GNU James Taylor (@jxtx) Simon Gladman (@slugger70) Jim Johnson (@jj-umn)';
 	}
 	location ~ ^/api/dataset_collections/([^/]+)/download/?$ {
+		client_header_timeout 600s;
+		client_body_timeout 600s;
+		send_timeout 600s;
+
+		proxy_connect_timeout 600s;
+		proxy_send_timeout 600s;
+		proxy_read_timeout 600s;
+
 		proxy_buffering off;
 		proxy_pass http://galaxy;
 		proxy_set_header Host $http_host;


### PR DESCRIPTION
Xref: https://github.com/usegalaxy-eu/infrastructure-playbook/pull/1557

Unfortunately, the collection download issue discussed [here](https://help.galaxyproject.org/t/problems-downloading-some-collections-from-eu/15702) still exists even after yesterday's PR (see above). So, in an attempt to rule things out, this PR increases the timeouts for the `api/dataset_collections/([^/]+)/download` endpoint.

