### PR TITLE
Update Seurat preprocessing memory

### DIFF
--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -1643,3 +1643,7 @@ tools:
 
   toolshed.g2.bx.psu.edu/repos/iuc/vapor/vapor/.*:
     mem: 8
+
+  toolshed.g2.bx.psu.edu/repos/iuc/seurat_preprocessing/seurat_preprocessing/.*:
+    cores: 1
+    mem: 20


### PR DESCRIPTION
There was a error report on EU server from a user trying to run this tool on a dataset of over 600MB. We cannot yet estimate the memory based on the input file size. I want to test whether it works out for now. Later, we can implement a proper rule on shared TPV.