### PR TITLE
Enable jwd08 as job working directory

### DIFF
--- a/group_vars/maintenance.yml
+++ b/group_vars/maintenance.yml
@@ -142,6 +142,7 @@ fsm_scripts:
       - /data/jwd05e/main
       - /data/jwd06/main
       - /data/jwd07/main
+      - /data/jwd08/main
     time: "{{ fsm_intervals.long }}"
 fsm_htcondor_enable: true
 

--- a/templates/galaxy/config/object_store_conf.yml.j2
+++ b/templates/galaxy/config/object_store_conf.yml.j2
@@ -238,7 +238,7 @@ backends:
     files_dir: "/data/dnb11/galaxy_db/files"
     extra_dirs:
       - type: job_work
-        path: "/data/jwd07/main"
+        path: "/data/jwd08/main"
 
   - id: files33
     type: disk
@@ -251,7 +251,7 @@ backends:
     files_dir: "/data/dnb12/galaxy_db/files"
     extra_dirs:
       - type: job_work
-        path: "/data/jwd07/main"
+        path: "/data/jwd08/main"
 
   - id: files34
     type: disk
@@ -364,7 +364,7 @@ backends:
       cache_updated_data: true ## do we need this here?
     extra_dirs:
       - type: job_work
-        path: "{{ jwd.jwd07.path }}/main"
+        path: "{{ jwd.jwd08.path }}/main"
       - type: temp
-        path: "{{ jwd.jwd07.path }}/tmp"
+        path: "{{ jwd.jwd08.path }}/tmp"
 


### PR DESCRIPTION
Switch the job working directory for files32, files33 (both NetApp FabricPool) and s3_private_netapp01 (private storage) to jwd08

Add jwd08 to the list of paths cleaned up by usegalaxy_eu.fs_maintenance.

⚠️ Be ready to deal with major fallout if something goes wrong (shouldn't happen).