### PR TITLE
Cleanup TPV and add submit_requirements to embedded pulsar

### DIFF
--- a/files/galaxy/tpv/destinations.yml.j2
+++ b/files/galaxy/tpv/destinations.yml.j2
@@ -72,6 +72,7 @@ destinations:
     min_accepted_gpus: 0
     max_accepted_gpus: 0
     params:
+      submit_requirements: {entity.params.get('requirements') or ""}
       docker_volumes: "$job_directory:rw,
         $_CONDOR_SCRATCH_DIR:rw,
         $tool_directory:ro,

--- a/files/galaxy/tpv/interactive_tools.yml
+++ b/files/galaxy/tpv/interactive_tools.yml
@@ -6,7 +6,6 @@ tools:
     params:
       docker_volumes: $defaults
       container_monitor_result: callback
-      submit_requirements: 'GalaxyDockerHack == True' # && GalaxyGroup == "interactive"'
     scheduling:
       require:
         - docker
@@ -15,21 +14,12 @@ tools:
       - if: not user
         fail: |
           Interactive tools require registration. Please log-in or register on https://usegalaxy.eu/login
-      - if: user is not None
-        execute: |
-          training_roles = [r.name for r in user.all_roles() if not r.deleted and "training" in r.name]
-          oubb_roles = [r for r in training_roles if "oubb" in r]
-          if oubb_roles:
-              # If there is an 'oubb' role, set the submit requirements accordingly
-              training_expr = 'GalaxyGroup == "%s"' % oubb_roles[0]
-              entity.params['submit_requirements'] = 'GalaxyDockerHack == True || %s' % training_expr
   interactive_tool_gpu:
     cores: 1
     mem: 4
     params:
       docker_volumes: $defaults
       container_monitor_result: callback
-      submit_requirements: 'GalaxyDockerHack == True'
     rules:
       - if: user and 'gpu_access_validated' in [role.name for role in user.all_roles() if not role.deleted]
         scheduling:

--- a/files/galaxy/tpv/tool_defaults.yml
+++ b/files/galaxy/tpv/tool_defaults.yml
@@ -48,6 +48,9 @@ tools:
           entity.params['requirements'] = '(GalaxyGroup == "compute") || (%s)' % training_expr if training_expr else '(GalaxyGroup == "compute")'
           entity.params['+Group'] = training_labels
           entity.params['accounting_group_user'] = str(user.id)
+      - if: user is None
+        execute: |
+          entity.params['requirements'] = '(GalaxyGroup == "compute")'
       - id: remote_resources
         if: user is not None
         execute: |

--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -344,7 +344,6 @@ tools:
 
   basic_docker_tool:
     params:
-      submit_requirements: "GalaxyDockerHack == True"
     scheduling:
       require:
         - docker


### PR DESCRIPTION
closes https://github.com/usegalaxy-eu/issues/issues/779
~~~diff
+ ADDS a submit_requirements: {entity.params.get('requirements') or ""}  to embedded pulsar docker destinations, which run locally, this was not set before so these tools did not get a GalaxyGroup and ran everywhere (see issue)
+ ADDS GalaxyGroup == compute for anonymous user; this should be replaced by the destination if it specifies GPU [docs](https://total-perspective-vortex.readthedocs.io/en/latest/topics/inner_workings.html#combining-envs-and-params)
- REMOVES the last GalaxyDockerHacks this was probably used when not all workers had docker, but I don't see any reason why we would need this still. We should also remove it from the HTCondor configuration.
- REMOVES an old training exception rule for interactive tools (the oubb training)
~~~