### PR TITLE
Fixing OpenAI monitoring script

### DIFF
--- a/roles/hxr.monitor-galaxy/files/galaxy_wizard_openai_utilization_and_costs.py
+++ b/roles/hxr.monitor-galaxy/files/galaxy_wizard_openai_utilization_and_costs.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Description: This script fetches OpenAI completions and costs data for a
 # specific project and outputs it in the influxDB line protocol format.
 # Author: @arash77 (GitHub), and @sanjaysrikakulam (GitHub)


### PR DESCRIPTION
Fetch data from the last 7 days by updating the START_TIME variable to make it faster and prevent timeout error.
Enhance output by adding flush=True to the print statement.