### PR TITLE
add EEN CORS allowlist

### DIFF
--- a/templates/nginx/galaxy-main.j2
+++ b/templates/nginx/galaxy-main.j2
@@ -145,17 +145,9 @@ server {
 		proxy_pass http://upload.galaxyproject.eu:1081/api/upload/resumable_upload;
 	}
 
-    # Allowlist the external origin(s) that may call the /authnz/keycloak/login endpoint
-    # might be extended to all /authnz/*/login endpoints?
-    # This is currently (2025-10) needed for the EOSC EU Node
-    map $http_origin $cors_allow_origin {
-        default "";
-        "~^https://(usegalaxy.eu|eosc-test-ds.acc.myaccessid.org)$" $http_origin;
-    }
-
     # This is currently (2025-10) needed for the EOSC EU Node
     location = /authnz/keycloak/login {
-        proxy_pass http://galaxy_upstream;
+        proxy_pass http://galaxy;
 
         # Only add CORS for cross-origin callers we allow
         if ($cors_allow_origin != "") {


### PR DESCRIPTION
Don't merge yet, not clear if needed. 

The EOSC EU Node wants to redirect users from the EU Node automatically, without login (SSO in the EOSC EU Node), back to Galaxy.

This might be needed. Thanks to Uwe for providing this snippet.

A review would be nice, so that I can merge and deploy it when it's needed.
See specifically the one comment in the code.