### PR TITLE
Update Traefik to route everything of usegalaxy.eu to sn09 instead of sn06 (part of migration)

### DIFF
--- a/files/traefik/rules/usegalaxy-eu-service.yml
+++ b/files/traefik/rules/usegalaxy-eu-service.yml
@@ -6,5 +6,5 @@ http:
         sticky:
           cookie: {}
         servers:
-          - url: "https://sn06.galaxyproject.eu/"
+          - url: "https://sn09.galaxyproject.eu/"
         #  - url: "https://sn07.galaxyproject.eu/"


### PR DESCRIPTION
Xref: https://github.com/usegalaxy-eu/issues/issues/754

Merge only after: https://github.com/usegalaxy-eu/infrastructure-playbook/pull/1575 and then deploy the Traefik and sn09 CIs.
