### PR TITLE
Apollo: increase timeout for apollo_calls

### DIFF
--- a/templates/nginx/apollo.j2
+++ b/templates/nginx/apollo.j2
@@ -53,7 +53,7 @@ server {
 		proxy_set_header           X-Forwarded-For $remote_addr;
 		proxy_set_header           X-Forwarded-Proto $scheme;
 		proxy_pass                 http://127.0.0.1:8080/apollo;
-		proxy_read_timeout         300;
+		proxy_read_timeout         3000;
 		proxy_pass_request_headers on;
 
 		location /apollo_api/organism/findAllOrganisms {


### PR DESCRIPTION
should fix 504 error on "create organism" tool

ping @bgruening -> I made the change on the server and it fixes the problem for me, need more test by other users now