### PR TITLE
replace deprecated python3-virtualenv package

### DIFF
--- a/maintenance.yml
+++ b/maintenance.yml
@@ -26,7 +26,7 @@
             'git',
             'postgresql',
             'python3-psycopg2',
-            'python3-virtualenv',
+            'python3-pip',
             'bc',
             'python3',
             'python3-devel',


### PR DESCRIPTION
This replaces the deprecated package to fix the maintenance build: https://build.galaxyproject.eu/job/usegalaxy-eu/job/playbooks/job/maintenance/1002/console 