### PR TITLE
Disable memory overcommit on sn11

### DIFF
--- a/requirements.yaml
+++ b/requirements.yaml
@@ -170,3 +170,7 @@ roles:
     version: main
   - name: geerlingguy.swap
     version: 1.2.0
+  - name: usegalaxy_eu.disable_memory_overcommit
+    version: 0.0.1
+    src: https://github.com/usegalaxy-eu/ansible-disable-memory-overcommit
+

--- a/sn11.yml
+++ b/sn11.yml
@@ -34,3 +34,4 @@
     - usegalaxy-eu.ansible-postgresql
     - dj-wasabi.telegraf
     - ssh_hardening
+    - usegalaxy_eu.disable_memory_overcommit


### PR DESCRIPTION
This adds our new role for turning off memory overcommit to `sn11`. I hope I got it right...