### PR TITLE
Re-enable `jwd06` for object stores

### DIFF
--- a/templates/galaxy/config/object_store_conf.yml.j2
+++ b/templates/galaxy/config/object_store_conf.yml.j2
@@ -266,6 +266,19 @@ backends:
       - type: job_work
         path: "/data/jwd07/main"
 
+  - id: files35
+    type: disk
+    store_by: uuid
+    device: "dnb12"
+    name: "University of Freiburg storage (NetApp FabricPool, id=files35)"
+    weight: 1
+    badges:
+      - type: more_stable
+    files_dir: "/data/dnb12/galaxy_db/files"
+    extra_dirs:
+      - type: job_work
+        path: "/data/jwd06/main"
+
   - id: dataplant01
     type: disk
     store_by: uuid


### PR DESCRIPTION
`chown -R 999:999` has been run on `jwd06` and root squash has been enabled, the disk can thus be used again, providing extra IO bandwidth.

Closes https://github.com/usegalaxy-eu/issues/issues/805.