### PR TITLE
Give kraken2 100G from 100MB input

### DIFF
--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -1512,6 +1512,9 @@ tools:
     scheduling:
       require:
         - singularity
+    rules:
+      - if: input_size >= 0.1
+        mem: 100
 
   toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_compute_graph/scanpy_compute_graph/.*:
     scheduling:


### PR DESCRIPTION
I think I need some help with the interpretation of my analysis :D
This means, that on average 1GB of input needed 506GB of memory?
~~~
galaxy@sn09:/data/dnb01/test3/mira$ cat kraken2_memory.tsv |         awk '{print $10}' | ./histogram.py --percentage --max=256
# NumSamples = 122212; Min = 0.00; Max = 256.00
# 72742 values outside of min/max
# Mean = 5085761.854932; Variance = 147305090613418592.000000; SD = 383803453.102520; Median 506.000000
# each ∎ represents a count of 238
0 - 25.6 [17861] ∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎  (14.61%)
25.6 - 51.2 [10820] ∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎  (8.85%)
51.2 - 76.8 [5866] ∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎  (4.80%)
76.8 - 102.4 [3500] ∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎  (2.86%)
102.4 - 128.0 [2575] ∎∎∎∎∎∎∎∎∎∎∎  (2.11%)
128.0 - 153.6 [2092] ∎∎∎∎∎∎∎∎∎  (1.71%)
153.6 - 179.2 [2072] ∎∎∎∎∎∎∎∎∎  (1.70%)
179.2 - 204.8 [1589] ∎∎∎∎∎∎∎  (1.30%)
204.8 - 230.4 [1533] ∎∎∎∎∎∎  (1.25%)
230.4 - 256.0 [1562] ∎∎∎∎∎∎∎  (1.28%)
~~~