### PR TITLE
TPV: Update circos tool locale to C instead of C.UTF-8

### DIFF
--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -1268,6 +1268,9 @@ tools:
     scheduling:
       require:
         - singularity
+    env:
+      - name: SINGULARITYENV_LC_ALL
+        value: C
 
   braker_tool:
     abstract: true


### PR DESCRIPTION
Bug report:  `85255976`

```
/bin/bash: warning: setlocale: LC_ALL: cannot change locale (C.UTF-8)
Traceback (most recent call last):
  File "/opt/galaxy/shed_tools/toolshed.g2.bx.psu.edu/repos/iuc/circos/31a35811dda6/circos/karyotype-colors.py", line 9, in <module>
    idx=idx, pos=int(float(idx) / highest * 360)
ZeroDivisionError: float division by zero
```