### PR TITLE
Add warning message for ChatGPT tool

### DIFF
--- a/group_vars/sn09/toolmsg.yml
+++ b/group_vars/sn09/toolmsg.yml
@@ -71,7 +71,7 @@ toolmsg_messages:
     class: warning
   - tool_id: toolshed.g2.bx.psu.edu/repos/bgruening/chatgpt_openai_api/chatgpt_openai_api
     message: >
-      <strong>This tool uses the OpenAI API and requires an access token. 
+      <strong>This tool uses the OpenAI API and requires an access token.
       If you prefer to use open-access models that are executed within the EU, we recommend using the
       <a href="https://usegalaxy.eu/?tool_id=llm_hub">LLM Hub</a>
       instead. It provides direct access to a wide range of open-source models without requiring an access token.</strong>


### PR DESCRIPTION
Add warning message that suggests using LLM Hub for direct access to open-source models instead of the ChatGPT API.