### PR TITLE
Run HTCondor job resubmission role only on sn09 and in one playbook only

### DIFF
--- a/htcondor.yml
+++ b/htcondor.yml
@@ -97,7 +97,7 @@
       when: htcondor_role_submit
     - grycap.htcondor
     - name: usegalaxy-eu.htcondor_release
-      when: htcondor_role_submit and inventory_hostname != "maintenance.galaxyproject.eu"
+      when: htcondor_role_submit and inventory_hostname == "sn09.galaxyproject.eu"
     - name: usegalaxy-eu.fix-stop-ITs
       when: htcondor_role_submit and inventory_hostname != "maintenance.galaxyproject.eu"
     - name: usegalaxy-eu.remove-orphan-condor-jobs

--- a/sn06.yml
+++ b/sn06.yml
@@ -271,7 +271,6 @@
     - usegalaxy_eu.fs_maintenance # Filesystems maintenance
     - usegalaxy-eu.logrotate # Rotate logs
     - usegalaxy-eu.error-pages # Copy the NGINX error pages
-    - usegalaxy-eu.htcondor_release
     # Various ugly fixes
     # - usegalaxy-eu.fix-unscheduled-jobs # Workaround for ???
     - usegalaxy-eu.fix-stuck-handlers # Restart handlers to prevent several classes of issues

--- a/sn09.yml
+++ b/sn09.yml
@@ -404,7 +404,6 @@
     - usegalaxy_eu.fs_maintenance # Filesystems maintenance
     - usegalaxy-eu.logrotate # Rotate logs
     - usegalaxy-eu.error-pages # Copy the NGINX error pages
-    - usegalaxy-eu.htcondor_release
     - usegalaxy-eu.fix-stuck-handlers # Restart handlers to prevent several classes of issues
     - usegalaxy-eu.log-cleaner # do not retain journalctl logs, they are unnecessary/risky under GDPR
     - dj-wasabi.telegraf


### PR DESCRIPTION
At the moment, the role that resubmits HTCondor jobs when they run out of memory, `usegalaxy-eu.htcondor_release` runs both on sn06 and sn09 via three playbooks: sn06.yml, sn09.yml and htcondor.yml.

The job resubmission script can run on one host only, otherwise a race condition occurs and the memory assigned to resubmitted jobs is not increased reliably.

Run the role only on sn09 via the htcondor.yml playbook only.