### PR TITLE
hide ebi scanpy tools

### DIFF
--- a/templates/galaxy/config/tool_conf.xml.j2
+++ b/templates/galaxy/config/tool_conf.xml.j2
@@ -283,6 +283,20 @@
     <tool file="phenotype_association/master2pg.xml" />
     </section>
   <section id="single-cell" name="Single-cell">
+    <tool file="/opt/galaxy/custom-tools/ebi-gxa/scanpy-parameter-iterator.xml" hidden="True" />
+    <tool file="/opt/galaxy/custom-tools/ebi-gxa/scanpy-plot-trajectory.xml" hidden="True" />
+    <tool file="/opt/galaxy/custom-tools/ebi-gxa/scanpy-compute-graph.xml" hidden="True" />
+    <tool file="/opt/galaxy/custom-tools/ebi-gxa/scanpy-filter-cells.xml" hidden="True" />
+    <tool file="/opt/galaxy/custom-tools/ebi-gxa/scanpy-filter-genes.xml" hidden="True" />
+    <tool file="/opt/galaxy/custom-tools/ebi-gxa/scanpy-find-cluster.xml" hidden="True" />
+    <tool file="/opt/galaxy/custom-tools/ebi-gxa/scanpy-find-variable-genes.xml" hidden="True" />
+    <tool file="/opt/galaxy/custom-tools/ebi-gxa/scanpy-normalise-data.xml" hidden="True" />
+    <tool file="/opt/galaxy/custom-tools/ebi-gxa/scanpy-read-10x.xml" hidden="True" />
+    <tool file="/opt/galaxy/custom-tools/ebi-gxa/scanpy-run-pca.xml" hidden="True" />
+    <tool file="/opt/galaxy/custom-tools/ebi-gxa/scanpy-run-tsne.xml" hidden="True" />
+    <tool file="/opt/galaxy/custom-tools/ebi-gxa/scanpy-run-umap.xml" hidden="True" />
+    <tool file="/opt/galaxy/custom-tools/ebi-gxa/scanpy-scale-data.xml" hidden="True" />
+    <tool file="/opt/galaxy/custom-tools/ebi-gxa/scanpy-find-markers.xml" hidden="True" />
   </section>
   <section id="single-cell-section-scdata" name="Import/manipulate sc data">
   </section>


### PR DESCRIPTION
As discussed at the SPOC meeting with @pavanvidem and @MarisaJL and previously with @nomadscientist :vulcan_salute: , we decided to continue with the scanpy IUC tool suite and hide the EBI version.

Currently, it is confusing for the user when they try to search "scanpy" in the tool panel, as many tools will pop up.

@nomadscientist did great work and migrated all the EBI tools of the single cell trainings to the IUC ones.

So it is time to hide EBI scanpy :)