### PR TITLE
Renaming biodiversity subdomain into biodiversity-genomics (sn09)

### DIFF
--- a/group_vars/sn09/subdomains.yml
+++ b/group_vars/sn09/subdomains.yml
@@ -99,7 +99,7 @@ galaxy_themes_subdomains:
     hidden: true
   - name: microgalaxy
   - name: microbiology
-  - name: biodiversity
+  - name: biodiversity-genomics
   - name: rna
   - name: graphclust
     hidden: true


### PR DESCRIPTION
Commit 87e1f14 from PR #1733 modified group variables for the old headnode sn06 rather than the current headnode sn09.

Update the group variables also for sn09.

This should hopefully fix the [sn09 CI](https://build.galaxyproject.eu/job/usegalaxy-eu/job/playbooks/job/sn09/172/console).