### PR TITLE
Consider only jobs launched by Galaxy as candidates for orphan job removal

### DIFF
--- a/roles/usegalaxy-eu.remove-orphan-condor-jobs/files/remove-orphan-condor-jobs
+++ b/roles/usegalaxy-eu.remove-orphan-condor-jobs/files/remove-orphan-condor-jobs
@@ -8,7 +8,7 @@ date
 
 IFS=$'\n'
 # Get running jobs from the HTCondor queue
-condor_running_jobs=(`condor_q -global -autoformat Cmd ClusterId JobStatus -json | jq -r -c '.[] | select(.JobStatus == 2) | [.Cmd, .ClusterId] | @sh' | cut -d " " -f1,2 | awk '{n = split($1, arr, "/"); print arr[n-1], $2}'`)
+condor_running_jobs=(`condor_q -global -constraint 'regexp("(.*galaxy_[0-9]+\.sh)|(.*\/[0-9]+\/command\.sh)", Cmd)' -autoformat Cmd ClusterId JobStatus -json | jq -r -c '.[] | select(.JobStatus == 2) | [.Cmd, .ClusterId] | @sh' | cut -d " " -f1,2 | awk '{n = split($1, arr, "/"); print arr[n-1], $2}'`)
 # Get running jobs from the Galaxy database
 galaxy_running_jobs=(`gxadmin query queue-detail | grep -E "queued|running" | awk '{print$3}'`)
 


### PR DESCRIPTION
The role `usegalaxy-eu.remove-orphan-condor-jobs` finds jobs that are known to HTCondor but not to Galaxy anymore, e.g. because the jobs were removed with `gxadmin mutate fail-job`, then kills the jobs.

Specifically, it considers any HTCondor jobs that do not show up in the Galaxy database as orphans kills them. This interferes with HTCondor jobs that have not been launched by Galaxy (e.g. filesystem maintenance jobs).

Filter the list of HTCondor jobs using a constraint so that only jobs launched by Galaxy can be flagged as orphan and cancelled.

The idea comes from [this comment](https://github.com/usegalaxy-eu/infrastructure-playbook/pull/1782#discussion_r2622242080) from @mira-miracoli. Closes https://github.com/usegalaxy-eu/issues/issues/850. Supersedes https://github.com/usegalaxy-eu/infrastructure-playbook/pull/1782.