### PR TITLE
change fsm maintenance time to morning

### DIFF
--- a/group_vars/maintenance.yml
+++ b/group_vars/maintenance.yml
@@ -174,6 +174,18 @@ fsm_cron_tasks:
     user: "{{ fsm_galaxy_user.username }}"
 fsm_htcondor_enable: true
 
+fsm_htcondor_cron_tasks:
+  submitter:
+    enable: True
+    name: "Condor maintenance tasks submitter"
+    minute: 0
+    hour: 11
+    dom: "*"
+    month: "*"
+    dow: "*"
+    job: "{{ fsm_maintenance_dir }}/htcondor_crontab_scheduling_submitter.sh"
+    user: "{{ fsm_galaxy_user.username }}"
+
 # Role: dj-wasabi.telegraf
 telegraf_agent_metric_buffer_limit: 100000
 telegraf_agent_hostname: "{{ hostname }}"


### PR DESCRIPTION
quick fix for 
- usegalaxy-eu/issues/issues/850

changes this default value:
https://github.com/usegalaxy-eu/ansible-fs-maintenance/blob/3ecf73039d4d1614cbf22945c55b2e12060472d2/defaults/main.yml#L90-L100

Instead (as a quick fix) this could also be changed:
https://github.com/usegalaxy-eu/infrastructure-playbook/blob/a66f6d3c31a5721c1c5c7e42f1f8069d6c062c54/roles/usegalaxy-eu.remove-orphan-condor-jobs/tasks/main.yml#L45