### PR TITLE
Change PG log file name pattern to include DoW numerical

### DIFF
--- a/group_vars/sn11.yml
+++ b/group_vars/sn11.yml
@@ -51,6 +51,7 @@ postgresql_conf:
   # the following line throws an error in v13
   #  - shared_preload_libraries: "'pg_stat_statements'"
   #  - log_line_prefix: "'%t:%r:%u@%d:[%p]<%m>: '"
+  - log_filename: "'postgresql-%u-%a.log'"
   - log_checkpoints: 'on'
   - log_min_duration_statement: 1500
   - track_activity_query_size: 4096


### PR DESCRIPTION
This PR changes PG's log file name pattern on `sn11` to include the day-of-the-week in numerical form, so that log files now have names like
```
postgresql-1-Mon.log
```
rather than the default of
```
postgresql-Mon.log
```
This proposed change serves two purposes:
1. the default collating order of the file names is in chronological order
~2. it is different from the current setting on `sn11` and thus I can mount the NFS dump file location on sn11 during the transition period without clobbering the current production backups~

PS: I just discovered the hard way that the GH comment editing dialog will under no circumstances allow you to enter the character sequence N-r-. (with a capital letter 'N' and without the separating dashes, as an abbreviation for "number") -- it will stubbornly change it to Nr., whether you like it or not. Even if you escape the trailing dot with a backslash in markdown, Nr. will be shown in the rendered version. That's **soo** typical, thank you for nothing, M$  >_>