### PR TITLE
add proxy_ssl_server_name on on training material

### DIFF
--- a/templates/nginx/galaxy-main.j2
+++ b/templates/nginx/galaxy-main.j2
@@ -261,6 +261,7 @@ server {
 
     # For GTN in Galaxy Webhook
     location /training-material/ {
+        proxy_ssl_server_name on;
         proxy_pass https://training.galaxyproject.org/training-material/;
     }
 


### PR DESCRIPTION
> Hey all, GTN moved to CloudFront and the certs now use SNI. Because of that, you will need to set proxy_ssl_server_name on in your proxy config for location /training-material/ or else the clickable tool links in the GTN modal will no longer work properly: https://github.com/galaxyproject/infrastructure-playbook/commit/262b572f21aa0ab06edd4af9961afc90618a19bb