### PR TITLE
Workaround bug in funannotate_predict v1.8.17+galaxy0 while running `augustus_parallel.py`

### DIFF
--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -1525,6 +1525,12 @@ tools:
     params:
       singularity_run_extra_arguments: "--env GENEMARK_PATH=/usr/local/tools/genemark/etp.for_braker/bin/gmes/ -B /tmp:/tmp"
       singularity_no_mount: null
+    rules:
+      - if: helpers.tool_version_eq(tool, '1.8.17+galaxy0')
+        params:
+          singularity_run_extra_arguments: "--writable-tmpfs --env GENEMARK_PATH=/usr/local/tools/genemark/etp.for_braker/bin/gmes/ -B /tmp:/tmp"
+       	env:
+          - execute: "chmod +x /usr/local/lib/python3.11/site-packages/funannotate/aux_scripts/augustus_parallel.py"
     scheduling:
       require:
         - singularity


### PR DESCRIPTION
The tool fails because the container was built wrongly, without setting the executable bit for /usr/local/lib/python3.11/site-packages/funannotate/aux_scripts/augustus_parallel.py (previous versions, such as 1.8.15+galaxy5, have it set).

```python
Running Augustus gene prediction using aspergillus_nidulans parameters
Traceback (most recent call last):
  File "/usr/local/bin/funannotate", line 10, in <module>
    sys.exit(main())
             ^^^^^^
  File "/usr/local/lib/python3.11/site-packages/funannotate/funannotate.py", line 717, in main
    mod.main(arguments)
  File "/usr/local/lib/python3.11/site-packages/funannotate/predict.py", line 2156, in main
    subprocess.call(cmd)
  File "/usr/local/lib/python3.11/subprocess.py", line 389, in call
    with Popen(*popenargs, **kwargs) as p:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/subprocess.py", line 1026, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/usr/local/lib/python3.11/subprocess.py", line 1955, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
PermissionError: [Errno 13] Permission denied: '/usr/local/lib/python3.11/site-packages/funannotate/aux_scripts/augustus_parallel.py'
```

Set the executable bit to workaround the problem. Closes usegalaxy-eu/issues#786.