### PR TITLE
Bump galaxyproject.galaxy to version 0.12.0

### DIFF
--- a/requirements.yaml
+++ b/requirements.yaml
@@ -62,8 +62,7 @@ roles:
   - name: dj-wasabi.telegraf
     version: 0.14.1
   - name: galaxyproject.galaxy
-    src: https://github.com/galaxyproject/ansible-galaxy
-    version: 54d7d459a2d27080d41179a87c4607d91065f540
+    version: 0.12.0
   - name: galaxyproject.cvmfs
     src: https://github.com/usegalaxy-eu/ansible-cvmfs
     version: master


### PR DESCRIPTION
Use the feature introduced in https://github.com/galaxyproject/ansible-galaxy/pull/232 to improve the CI run times for usegalaxy.eu.