### PR TITLE
Update Grafana YUM repo URLs

### DIFF
--- a/group_vars/grafana/vars.yml
+++ b/group_vars/grafana/vars.yml
@@ -43,6 +43,12 @@ grafana_on_call_path: /data/grafana-on-call
 # Grafana
 grafana_version: "11.4.0"
 
+# patch from https://github.com/grafana/grafana-ansible-collection/pull/414;
+# once merged upstream, update the collection version in requirements.yml and
+# remove the next two lines
+grafana_yum_repo: "https://rpm.grafana.com"
+grafana_yum_key: "https://rpm.grafana.com/gpg.key"
+
 grafana_address: "127.0.0.1"
 grafana_domain: stats.galaxyproject.eu
 grafana_url: "https://{{ grafana_domain }}"


### PR DESCRIPTION
The Grafana YUM repo was moved from packages.grafana.com to rpm.grafana.com.

There is an open upstream PR https://github.com/grafana/grafana-ansible-collection/pull/414. Until it is merged, and a new collection version is released, configure the new URLs in the group vars file.

Closes https://github.com/usegalaxy-eu/issues/issues/784.