### PR TITLE
Fix/tool usage script

### DIFF
--- a/roles/hxr.monitor-galaxy/tasks/main.yml
+++ b/roles/hxr.monitor-galaxy/tasks/main.yml
@@ -49,11 +49,11 @@
 
 - name: Copy the galaxy tool-usage over time script
   ansible.builtin.copy:
-    src: "galaxy_tool_usage_over_time.sh.j2"
+    src: "galaxy_tool_usage_over_time.sh"
     dest: "/usr/bin/galaxy_tool_usage_over_time"
     owner: root
     group: root
-    mode: "0755"
+    mode: 0755
 
 - name: Copy the galaxy wizard utilization and OpenAI costs-completion script
   ansible.builtin.copy:


### PR DESCRIPTION
This fixes the tool usage over time script. 
We need to always read the data from the last two years because influxdb only as 2 week retention time. In my opinion I would increase the retention time from of influxdb an query only the present month instead. This would apply for all monitor queries that need data from long periods of time. 

Also it would be nice to have a docker compose file for this container. 