### PR TITLE
Add WHISPERX_COMPUTE_TYPE environment variable to docker run arguments

### DIFF
--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -507,7 +507,7 @@ tools:
     cores: 1
     mem: 5
     params:
-      docker_run_extra_arguments: '--gpus all --env WHISPERX_MODEL_DIR=$WHISPERX_MODEL_DIR --env WHISPERX_DEVICE=$WHISPERX_DEVICE'
+      docker_run_extra_arguments: '--gpus all --env WHISPERX_MODEL_DIR=$WHISPERX_MODEL_DIR --env WHISPERX_DEVICE=$WHISPERX_DEVICE --env WHISPERX_COMPUTE_TYPE=$WHISPERX_COMPUTE_TYPE'
     env:
       WHISPERX_MODEL_DIR: "/data/db/models/whisperx/whisperx_models/"
       WHISPERX_DEVICE: "cuda"


### PR DESCRIPTION
Include the `WHISPERX_COMPUTE_TYPE` environment variable in the Docker run extra arguments to enhance configuration options.
Fixes https://github.com/usegalaxy-eu/infrastructure-playbook/pull/1564#discussion_r2189255567