### PR TITLE
Use container_override

### DIFF
--- a/files/galaxy/tpv/destinations.yml.j2
+++ b/files/galaxy/tpv/destinations.yml.j2
@@ -475,7 +475,7 @@ destinations:
           # Use Centos 7 as a fallback container here
           # Most times this fallback is needed for very old tools
           # Centos 7 has libncurses.so.5.9 and python 2.7
-          identifier: "{{ misc.misc06.path }}/singularity_base_images/centos:7.9.2009"
+          identifier: "/cvmfs/main.galaxyproject.org/singularity/usegalaxy.org-legacy-environment--0"
     scheduling:
       require:
         - singularity


### PR DESCRIPTION
> Like in the above examples, "container_override"
    # will override the tool centric container resolution specified by the container
    # resolvers configuration and "containers" will provide a default if no such
    # container is found during resolution.

from [job_conf.sample.yml](https://github.com/galaxyproject/galaxy/blob/9bc373c0c9d263e86559337ce00f32b0712de433/lib/galaxy/config/sample/job_conf.sample.yml#L657-L662)

**The other issue is:**
The centos7 container is not working for example for `toolshed.g2.bx.psu.edu/repos/crs4/taxonomy_krona_chart/taxonomy_krona_chart/2.6.1.1`
because it does not have `perl` installed.
I would suggest using the same container as @natefoo:
https://github.com/galaxyproject/usegalaxy-playbook/blob/7af9ab26991a61015e47a75dbbb3e307e5abe010/env/common/templates/galaxy/config/tpv/tools.yaml.j2#L78-L85