### PR TITLE
Change log level from INFO to DEBUG for TCP router

### DIFF
--- a/group_vars/traefik.yml
+++ b/group_vars/traefik.yml
@@ -108,7 +108,7 @@ traefik_containers:
       - "--log=true"
       - "--log.format=json"
       - --log.filePath={{ traefik_log_dir }}/traefik.log
-      - "--log.level=INFO" # DEBUG, PANIC, FATAL, ERROR, WARN, INFO
+      - "--log.level=DEBUG" # DEBUG, PANIC, FATAL, ERROR, WARN, INFO
       - --accesslog=true
       - --accesslog.filepath={{ traefik_log_dir }}/access.log
     labels:


### PR DESCRIPTION
This makes tcp router connections visible in the logs https://community.traefik.io/t/access-log-for-tcp-routers/9457