### PR TITLE
remove postgresql service from internal zone firewall rules

### DIFF
--- a/group_vars/sn11.yml
+++ b/group_vars/sn11.yml
@@ -27,7 +27,6 @@ firewall_restart_daemon: false
 firewall_internal_services:
   - ssh
   - mosh
-  - postgresql
 firewall_mosh_service: >
   <?xml version="1.0" encoding="utf-8"?>
   <service>


### PR DESCRIPTION
This was NR as per @sj213 and so I manually removed it from sn11 (also from the public zone).