### PR TITLE
Add missing steps packages and steps to make maintenance work

### DIFF
--- a/maintenance.yml
+++ b/maintenance.yml
@@ -34,7 +34,7 @@
             'bc',
             'python3',
             'python3-devel',
-            'restic',
+            'bzip2',
             'firewalld',
           ]
       become: true


### PR DESCRIPTION
Maintenance as been upgraded to Rocky 9.4 !

Small bundle of packages I installed on the go and the firewalld install/enabling setup was missing for the post-tasks.  

https://build.galaxyproject.eu/job/usegalaxy-eu/job/playbooks/job/maintenance/1008/

ref: https://github.com/usegalaxy-eu/issues/issues/858