### PR TITLE
bump role rabbitmqserver version

### DIFF
--- a/requirements.yaml
+++ b/requirements.yaml
@@ -125,7 +125,7 @@ roles:
   - name: usegalaxy_eu.rustus
     version: 0.3.0
   - name: usegalaxy_eu.rabbitmqserver
-    version: 1.4.5
+    version: 1.5.0
   - name: usegalaxy_eu.influxdbserver
     version: 1.1.1
   - name: usegalaxy_eu.flower


### PR DESCRIPTION
This will recreate the current container and map the data (by default) into /opt/rabbitmq/data.

This means any previous data will be gone. 