### PR TITLE
Switch rustus directory to `misc06` on zfs06 box

### DIFF
--- a/group_vars/all/vars.yml
+++ b/group_vars/all/vars.yml
@@ -7,8 +7,8 @@ short_term_web_storage_dir: "{{ misc.misc06.path }}/short_term_web_storage/"
 ftp_upload_dir: "{{ misc.misc06.path }}/incoming"
 
 # Upload dirs
-upload_dir_test: "{{ misc.misc07.path }}/tus_upload/test"
-upload_dir_main: "{{ misc.misc07.path }}/tus_upload/main" # tus_upload_store
+upload_dir_test: "{{ misc.misc06.path }}/tus_upload/test"
+upload_dir_main: "{{ misc.misc06.path }}/tus_upload/main" # tus_upload_store
 nginx_upload_dir: "{{ misc.misc06.path }}/nginx_upload/"
 
 galaxy_config:


### PR DESCRIPTION
Change the rustus uploads directory to `misc06` on the zfs07 box with the goal of rebooting the zfs07 box to deal with stuck delegations.

This doesn't completely prevent uploads downtime, but it makes it "instantaneous"; only ongoing uploads break. The other solution (just rebooting) arguably allows newer uploads to continue after the reboot. It's a tradeoff between small-file uploads and large file uploads, and all options are bad. Choose your poison.

A real solution that prevents downtime is to store nfo files in a [redis instance](https://s3rius.github.io/rustus/configuration/#configuring-info-storage) setup for high-availability and [S3-like storage](https://s3rius.github.io/rustus/configuration/#s3-storage) (e.g. NetApp). But that's too much.