### PR TITLE
Switch singularity base images directory to `misc06` on zfs06 box

### DIFF
--- a/files/galaxy/tpv/destinations.yml.j2
+++ b/files/galaxy/tpv/destinations.yml.j2
@@ -464,7 +464,7 @@ destinations:
           # Use Centos 7 as a fallback container here
           # Most times this fallback is needed for very old tools
           # Centos 7 has libncurses.so.5.9 and python 2.7
-          identifier: "{{ misc.misc07.path }}/singularity_base_images/centos:7.9.2009"
+          identifier: "{{ misc.misc06.path }}/singularity_base_images/centos:7.9.2009"
     scheduling:
       require:
         - singularity


### PR DESCRIPTION
Change the singularity base images directory to `misc06` on the zfs06 box with the goal of rebooting the zfs07 box to deal with stuck delegations.

I did already run `cp -avp /data/misc07/singularity_base_images/ /data/misc06/singularity_base_images/`. 