### PR TITLE
Add tailscale to all servers

### DIFF
--- a/all.yml
+++ b/all.yml
@@ -1,0 +1,8 @@
+---
+- name: Manage authorized SSH keys
+  hosts: all
+  gather_facts: false
+  vars_files:
+    - secret_group_vars/all.yml
+  roles:
+    - artis3n.tailscale

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -83,6 +83,9 @@ os_auditd_space_left_action: suspend
 
 # Tailscale
 tailscale_args: "--accept-dns=false"
+tailscale_authkey: "{{ tailacale_auth_key_usegalaxy_eu }}"
+tailscale_tags:
+  - "critical"
 
 # Telegraf
 telegraf_agent_package_state: latest


### PR DESCRIPTION
This installs tailscale to all servers managed in infrastructure-playbook.
It uses a central key, which is stored in the vault.
`--accept-dns=false` prevents tailscale from managing the servers DNS (errors in the past).
the tag `critical` is used for our tailscale ACLs

Goes before #1673 