### PR TITLE
Add missing `galaxy_config_file` variable to sn09.yml

### DIFF
--- a/group_vars/sn09/sn09.yml
+++ b/group_vars/sn09/sn09.yml
@@ -334,6 +334,7 @@ galaxy_backup_configfiles: false
 
 galaxy_server_dir: '{{ galaxy_root }}/server'
 galaxy_config_dir: '{{ galaxy_root }}/config'
+galaxy_config_file: '{{ galaxy_config_dir }}/galaxy.yml'
 galaxy_venv_dir: '{{ galaxy_root }}/venv'
 galaxy_job_working_directory: "{{ galaxy_config['galaxy']['job_working_directory'] }}"
 ucsc_build_sites:


### PR DESCRIPTION
Fixes the htcondor.yml playbook ('galaxy_config_file' is undefined).

Follow-up of https://github.com/usegalaxy-eu/infrastructure-playbook/pull/1783.