### PR TITLE
add firewall role and configuration to sn11

### DIFF
--- a/group_vars/sn11.yml
+++ b/group_vars/sn11.yml
@@ -27,6 +27,7 @@ firewall_restart_daemon: false
 firewall_internal_services:
   - ssh
   - mosh
+  - postgresql
 firewall_mosh_service: >
   <?xml version="1.0" encoding="utf-8"?>
   <service>

--- a/group_vars/sn11.yml
+++ b/group_vars/sn11.yml
@@ -18,6 +18,23 @@ software_groups_to_install:
   - utils
   - terminals
 
+# Role: usegalaxy_eu.firewall
+# NOTE: firewall_restart_daemon is set to false by default and it is deliberately set to false
+# to avoid restarting the firewall daemon because the changes can possibly disrupt your only
+# way to connect to the machine. So, if you would like to see the changes applied immediately,
+# you can set this to true or login to the node and restart the firewall daemon manually.
+firewall_restart_daemon: false
+firewall_internal_services:
+  - ssh
+  - mosh
+firewall_mosh_service: >
+  <?xml version="1.0" encoding="utf-8"?>
+  <service>
+    <short>MOSH</short>
+    <description>Mosh (mosh.mit.edu) is a free replacement for SSH that allows roaming and supports intermittent connectivity.</description>
+    <port protocol="udp" port="60001-60100"/>
+  </service>
+
 # PostgreSQL
 postgresql_version: 17
 postgresql_pgdump_dir: '/var/lib/pgsql/pgdump3'

--- a/sn11.yml
+++ b/sn11.yml
@@ -11,6 +11,11 @@
     - mounts/mountpoints.yml
   collections:
     - devsec.hardening
+  pre_tasks:
+    - name: Add mosh service config for FirewallD
+      ansible.builtin.copy:
+        content: '{{ firewall_mosh_service }}'
+        dest: /etc/firewalld/services/mosh.xml
   post_tasks:
     - name: Ensure PostgreSQL is allowed on the firewall
       ansible.builtin.firewalld:
@@ -35,3 +40,4 @@
     - dj-wasabi.telegraf
     - ssh_hardening
     - usegalaxy_eu.disable_memory_overcommit
+    - usegalaxy_eu.firewall


### PR DESCRIPTION
Note: don't forget to manually reload the firewalld service after the deployment because

> NOTE: firewall_restart_daemon is set to false by default and it is deliberately set to false to avoid restarting the firewall daemon because the changes can possibly disrupt your only way to connect to the machine. So, if you would like to see the changes applied immediately, you can set this to true or login to the node and restart the firewall daemon manually. 