### PR TITLE
Revert undefining `hostname` in Grafana on-call removal PR (fixes grafana.yml playbook)

### DIFF
--- a/grafana.yml
+++ b/grafana.yml
@@ -55,6 +55,8 @@
     ## Grafana
     - role: galaxyproject.nginx
       become: true
+      vars:
+        hostname: "{{ grafana_domain }}"
     - grafana
     - role: pgs
       become: true


### PR DESCRIPTION
When commit a7fcf21 from PR #1687 was merged, it [left the variable `hostname` undefined](https://github.com/usegalaxy-eu/infrastructure-playbook/pull/1687/commits/a7fcf210a96574e28fbcef73d84a0db889e0aa0f#diff-8d0c3127a139fe96af7ed65a80c62a7cddd117794db6b15a9680318a7a587a04L76-L77) while running `galaxyproject.nginx`, which in turns runs `usegalaxy-eu.certbot`. This [causes the grafana.yml playbook to fail](https://build.galaxyproject.eu/job/usegalaxy-eu/job/playbooks/job/stats-grafana/1756/console).

Revert this change to make the playbook work again.