### PR TITLE
Increase memory allocation for semibin tool

### DIFF
--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -1082,7 +1082,7 @@ tools:
     mem: 128
 
   toolshed.g2.bx.psu.edu/repos/iuc/semibin/semibin/.*:
-    mem: 16
+    mem: 32
     cores: 16
 
   toolshed.g2.bx.psu.edu/repos/bgruening/nextdenovo/nextdenovo/.*:


### PR DESCRIPTION
We hit some Segmentation fault (core dumped), Tool Exit Code 139 with this tool in the MAGs workflow.
Will try to investigate are better rule once I got the de.NBI cloud VM.