### PR TITLE
Add `caj` – condor_analyze_job and directly use better analyze on galaxy job IDs

### DIFF
--- a/roles/usegalaxy-eu.bashrc/tasks/bashrc_tasks.yml
+++ b/roles/usegalaxy-eu.bashrc/tasks/bashrc_tasks.yml
@@ -113,7 +113,7 @@
               elif [ $# -eq 2 ]; then
                   condor_q -autoformat ClusterID Cmd JobDescription | grep $1 | awk '{print$1}' | xargs -i condor_q --better-analyze {} --machine $2
               else
-                  echo "Pass a CondorID or GalaxyID or a tool name and optional a RemoteHost to compare ClassAds against (e.g. tstimg.bi.privat)"
+                  echo "Pass a CondorID or GalaxyID or a tool name and optionally a RemoteHost to compare ClassAds (e.g. tstimg.bi.privat)"
               fi
           }
 


### PR DESCRIPTION
Helps to quickly find out if and why jobs are not running and if they could run on a specific machine.

⚠️ This has collision potential if Galaxy job IDs and Condor IDs overlap in the current queue, however in our setup, it will probaly not be the case (Condor IDs should grow the same speed or slower as Galaxy IDs because of remote jobs)

The tool should only be used as a quick lookup help not as production tool for automated job manipulation etc.

~~~bash
Pass a CondorID or GalaxyID or a tool name and optionally a RemoteHost to compare ClassAds (e.g. tstimg.bi.privat)
$ caj 01234567 tstimg.bi.privat
~~~
Outputs `condor_q --better-analyze`