### PR TITLE
Increase number of gunicorn workers per systemd service to 5

### DIFF
--- a/group_vars/sn09/sn09.yml
+++ b/group_vars/sn09/sn09.yml
@@ -232,7 +232,7 @@ galaxy_cvmfs_server_urls:
 # SystemD
 galaxy_systemd_mode: 'gunicorn'
 galaxy_systemd_gunicorns: 7
-galaxy_systemd_gunicorn_workers: 4
+galaxy_systemd_gunicorn_workers: 5
 galaxy_systemd_gunicorn_timeout: 600
 galaxy_systemd_handlers: 6
 galaxy_systemd_workflow_schedulers: 3


### PR DESCRIPTION
Set `galaxy_systemd_gunicorn_workers: 5` to handler larger numbers of requests per second with each `galaxy-gunicorn` service.

@bgruening @mira-miracoli this PR is meant to make the response to incident https://github.com/usegalaxy-eu/incidents/pull/6 permanent if it makes sense, to raise awareness on the incident and to foster discussion on the response (if necessary).