### PR TITLE
Ensure /opt/galaxy/server/database directory exists and is owned by he Galaxy user

### DIFF
--- a/sn09.yml
+++ b/sn09.yml
@@ -287,6 +287,14 @@
         group: galaxy
         mode: '0755'
 
+    - name: "Ensure {{ galaxy_server_dir }}/database directory exists and is owned by galaxy user"
+      ansible.builtin.file:
+        path: "{{ galaxy_server_dir }}/database"
+        state: directory
+        owner: "{{ galaxy_user.name }}"
+        group: "{{ galaxy_group.name }}"
+        mode: "0750"
+
     - name: Add gxadmin local script
       ansible.builtin.copy:
         src: '{{ playbook_dir }}/files/galaxy/config/gxadmin-local.sh'


### PR DESCRIPTION
Galaxy stores the tool recommendation model in the `database` directory relative to the working directory it is running on (the path is not configurable, see the [download function](https://github.com/galaxyproject/galaxy/blob/f6adc7c52dd87aed1c32a8d9ac82390ab784ac4c/lib/galaxy/tools/recommendations.py#L176-L186) and [how it is called](https://github.com/galaxyproject/galaxy/blob/f6adc7c52dd87aed1c32a8d9ac82390ab784ac4c/lib/galaxy/tools/recommendations.py#L133)).

By default, the `galaxyproject.galaxy` role does not allow Galaxy to create directories in /opt/galaxy/server, so the web handlers fail to download the tool recommendation model.

This commit works around the issue using a post-task that ensures the directory exists and has the correct permissions.