### PR TITLE
fix TPV

### DIFF
--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -22,18 +22,15 @@ tools:
       - id: no-pulsar
         if: user is not None
         execute: |
-            from tpv.core.entities import Tag, TagType
-
             user_preferences = user.extra_preferences
             pulsar_tag = user_preferences.get("distributed_compute|remote_resources", "None")
-            pulsar_tag = Tag("scheduling", pulsar_tag, TagType.REQUIRE) if pulsar_tag != "None" else None
 
-            entity.tpv_tags.tags = [
-                tag
-                for tag in entity.tpv_tags.tags
-                if tag != pulsar_tag
-            ]
-
+            if pulsar_tag != "None":
+                entity.tpv_tags.require = [
+                    tag
+                    for tag in (entity.tpv_tags.require or [])
+                    if tag != pulsar_tag
+                ]
     env:
       TEMP: /data/1/galaxy_db/tmp
 


### PR DESCRIPTION
```
The TPV configurations seem to have problems.

I see this here:

Jan 04 00:05:43 sn09.galaxyproject.eu python[1815620]: AttributeError: property 'tags' of 'SchedulingTags' object has no setter
Jan 04 00:05:43 sn09.galaxyproject.eu python[1815620]: During handling of the above exception, another exception occurred:
Jan 04 00:05:43 sn09.galaxyproject.eu python[1815620]: Traceback (most recent call last):
Jan 04 00:05:43 sn09.galaxyproject.eu python[1815620]:   File "/opt/galaxy/server/lib/galaxy/jobs/mapper.py", line 268, in __cache_job_destination
Jan 04 00:05:43 sn09.galaxyproject.eu python[1815620]:     self.cached_job_destination = self.__determine_job_destination(
Jan 04 00:05:43 sn09.galaxyproject.eu python[1815620]:                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Jan 04 00:05:43 sn09.galaxyproject.eu python[1815620]:   File "/opt/galaxy/server/lib/galaxy/jobs/mapper.py", line 252, in __determine_job_destination
Jan 04 00:05:43 sn09.galaxyproject.eu python[1815620]:     job_destination = self.__handle_dynamic_job_destination(raw_job_destination)
Jan 04 00:05:43 sn09.galaxyproject.eu python[1815620]:                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Jan 04 00:05:43 sn09.galaxyproject.eu python[1815620]:   File "/opt/galaxy/server/lib/galaxy/jobs/mapper.py", line 215, in __handle_dynamic_job_destination
Jan 04 00:05:43 sn09.galaxyproject.eu python[1815620]:     return self.__handle_rule(expand_function, destination)
Jan 04 00:05:43 sn09.galaxyproject.eu python[1815620]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Jan 04 00:05:43 sn09.galaxyproject.eu python[1815620]:   File "/opt/galaxy/server/lib/galaxy/jobs/mapper.py", line 230, in __handle_rule
Jan 04 00:05:43 sn09.galaxyproject.eu python[1815620]:     raise e
Jan 04 00:05:43 sn09.galaxyproject.eu python[1815620]:   File "/opt/galaxy/server/lib/galaxy/jobs/mapper.py", line 219, in __handle_rule
Jan 04 00:05:43 sn09.galaxyproject.eu python[1815620]:     job_destination = self.__invoke_expand_function(rule_function, destination)
Jan 04 00:05:43 sn09.galaxyproject.eu python[1815620]:                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Jan 04 00:05:43 sn09.galaxyproject.eu python[1815620]:   File "/opt/galaxy/server/lib/galaxy/jobs/mapper.py", line 141, in __invoke_expand_function
Jan 04 00:05:43 sn09.galaxyproject.eu python[1815620]:     return expand_function(**actual_args)
Jan 04 00:05:43 sn09.galaxyproject.eu python[1815620]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Jan 04 00:05:43 sn09.galaxyproject.eu python[1815620]:   File "/opt/galaxy/venv/lib/python3.11/site-packages/tpv/rules/gateway.py", line 109, in map_tool_to_destination
Jan 04 00:05:43 sn09.galaxyproject.eu python[1815620]:     return destination_mapper.map_to_destination(
Jan 04 00:05:43 sn09.galaxyproject.eu python[1815620]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Jan 04 00:05:43 sn09.galaxyproject.eu python[1815620]:   File "/opt/galaxy/venv/lib/python3.11/site-packages/tpv/core/mapper.py", line 241, in map_to_destination
Jan 04 00:05:43 sn09.galaxyproject.eu python[1815620]:     evaluated_entity = self.match_combine_evaluate_entities(context, tool, user)
Jan 04 00:05:43 sn09.galaxyproject.eu python[1815620]:                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Jan 04 00:05:43 sn09.galaxyproject.eu python[1815620]:   File "/opt/galaxy/venv/lib/python3.11/site-packages/tpv/core/mapper.py", line 204, in match_combine_evaluate_entities
Jan 04 00:05:43 sn09.galaxyproject.eu python[1815620]:     evaluated_entity = combined_entity.evaluate_rules(context)
Jan 04 00:05:43 sn09.galaxyproject.eu python[1815620]:                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Jan 04 00:05:43 sn09.galaxyproject.eu python[1815620]:   File "/opt/galaxy/venv/lib/python3.11/site-packages/tpv/core/entities.py", line 572, in evaluate_rules
Jan 04 00:05:43 sn09.galaxyproject.eu python[1815620]:     rule = rule.evaluate(context)
Jan 04 00:05:43 sn09.galaxyproject.eu python[1815620]:            ^^^^^^^^^^^^^^^^^^^^^^
Jan 04 00:05:43 sn09.galaxyproject.eu python[1815620]:   File "/opt/galaxy/venv/lib/python3.11/site-packages/tpv/core/entities.py", line 535, in evaluate
Jan 04 00:05:43 sn09.galaxyproject.eu python[1815620]:     self.evaluator.eval_code_block(self.execute, context, exec_only=True)
Jan 04 00:05:43 sn09.galaxyproject.eu python[1815620]:   File "/opt/galaxy/venv/lib/python3.11/site-packages/tpv/core/loader.py", line 76, in eval_code_block
Jan 04 00:05:43 sn09.galaxyproject.eu python[1815620]:     exec(exec_block, locals)
Jan 04 00:05:43 sn09.galaxyproject.eu python[1815620]:   File "<string>", line 7, in <module>
Jan 04 00:05:43 sn09.galaxyproject.eu python[1815620]:   File "/opt/galaxy/venv/lib/python3.11/site-packages/pydantic/main.py", line 998, in __setattr__
Jan 04 00:05:43 sn09.galaxyproject.eu python[1815620]:     setattr_handler(self, name, value)  # call here to not memo on possibly unknown fields
Jan 04 00:05:43 sn09.galaxyproject.eu python[1815620]:     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Jan 04 00:05:43 sn09.galaxyproject.eu python[1815620]:   File "/opt/galaxy/venv/lib/python3.11/site-packages/pydantic/main.py", line 1038, in <lambda>
Jan 04 00:05:43 sn09.galaxyproject.eu python[1815620]:     return lambda model, _name, val: attr.__set__(model, val)
Jan 04 00:05:43 sn09.galaxyproject.eu python[1815620]:                                      ^^^^^^^^^^^^^^^^^^^^^^^^
Jan 04 00:05:43 sn09.galaxyproject.eu python[1815620]: AttributeError: property 'tags' of 'SchedulingTags' object has no setter

```


Interestingly, this was not caught my the linter.