### PR TITLE
Change LC_ALL value back to C.UTF-8

### DIFF
--- a/files/galaxy/tpv/tool_defaults.yml
+++ b/files/galaxy/tpv/tool_defaults.yml
@@ -22,7 +22,7 @@ tools:
       - name: AWS_REQUEST_CHECKSUM_CALCULATION
         value: "when_required"
       - name: LC_ALL
-        value: C
+        value: C.UTF-8
       - name: SINGULARITYENV_LC_ALL
         value: '${{LANG:-C}}'
       - name: TERM


### PR DESCRIPTION
reverts a part of #1863 since we have considerably more tools running outside containers than .org