### PR TITLE
add 3dtrees_potree resource specification

### DIFF
--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -428,6 +428,11 @@ tools:
     cores: 10
     mem: 10
 
+  toolshed.g2.bx.psu.edu/repos/bgruening/3dtrees_potree/3dtrees_potree/.*:
+    inherits: _container_tool
+    cores: 10
+    mem: 10
+
   toolshed.g2.bx.psu.edu/repos/galaxyp/msconvert/msconvert/.*:
     inherits: _container_tool
     ## seems to be still needed 2025/12


### PR DESCRIPTION
This pull request adds configuration for a new tool in the Galaxy TPV tool registry. The main change is the inclusion of resource settings for the `3dtrees_potree` tool.

New tool configuration:

* Added resource settings (`cores: 10`, `mem: 10`) for `toolshed.g2.bx.psu.edu/repos/bgruening/3dtrees_potree/3dtrees_potree/.*` in `files/galaxy/tpv/tools.yml`, inheriting from `_container_tool`.