### PR TITLE
Add configurations for local tool versions of 3dtrees tool suite

### DIFF
--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -417,7 +417,6 @@ tools:
 
   toolshed.g2.bx.psu.edu/repos/bgruening/3dtrees_segmentanytree/3dtrees_segmentanytree/.*:
     inherits: basic_docker_tool
-    gpus: 1
     cores: 10
     mem: 20
 


### PR DESCRIPTION
Alongside the versions from the Galaxy Tool Shed, tools from the 3dtrees suite are also installed as local tools. Add separate definitions in tools.yml to control them.