### PR TITLE
Add pxe to normal scheduling

### DIFF
--- a/files/galaxy/tpv/destinations.yml.j2
+++ b/files/galaxy/tpv/destinations.yml.j2
@@ -564,13 +564,15 @@ destinations:
       request_gpus: "{gpus or 0}"
       docker_run_extra_arguments: "{entity.params.get('docker_run_extra_arguments') or ''} --gpus all --env CUDA_VISIBLE_DEVICES=$_CONDOR_AssignedGPUs --env NVIDIA_VISIBLE_DEVICES=$_CONDOR_AssignedGPUs"
 
+  # This means a GPU can be shared by max 4 jobs at the same time
   condor_docker_gpu_pxe_divide4:
     inherits: condor_docker_gpu_pxe
     max_accepted_gpus: 1
     params:
       requirements: 'GalaxyGroup == "pxe-gpu-div4"'
-      request_gpus: "{gpus or 0}"
-      docker_run_extra_arguments: "{entity.params.get('docker_run_extra_arguments') or ''} --gpus all --env CUDA_VISIBLE_DEVICES=$_CONDOR_AssignedGPUs --env NVIDIA_VISIBLE_DEVICES=$_CONDOR_AssignedGPUs"
+    scheduling:
+      require:
+        - gpu-divided
 
   condor_singularity_gpu_pxe:
     inherits: basic_singularity_destination
@@ -585,6 +587,6 @@ destinations:
         - singularity
         - pxe-gpu
     params:
-      requirements: 'GalaxyGroup == "pxe-gpu-div4"'
+      requirements: 'GalaxyGroup == "pxe-gpu"'
       request_gpus: "{gpus or 0}"
       singularity_run_extra_arguments: "{entity.params.get('singularity_run_extra_arguments') or ''} --nv --env CUDA_VISIBLE_DEVICES=$_CONDOR_AssignedGPUs"

--- a/files/galaxy/tpv/destinations.yml.j2
+++ b/files/galaxy/tpv/destinations.yml.j2
@@ -541,6 +541,7 @@ destinations:
     max_accepted_gpus: 4
     env:
       GPU_AVAILABLE: 1
+      CUDA_VISIBLE_DEVICES: "$_CONDOR_AssignedGPUs"
     params:
       requirements: 'GalaxyGroup == "pxe-gpu"'
 

--- a/files/galaxy/tpv/destinations.yml.j2
+++ b/files/galaxy/tpv/destinations.yml.j2
@@ -537,7 +537,6 @@ destinations:
     scheduling:
       require:
         - docker
-        - pxe-gpu
     env:
       GPU_AVAILABLE: 1
     params:
@@ -547,6 +546,8 @@ destinations:
 
   condor_docker_gpu_pxe_divide4:
     inherits: condor_docker_gpu_pxe
+    max_accepted_gpus: 1
+    scheduling:
     params:
       requirements: 'GalaxyGroup == "pxe-gpu-div4"'
       request_gpus: "{gpus or 0}"
@@ -559,7 +560,7 @@ destinations:
     max_accepted_cores: 128
     max_accepted_mem: 500
     min_accepted_gpus: 1
-    max_accepted_gpus: 4
+    max_accepted_gpus: 1
     scheduling:
       require:
         - singularity

--- a/files/galaxy/tpv/destinations.yml.j2
+++ b/files/galaxy/tpv/destinations.yml.j2
@@ -547,7 +547,6 @@ destinations:
   condor_docker_gpu_pxe_divide4:
     inherits: condor_docker_gpu_pxe
     max_accepted_gpus: 1
-    scheduling:
     params:
       requirements: 'GalaxyGroup == "pxe-gpu-div4"'
       request_gpus: "{gpus or 0}"

--- a/files/galaxy/tpv/destinations.yml.j2
+++ b/files/galaxy/tpv/destinations.yml.j2
@@ -493,6 +493,9 @@ destinations:
       GPU_AVAILABLE: 1
     params:
       requirements: 'GalaxyGroup == "compute_gpu"'
+    scheduling:
+      reject:
+        - offline
 
   condor_docker_gpu:
     inherits: basic_docker_destination
@@ -505,6 +508,8 @@ destinations:
     scheduling:
       require:
         - docker
+      reject:
+        - offline
     env:
       GPU_AVAILABLE: 1
     params:
@@ -521,10 +526,23 @@ destinations:
     scheduling:
       require:
         - singularity
+      reject:
+        - offline
     env:
       GPU_AVAILABLE: 1
     params:
       requirements: 'GalaxyGroup == "compute_gpu"'
+
+  condor_gpu_pxe:
+    runner: condor
+    max_accepted_cores: 128
+    max_accepted_mem: 500
+    min_accepted_gpus: 1
+    max_accepted_gpus: 4
+    env:
+      GPU_AVAILABLE: 1
+    params:
+      requirements: 'GalaxyGroup == "pxe-gpu"'
 
   condor_docker_gpu_pxe:
     inherits: basic_docker_destination

--- a/files/galaxy/tpv/destinations.yml.j2
+++ b/files/galaxy/tpv/destinations.yml.j2
@@ -544,6 +544,7 @@ destinations:
       CUDA_VISIBLE_DEVICES: "$_CONDOR_AssignedGPUs"
     params:
       requirements: 'GalaxyGroup == "pxe-gpu"'
+      request_gpus: "{gpus or 0}"
 
   condor_docker_gpu_pxe:
     inherits: basic_docker_destination

--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -491,9 +491,6 @@ tools:
     mem: 5
     env:
       OPENAI_WHISPER_MODEL_DIR: "/data/db/models/openai_whisper/"
-    scheduling:
-      require:
-        - gpu-divided
 
   toolshed.g2.bx.psu.edu/repos/bgruening/whisperx/whisperx/.*:
     inherits: basic_docker_tool

--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -345,18 +345,6 @@ tools:
       require:
         - docker
 
-  basic_pxe_gpu_tool:
-    inherits: basic_docker_tool
-    rule:
-      - name: Assign pxe-gpu by random
-        if: true
-        execute: |
-          from tpv.core.entities import Tag, TagSetManager, TagType
-          from random import SystemRandom
-          if SystemRandom().random() < 0.2:
-            pulsar_tag = Tag("scheduling", "pxe-gpu", TagType.PREFER)
-            entity.tpv_tags = entity.tpv_tags.combine(TagSetManager(tags=[pulsar_tag]))
-
   toolshed.g2.bx.psu.edu/repos/bgruening/markitdown/markitdown/.*:
     inherits: basic_docker_tool
     params:
@@ -458,7 +446,7 @@ tools:
   toolshed.g2.bx.psu.edu/repos/galaxyp/diann/diann/.*:
     inherits: basic_docker_tool
   toolshed.g2.bx.psu.edu/repos/bgruening/instagraal/instagraal/.*:
-    inherits: basic_pxe_gpu_tool
+    inherits: basic_docker_tool
     gpus: 1
     cores: 1
     mem: 30
@@ -476,7 +464,7 @@ tools:
       _GALAXY_JOB_TMP_DIR: '/tmp'
 
   toolshed.g2.bx.psu.edu/repos/iuc/diffdock/diffdock/.*:
-    inherits: basic_pxe_gpu_tool
+    inherits: basic_docker_tool
     gpus: 1
     cores: 1
     params:
@@ -485,7 +473,7 @@ tools:
       GPU_AVAILABLE: 1
 
   toolshed.g2.bx.psu.edu/repos/bgruening/black_forest_labs_flux/black_forest_labs_flux/.*:
-    inherits: basic_pxe_gpu_tool
+    inherits: basic_docker_tool
     gpus: 1
     cores: 1
     params:
@@ -495,14 +483,14 @@ tools:
       GPU_AVAILABLE: 1
 
   toolshed.g2.bx.psu.edu/repos/bgruening/whisper/whisper/.*:
-    inherits: basic_pxe_gpu_tool
+    inherits: basic_docker_tool
     cores: 1
     mem: 5
     env:
       OPENAI_WHISPER_MODEL_DIR: "/data/db/models/openai_whisper/"
 
   toolshed.g2.bx.psu.edu/repos/bgruening/whisperx/whisperx/.*:
-    inherits: basic_pxe_gpu_tool
+    inherits: basic_docker_tool
     gpus: 1
     cores: 1
     mem: 5

--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -481,6 +481,9 @@ tools:
       docker_run_extra_arguments: ' --gpus all '
     env:
       GPU_AVAILABLE: 1
+    scheduling:
+      require:
+        - gpu-divided
 
   toolshed.g2.bx.psu.edu/repos/bgruening/whisper/whisper/.*:
     inherits: basic_docker_tool
@@ -488,6 +491,9 @@ tools:
     mem: 5
     env:
       OPENAI_WHISPER_MODEL_DIR: "/data/db/models/openai_whisper/"
+    scheduling:
+      require:
+        - gpu-divided
 
   toolshed.g2.bx.psu.edu/repos/bgruening/whisperx/whisperx/.*:
     inherits: basic_docker_tool
@@ -500,6 +506,9 @@ tools:
       WHISPERX_MODEL_DIR: "/data/db/models/whisperx/whisperx_models/"
       WHISPERX_DEVICE: "cuda"
       WHISPERX_COMPUTE_TYPE: "float16"
+    scheduling:
+      require:
+        - gpu-divided
 
   toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/.*:
     # 8 (from the shared TPV) seems to high for me


### PR DESCRIPTION
The separate destinations and Condor Groups are kept to ensure only jobs who get the `docker_run_extra_arguments` for condor GPU partitioning will be computed on the pxe nodes.
Once we remove all nodes from the cloud, we must mark the normal gpu destinations as offline/remove them