### PR TITLE
🚀🌙  Dark launch pxe-gpu

### DIFF
--- a/files/galaxy/tpv/destinations.yml.j2
+++ b/files/galaxy/tpv/destinations.yml.j2
@@ -543,19 +543,20 @@ destinations:
     params:
       requirements: 'GalaxyGroup == "pxe-gpu"'
       request_gpus: "{gpus or 0}"
-      docker_run_extra_arguments: "--gpus all --env CUDA_VISIBLE_DEVICES=$_CONDOR_AssignedGPUs --env NVIDIA_VISIBLE_DEVICES=$_CONDOR_AssignedGPUs"
+      docker_run_extra_arguments: "{{ entity.params.get('docker_run_extra_arguments') or '' }} --gpus all --env CUDA_VISIBLE_DEVICES=$_CONDOR_AssignedGPUs --env NVIDIA_VISIBLE_DEVICES=$_CONDOR_AssignedGPUs"
+
   condor_docker_gpu_pxe_divide4:
     inherits: condor_docker_gpu_pxe
     params:
       requirements: 'GalaxyGroup == "pxe-gpu-div4"'
       request_gpus: "{gpus or 0}"
-      docker_run_extra_arguments: "--gpus all --env CUDA_VISIBLE_DEVICES=$_CONDOR_AssignedGPUs --env NVIDIA_VISIBLE_DEVICES=$_CONDOR_AssignedGPUs"
+      docker_run_extra_arguments: "{{ entity.params.get('docker_run_extra_arguments') or '' }} --gpus all --env CUDA_VISIBLE_DEVICES=$_CONDOR_AssignedGPUs --env NVIDIA_VISIBLE_DEVICES=$_CONDOR_AssignedGPUs"
 
   condor_singularity_gpu_pxe:
     inherits: basic_singularity_destination
     # shorter than inheriting from condor_gpu
     runner: condor
-    max_accepted_cores: 32
+    max_accepted_cores: 128
     max_accepted_mem: 500
     min_accepted_gpus: 1
     max_accepted_gpus: 4
@@ -563,8 +564,7 @@ destinations:
       require:
         - singularity
         - pxe-gpu
-    env:
-      GPU_AVAILABLE: 1
     params:
-      requirements: 'GalaxyGroup == "training-pxe-test-gpu"'
+      requirements: 'GalaxyGroup == "pxe-gpu-div4"'
       request_gpus: "{gpus or 0}"
+      singularity_run_extra_arguments: "{{ entity.params.get('singularity_run_extra_arguments') or '' }} --nv --env CUDA_VISIBLE_DEVICES=$_CONDOR_AssignedGPUs"

--- a/files/galaxy/tpv/destinations.yml.j2
+++ b/files/galaxy/tpv/destinations.yml.j2
@@ -543,14 +543,14 @@ destinations:
     params:
       requirements: 'GalaxyGroup == "pxe-gpu"'
       request_gpus: "{gpus or 0}"
-      docker_run_extra_arguments: "{{ entity.params.get('docker_run_extra_arguments') or '' }} --gpus all --env CUDA_VISIBLE_DEVICES=$_CONDOR_AssignedGPUs --env NVIDIA_VISIBLE_DEVICES=$_CONDOR_AssignedGPUs"
+      docker_run_extra_arguments: "{entity.params.get('docker_run_extra_arguments') or ''} --gpus all --env CUDA_VISIBLE_DEVICES=$_CONDOR_AssignedGPUs --env NVIDIA_VISIBLE_DEVICES=$_CONDOR_AssignedGPUs"
 
   condor_docker_gpu_pxe_divide4:
     inherits: condor_docker_gpu_pxe
     params:
       requirements: 'GalaxyGroup == "pxe-gpu-div4"'
       request_gpus: "{gpus or 0}"
-      docker_run_extra_arguments: "{{ entity.params.get('docker_run_extra_arguments') or '' }} --gpus all --env CUDA_VISIBLE_DEVICES=$_CONDOR_AssignedGPUs --env NVIDIA_VISIBLE_DEVICES=$_CONDOR_AssignedGPUs"
+      docker_run_extra_arguments: "{entity.params.get('docker_run_extra_arguments') or ''} --gpus all --env CUDA_VISIBLE_DEVICES=$_CONDOR_AssignedGPUs --env NVIDIA_VISIBLE_DEVICES=$_CONDOR_AssignedGPUs"
 
   condor_singularity_gpu_pxe:
     inherits: basic_singularity_destination
@@ -567,4 +567,4 @@ destinations:
     params:
       requirements: 'GalaxyGroup == "pxe-gpu-div4"'
       request_gpus: "{gpus or 0}"
-      singularity_run_extra_arguments: "{{ entity.params.get('singularity_run_extra_arguments') or '' }} --nv --env CUDA_VISIBLE_DEVICES=$_CONDOR_AssignedGPUs"
+      singularity_run_extra_arguments: "{entity.params.get('singularity_run_extra_arguments') or ''} --nv --env CUDA_VISIBLE_DEVICES=$_CONDOR_AssignedGPUs"

--- a/files/galaxy/tpv/destinations.yml.j2
+++ b/files/galaxy/tpv/destinations.yml.j2
@@ -526,18 +526,6 @@ destinations:
     params:
       requirements: 'GalaxyGroup == "compute_gpu"'
 
-  condor_pxe:
-    runner: condor
-    max_accepted_cores: 32
-    max_accepted_mem: 500
-    min_accepted_gpus: 0
-    max_accepted_gpus: 0
-    scheduling:
-      require:
-        - pxe
-    params:
-      requirements: 'GalaxyGroup == "pxe"'
-
   condor_docker_gpu_pxe:
     inherits: basic_docker_destination
     # shorter than inheriting from condor_gpu
@@ -555,11 +543,13 @@ destinations:
     params:
       requirements: 'GalaxyGroup == "pxe-gpu"'
       request_gpus: "{gpus or 0}"
+      docker_run_extra_arguments: "--gpus all --env CUDA_VISIBLE_DEVICES=$_CONDOR_AssignedGPUs --env NVIDIA_VISIBLE_DEVICES=$_CONDOR_AssignedGPUs"
   condor_docker_gpu_pxe_divide4:
     inherits: condor_docker_gpu_pxe
     params:
       requirements: 'GalaxyGroup == "pxe-gpu-div4"'
       request_gpus: "{gpus or 0}"
+      docker_run_extra_arguments: "--gpus all --env CUDA_VISIBLE_DEVICES=$_CONDOR_AssignedGPUs --env NVIDIA_VISIBLE_DEVICES=$_CONDOR_AssignedGPUs"
 
   condor_singularity_gpu_pxe:
     inherits: basic_singularity_destination

--- a/files/galaxy/tpv/destinations.yml.j2
+++ b/files/galaxy/tpv/destinations.yml.j2
@@ -526,11 +526,23 @@ destinations:
     params:
       requirements: 'GalaxyGroup == "compute_gpu"'
 
+  condor_pxe:
+    runner: condor
+    max_accepted_cores: 32
+    max_accepted_mem: 500
+    min_accepted_gpus: 0
+    max_accepted_gpus: 0
+    scheduling:
+      require:
+        - pxe
+    params:
+      requirements: 'GalaxyGroup == "pxe"'
+
   condor_docker_gpu_pxe:
     inherits: basic_docker_destination
     # shorter than inheriting from condor_gpu
     runner: condor
-    max_accepted_cores: 32
+    max_accepted_cores: 128
     max_accepted_mem: 500
     min_accepted_gpus: 1
     max_accepted_gpus: 4
@@ -541,7 +553,12 @@ destinations:
     env:
       GPU_AVAILABLE: 1
     params:
-      requirements: 'GalaxyGroup == "training-pxe-test-gpu"'
+      requirements: 'GalaxyGroup == "pxe-gpu"'
+      request_gpus: "{gpus or 0}"
+  condor_docker_gpu_pxe_divide4:
+    inherits: condor_docker_gpu_pxe
+    params:
+      requirements: 'GalaxyGroup == "pxe-gpu-div4"'
       request_gpus: "{gpus or 0}"
 
   condor_singularity_gpu_pxe:

--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -218,6 +218,7 @@ tools:
     cores: 8
     params:
       singularity_enabled: true
+    inherits: basic_pxe_tool
 
   toolshed.g2.bx.psu.edu/repos/rnateam/dewseq/dewseq/.*:
     cores: 2
@@ -344,7 +345,31 @@ tools:
     scheduling:
       require:
         - docker
-
+  basic_pxe_tool:
+    rule:
+      - name: Assign pxe by random
+        if: true
+        execute: |
+          from tpv.core.entities import Tag, TagSetManager, TagType
+          from random import SystemRandom
+          if SystemRandom().random() < 0.5:
+             pulsar_tag = Tag("scheduling", "pxe", TagType.PREFER)
+             entity.tpv_tags = entity.tpv_tags.combine(
+                     TagSetManager(tags=[pulsar_tag])
+                 )
+  basic_pxe_gpu_tool:
+    inherits: basic_docker_tool
+    rule:
+      - name: Assign pxe-gpu by random
+        if: true
+        execute: |
+          from tpv.core.entities import Tag, TagSetManager, TagType
+          from random import SystemRandom
+          if SystemRandom().random() < 0.5:
+            pulsar_tag = Tag("scheduling", "pxe-gpu", TagType.PREFER)
+             entity.tpv_tags = entity.tpv_tags.combine(
+                     TagSetManager(tags=[pulsar_tag])
+                 )
   toolshed.g2.bx.psu.edu/repos/bgruening/markitdown/markitdown/.*:
     inherits: basic_docker_tool
     params:
@@ -446,7 +471,7 @@ tools:
   toolshed.g2.bx.psu.edu/repos/galaxyp/diann/diann/.*:
     inherits: basic_docker_tool
   toolshed.g2.bx.psu.edu/repos/bgruening/instagraal/instagraal/.*:
-    inherits: basic_docker_tool
+    inherits: basic_pxe_gpu_tool
     gpus: 1
     cores: 1
     mem: 30
@@ -464,7 +489,7 @@ tools:
       _GALAXY_JOB_TMP_DIR: '/tmp'
 
   toolshed.g2.bx.psu.edu/repos/iuc/diffdock/diffdock/.*:
-    inherits: basic_docker_tool
+    inherits: basic_pxe_gpu_tool
     gpus: 1
     cores: 1
     params:
@@ -473,7 +498,7 @@ tools:
       GPU_AVAILABLE: 1
 
   toolshed.g2.bx.psu.edu/repos/bgruening/black_forest_labs_flux/black_forest_labs_flux/.*:
-    inherits: basic_docker_tool
+    inherits: basic_pxe_gpu_tool
     gpus: 1
     cores: 1
     params:
@@ -483,14 +508,14 @@ tools:
       GPU_AVAILABLE: 1
 
   toolshed.g2.bx.psu.edu/repos/bgruening/whisper/whisper/.*:
-    inherits: basic_docker_tool
+    inherits: basic_pxe_gpu_tool
     cores: 1
     mem: 5
     env:
       OPENAI_WHISPER_MODEL_DIR: "/data/db/models/openai_whisper/"
 
   toolshed.g2.bx.psu.edu/repos/bgruening/whisperx/whisperx/.*:
-    inherits: basic_docker_tool
+    inherits: basic_pxe_gpu_tool
     gpus: 1
     cores: 1
     mem: 5
@@ -503,7 +528,9 @@ tools:
 
   toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/.*:
     # 8 (from the shared TPV) seems to high for me
+    inherits: basic_pxe_tool
     cores: 3
+
 
   toolshed.g2.bx.psu.edu/repos/iuc/bbtools_tadpole/bbtools_tadpole/.*:
     mem: 8
@@ -1035,6 +1062,7 @@ tools:
   toolshed.g2.bx.psu.edu/repos/iuc/trinity/trinity/.*:
     cores: 24
     mem: 250
+    inherits: basic_pxe_tool
     scheduling:
       prefer:
         - condor-tpv

--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -345,18 +345,6 @@ tools:
     scheduling:
       require:
         - docker
-  basic_pxe_tool:
-    rule:
-      - name: Assign pxe by random
-        if: true
-        execute: |
-          from tpv.core.entities import Tag, TagSetManager, TagType
-          from random import SystemRandom
-          if SystemRandom().random() < 0.5:
-             pulsar_tag = Tag("scheduling", "pxe", TagType.PREFER)
-             entity.tpv_tags = entity.tpv_tags.combine(
-                     TagSetManager(tags=[pulsar_tag])
-                 )
   basic_pxe_gpu_tool:
     inherits: basic_docker_tool
     rule:
@@ -365,11 +353,9 @@ tools:
         execute: |
           from tpv.core.entities import Tag, TagSetManager, TagType
           from random import SystemRandom
-          if SystemRandom().random() < 0.5:
+          if SystemRandom().random() < 0.2:
             pulsar_tag = Tag("scheduling", "pxe-gpu", TagType.PREFER)
-             entity.tpv_tags = entity.tpv_tags.combine(
-                     TagSetManager(tags=[pulsar_tag])
-                 )
+            entity.tpv_tags = entity.tpv_tags.combine(TagSetManager(tags=[pulsar_tag]))
   toolshed.g2.bx.psu.edu/repos/bgruening/markitdown/markitdown/.*:
     inherits: basic_docker_tool
     params:

--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -218,7 +218,6 @@ tools:
     cores: 8
     params:
       singularity_enabled: true
-    inherits: basic_pxe_tool
 
   toolshed.g2.bx.psu.edu/repos/rnateam/dewseq/dewseq/.*:
     cores: 2
@@ -514,7 +513,6 @@ tools:
 
   toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/.*:
     # 8 (from the shared TPV) seems to high for me
-    inherits: basic_pxe_tool
     cores: 3
 
 
@@ -1048,7 +1046,6 @@ tools:
   toolshed.g2.bx.psu.edu/repos/iuc/trinity/trinity/.*:
     cores: 24
     mem: 250
-    inherits: basic_pxe_tool
     scheduling:
       prefer:
         - condor-tpv

--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -344,6 +344,7 @@ tools:
     scheduling:
       require:
         - docker
+
   basic_pxe_gpu_tool:
     inherits: basic_docker_tool
     rule:
@@ -355,6 +356,7 @@ tools:
           if SystemRandom().random() < 0.2:
             pulsar_tag = Tag("scheduling", "pxe-gpu", TagType.PREFER)
             entity.tpv_tags = entity.tpv_tags.combine(TagSetManager(tags=[pulsar_tag]))
+
   toolshed.g2.bx.psu.edu/repos/bgruening/markitdown/markitdown/.*:
     inherits: basic_docker_tool
     params:


### PR DESCRIPTION
⚠️ Merge only after:
- https://github.com/usegalaxy-eu/vgcn-infrastructure-playbook/pull/3

Compute pxe (`tstimg.bi.privat`) was [added as regular compute node](https://github.com/usegalaxy-eu/vgcn-infrastructure-playbook/commit/a9dd7ab59539409e3af8e22c420729555532b032) – seems stable so far 🤞🏼 
I am monitoring it with 
~~~
condor_history -name tstimg.bi.privat -startd | grep -v OWNER | cut -d. -f1 | xargs -i sh -c 'gxadmin query errored-jobs 4 | grep {}'
~~~
assigns selected tools to the PXE-GPU servers with a probability of 20% and TagType PREFER
