### PR TITLE
remove miniconda from sn09 playbook and use the conda from /usr/local/tools/_conda for creating Python envs

### DIFF
--- a/group_vars/sn09/sn09.yml
+++ b/group_vars/sn09/sn09.yml
@@ -27,9 +27,6 @@ autofs_mount_points:
   - cache
   - misc
 
-# Miniconda role variables (galaxyproject.miniconda)
-conda_prefix: /opt/miniconda
-
 # Role: usegalaxy_eu.firewall
 # NOTE: firewall_restart_daemon is set to false by default and it is deliberately set to false
 # to avoid restarting the firewall daemon because the changes can possibly disrupt your only
@@ -259,7 +256,7 @@ galaxy_systemd_memory_limit_workflow: 15
 gie_proxy_dir: '{{ galaxy_root }}/gie-proxy/proxy'
 gie_proxy_git_version: v0.1.0
 gie_proxy_setup_nodejs: nodeenv
-gie_proxy_virtualenv_command: '{{ conda_prefix }}/envs/_galaxy_/bin/python -m venv --copies' #"{{ pip_virtualenv_command }}"
+gie_proxy_virtualenv_command: '{{ galaxy_virtualenv_command }}'
 gie_proxy_nodejs_version: '22.0.0'
 gie_proxy_virtualenv: '{{ galaxy_root }}/gie-proxy/venv'
 gie_proxy_setup_service: systemd
@@ -327,7 +324,7 @@ galaxy_venv_dir: '{{ galaxy_root }}/venv'
 galaxy_job_working_directory: "{{ galaxy_config['galaxy']['job_working_directory'] }}"
 ucsc_build_sites:
 
-galaxy_virtualenv_command: '{{ conda_prefix }}/envs/_galaxy_/bin/python -m venv --copies'
+galaxy_virtualenv_command: '/usr/local/tools/_conda/envs/__python@3.11.5/bin/python -m venv --copies'
 galaxy_nonrepro_tools: '{{ galaxy_root }}/custom-tools'
 galaxy_nonrepro_commit: master
 

--- a/sn09.yml
+++ b/sn09.yml
@@ -285,21 +285,6 @@
         enable_pam_limits: true # Prevent out of control processes
         enable_install_software: true # Some extra admin tools (*top, vim, etc)
     - geerlingguy.repo-epel # Install EPEL repository
-
-    ## Install miniconda, create a _galaxy_ environment and install Packages
-    ## Galaxy will use the virtualenv from this conda environment (see
-    ## galaxy_virtualenv_command) in the group_vars/sn09.yml
-    - role: galaxyproject.miniconda
-      vars:
-        miniconda_prefix: '{{ conda_prefix }}'
-        miniconda_distribution: 'miniconda'
-        miniconda_executable: 'conda'
-        galaxy_conda_create_env: true
-        galaxy_conda_env_packages:
-          - python=3.11.5
-          - pip
-          - libsqlite=3.43.0 #pinning this due to https://github.com/galaxyproject/ansible-galaxy/issues/228
-
     - usegalaxy-eu.autoupdates # keep all of our packages up to date
     - influxdata.chrony # Keep our time in sync.
 


### PR DESCRIPTION
@bgruening during testing found the following

```
root@sn09:/data/jwd05e/main/086/589/86589397$ cat galaxy_86589397.e
Could not find platform independent libraries <prefix>
Could not find platform dependent libraries <exec_prefix>
Python path configuration:
  PYTHONHOME = (not set)
  PYTHONPATH = '/opt/galaxy/server/lib:/opt/galaxy/server/lib/galaxy/jobs/rules'
  program name = 'python'
  isolated = 0
  environment = 1
  user site = 1
  safe_path = 0
  import site = 1
  is in build tree = 0
  stdlib dir = '/opt/miniconda/envs/_galaxy_/lib/python3.11'
  sys._base_executable = '/opt/miniconda/envs/_galaxy_/bin/python'
  sys.base_prefix = '/opt/miniconda/envs/_galaxy_'
  sys.base_exec_prefix = '/opt/miniconda/envs/_galaxy_'
  sys.platlibdir = 'lib'
  sys.executable = '/opt/galaxy/venv/bin/python'
  sys.prefix = '/opt/miniconda/envs/_galaxy_'
  sys.exec_prefix = '/opt/miniconda/envs/_galaxy_'
  sys.path = [
    '/opt/galaxy/server/lib',
    '/opt/galaxy/server/lib/galaxy/jobs/rules',
    '/opt/miniconda/envs/_galaxy_/lib/python311.zip',
    '/opt/miniconda/envs/_galaxy_/lib/python3.11',
    '/opt/miniconda/envs/_galaxy_/lib/python3.11/lib-dynload',
  ]
Fatal Python error: init_fs_encoding: failed to get the Python codec of the filesystem encoding
Python runtime state: core initialized
ModuleNotFoundError: No module named 'encodings'

Current thread 0x0000147227d48740 (most recent call first):
  <no Python frame>
```

This is because the `/opt/miniconda/` is not available on the workers. 