### PR TITLE
Update geographical_server_location_code in galaxy config file

### DIFF
--- a/group_vars/gxconfig.yml
+++ b/group_vars/gxconfig.yml
@@ -1021,7 +1021,7 @@ base_app_main: &BASE_APP_MAIN
   # `geographical_server_location_code` value is invalid or unsupported.
   # To see a full list of supported locations, visit
   # https://docs.galaxyproject.org/en/master/admin/carbon_emissions.html
-  geographical_server_location_code: DE-BW
+  geographical_server_location_code: DE
 
   # The estimated power usage effectiveness of the data centre housing
   # the server your galaxy instance is running on. This can make carbon


### PR DESCRIPTION
`DE-BW` does not exist on the [carbon intensity file](https://github.com/galaxyproject/galaxy/blob/dev/lib/galaxy/carbon_emissions/carbon_intensity.csv) and supports only `DE`. Since `DE-BW` was used, we see the [global constant](https://github.com/galaxyproject/galaxy/blob/dev/client/src/components/JobMetrics/CarbonEmissions/carbonEmissionConstants.js#L29) `475` being used (see image below) instead of the `DE` which is `338.66`.

<img width="1370" height="629" alt="image" src="https://github.com/user-attachments/assets/442fec41-d953-42db-afa9-8e8c7d1978d1" />
