### PR TITLE
Bump grafana.grafana colection to version 6.0.5

### DIFF
--- a/group_vars/grafana/vars.yml
+++ b/group_vars/grafana/vars.yml
@@ -43,12 +43,6 @@ grafana_on_call_path: /data/grafana-on-call
 # Grafana
 grafana_version: "11.4.0"
 
-# patch from https://github.com/grafana/grafana-ansible-collection/pull/414;
-# once merged upstream, update the collection version in requirements.yml and
-# remove the next two lines
-grafana_yum_repo: "https://rpm.grafana.com"
-grafana_yum_key: "https://rpm.grafana.com/gpg.key"
-
 grafana_address: "127.0.0.1"
 grafana_domain: stats.galaxyproject.eu
 grafana_url: "https://{{ grafana_domain }}"

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -30,7 +30,7 @@ collections:
     type: git
   - name: ansible.posix # required by `grafana.grafana`
     source: https://github.com/ansible-collections/ansible.posix.git
-    version: 1.5.2
+    version: 1.5.4
     type: git
   - name: community.rabbitmq
     version: 1.1.0

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -1,7 +1,7 @@
 ---
 collections:
   - name: community.general
-    version: 8.0.2
+    version: 8.2.0
     source: https://galaxy.ansible.com
   - name: amazon.aws
     version: 1.5.0

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -19,7 +19,7 @@ collections:
     # Therefore, they have to be included in this file. @kysrpex opened an issue on the repository of the Grafana Ansible collection
     # https://github.com/grafana/grafana-ansible-collection/issues/222
     # notifying the developers of this issue.
-    version: 5.3.0
+    version: 6.0.5
   # - name: community.general  # required by `grafana.grafana` (already specified above)
   #   source: https://github.com/ansible-collections/community.general.git
   #   version: 9.0.1


### PR DESCRIPTION
PR usegalaxy-eu/infrastructure-playbook#1635 was a workaround to fix https://github.com/usegalaxy-eu/issues/issues/784, and it was needed because https://github.com/grafana/grafana-ansible-collection/pull/414 was not merged. 

Revert usegalaxy-eu/infrastructure-playbook#1635 and update the Grafana collection to [version 6.0.5](https://github.com/grafana/grafana-ansible-collection/releases/tag/6.0.5), which includes the upstream fix. 