### PR TITLE
Update flower and Galaxy systemd role

### DIFF
--- a/requirements.yaml
+++ b/requirements.yaml
@@ -97,7 +97,7 @@ roles:
     src: https://github.com/usegalaxy-eu/ansible-certbot
     version: 0.1.5
   - name: usegalaxy_eu.galaxy_systemd
-    version: 2.1.0
+    version: 2.2.0
   - name: usegalaxy-eu.dynmotd
     src: https://github.com/usegalaxy-eu/ansible-dynmotd
     version: 0.0.1
@@ -129,7 +129,7 @@ roles:
   - name: usegalaxy_eu.influxdbserver
     version: 1.1.1
   - name: usegalaxy_eu.flower
-    version: 2.0.0
+    version: 2.1.1
   - name: usegalaxy_eu.walle
     version: a9f33867c32a9a447f6eca636c1dafd637f160a7
     src: https://github.com/usegalaxy-eu/WallE


### PR DESCRIPTION
Among others, incorporate changes that replace the deprecated setting `MemoryLimit` with `MemoryMax` in systemd units.

Closes https://github.com/usegalaxy-eu/issues/issues/791.