### PR TITLE
Reduce concurrent jobs limit for registered users

### DIFF
--- a/templates/galaxy/config/job_conf.yml
+++ b/templates/galaxy/config/job_conf.yml
@@ -287,7 +287,7 @@ galaxy_jobconf:
     - type: "output_size"
       value: "'300GB'"
     - type: "registered_user_concurrent_jobs"
-      value: "40"
+      value: "15"
     - type: "anonymous_user_concurrent_jobs"
       value: "3"
     - type: "destination_user_concurrent_jobs"


### PR DESCRIPTION
Release stress from the compute cluster while the RZ is restoring compute capacity.

usegalaxy-eu/issues#812