### PR TITLE
Upgrade GitLab ARCfs to v0.0.24.dev1

### DIFF
--- a/group_vars/sn09/sn09.yml
+++ b/group_vars/sn09/sn09.yml
@@ -123,7 +123,7 @@ pip_install_dependencies:
   # used by reports
   - WeasyPrint
   - nbconvert
-  - gitlab-arc-fs
+  - gitlab-arc-fs==0.0.24.dev1
   # Needed for usegalaxy-eu.vgcn-monitoring Telegraf role
   - pyyaml
   - GitPython


### PR DESCRIPTION
This package provides a filesystem-like view of [DataPLANT DataHUB ARCs](https://github.com/nfdi4plants/ARC-specification) in Python. It is used to power the [`arcfs1` files source](https://github.com/usegalaxy-eu/infrastructure-playbook/blob/0337c87f96df863a8235e19ccae046eaf66db987/templates/galaxy/config/file_sources_conf.yml.j2#L238-L244).

This PR updates the package to the latest version published by [@TetraW](https://github.com/TetraW).