### PR TITLE
Migrate workflow schedulers to use db-skip-locked like the job handlers in the job conf

### DIFF
--- a/templates/galaxy/config/galaxy_workflow_scheduler.j2
+++ b/templates/galaxy/config/galaxy_workflow_scheduler.j2
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <workflow_schedulers default="core">
     <core id="core" />
-    <handlers assign_with="db-preassign" default="schedulers">
+    <handlers assign_with="db-skip-locked" default="schedulers">
 {% for n in range(galaxy_workflow_scheduler_count) %}
         <handler id="{{ galaxy_systemd_workflow_scheduler_prefix }}_{{ n }}" tags="schedulers"/>
 {% endfor %}


### PR DESCRIPTION
See Matrix [admin chat for details](https://matrix.to/#/!rfLDbcWEWZapZrujix:gitter.im/$hNq3qL8v30izq7XbKWW411zT8Pm3sq0-wyTDf6a6glA?via=gitter.im&via=matrix.org&via=surf.nl).

`db-preassign` is a legacy configuration, and in our job configuration, we use `db-skip-locked` for the job handlers, so we will switch the workflow schedulers to use the same. 

Before merging and deploying this, we should ensure the following and report it,

> if the job handlers do not attach to the workflow scheduler pool but do schedule workflows, then that is definitely a bug we want to know about and fix

_I am not sure how to test this or if I fully understand it, so I have asked in the chat for guidance on testing._