### PR TITLE
Apply firewall configuration immediately for upload host

### DIFF
--- a/upload.yml
+++ b/upload.yml
@@ -14,6 +14,7 @@
         zone: public
         port: 1080-1081/tcp
         permanent: true
+        immediate: true
         state: enabled
     - name: Copy Rustus request monitoring script
       ansible.builtin.copy:


### PR DESCRIPTION
Pass [`immediate: true`](https://docs.ansible.com/projects/ansible/latest/collections/ansible/posix/firewalld_module.html#parameter-immediate) to the `ansible.posix.firewalld` task.

This was spotted during the migration of the upload host from bwCloud to KVM.