### PR TITLE
Raise PG connection limit to 2048

### DIFF
--- a/group_vars/sn11.yml
+++ b/group_vars/sn11.yml
@@ -47,7 +47,7 @@ postgresql_conf:
   # Cores: 128
   # Storage: SSD
   - listen_addresses: "'*'"
-  - max_connections: 1024
+  - max_connections: 2048
   - shared_buffers: '128GB'
   - effective_cache_size: '384GB'
   - maintenance_work_mem: '2GB'


### PR DESCRIPTION
This PR makes the change I had hacked into my local PG settings override file (`conf.d/30temporary.conf`) during the load spike incident on 2025-08-12 now "official". Actually, I'm still not convinced that this limit should remain this high in normal operation but this needs to be discussed when Mira is back and I rly don't want a hack that overrides CI-controlled settings behind Ansible's back to be active this long. `30temporary.conf` is only intended for temporarily activating debugging settings or quick & dirty emergency overrides.