### PR TITLE
Update docker_run_extra_arguments in tools.yml for Parabricks

### DIFF
--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -537,7 +537,7 @@ tools:
     cores: 16
     params:
       docker_env_CUDA_VISIBLE_DEVICES: "$_CONDOR_AssignedGPUs"
-      docker_run_extra_arguments: ' --gpus all --shm-size 16g --env CUDA_VISIBLE_DEVICES=$_CONDOR_AssignedGPUs '
+      docker_run_extra_arguments: ' --gpus all --env CUDA_VISIBLE_DEVICES=$_CONDOR_AssignedGPUs '
     context:
       exclude_gpu_models: ["Tesla V100-PCIE-32GB"]
       include_gpu_models: ["NVIDIA L40S", "Tesla T4"]


### PR DESCRIPTION
Removed `shm-size` argument from docker run options.