### PR TITLE
fix redis config path

### DIFF
--- a/group_vars/mq.yml
+++ b/group_vars/mq.yml
@@ -168,7 +168,7 @@ redis_dbfilename: dump.rdb
 redis_dbdir: /var/lib/redis
 redis_loglevel: "notice"
 redis_logfile: /var/log/redis/redis-server.log
-redis_conf_path: /etc/redis
+redis_conf_path: /etc/redis/redis.conf
 # Telegraf
 telegraf_plugins_extra:
   prometheus:


### PR DESCRIPTION
I guess it was only deployed manually before and never worked in Ansible.. my bad o.O