### PR TITLE
up the resources for AnyLabeling IT and yolo_train headless tool

### DIFF
--- a/files/galaxy/tpv/interactive_tools.yml
+++ b/files/galaxy/tpv/interactive_tools.yml
@@ -58,8 +58,8 @@ tools:
 
   interactive_tool_anylabeling:
     inherits: interactive_tool
-    cores: 1
-    mem: 4
+    cores: 4
+    mem: 16
 
   interactive_tool_cellpose:
     inherits: interactive_tool

--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -430,6 +430,13 @@ tools:
     inherits: basic_docker_tool
   toolshed.g2.bx.psu.edu/repos/bgruening/yolo_training/yolo_training/.*:
     inherits: basic_docker_tool
+    gpus: 1
+    cores: 4
+    mem: 32
+    params:
+      docker_run_extra_arguments: ' --gpus all '
+    env:
+      GPU_AVAILABLE: 1
   toolshed.g2.bx.psu.edu/repos/imgteam/rfove/rfove/.*:
     inherits: basic_docker_tool
   toolshed.g2.bx.psu.edu/repos/iuc/homer_findmotifs/homer_findMotifs/.*:


### PR DESCRIPTION
@bgruening 
anylabeling cache the images into RAM, the actual RAM usage depends on the number of images and image resolutions.

can we start with these numbers for my testing set of images, and update at later time once we have other images, and if it is needed.

these numbers should be okay for my current testing images with sam-tiny model for auto-labeling in AnyLabeling IT.

Thank you very much