### PR TITLE
Update tools.yml to include singularity arguments for markduplicates

### DIFF
--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -819,6 +819,9 @@ tools:
     cores: 8
     mem: 20
     inherits: _container_tool
+    params:
+      # /tmp is not mounted in, and is not writeable, this make markduplicates crash
+      singularity_run_extra_arguments: " -B $TMPDIR:/tmp "
     #params:
     #  docker_run_extra_arguments: --user 999
 


### PR DESCRIPTION
Add singularity_run_extra_arguments to prevent crashes.
Will fix the error from markduplicates:
```
/bin/bash: warning: setlocale: LC\_ALL: cannot change locale (en\_US.UTF-8)
/bin/bash: warning: setlocale: LC\_ALL: cannot change locale (en\_US.UTF-8)
/usr/local/bin/picard: line 5: warning: setlocale: LC\_ALL: cannot change locale (en\_US.UTF-8)
Picked up \_JAVA\_OPTIONS: -Xmx2048m -Xms256m
14:28:49.583 INFO  NativeLibraryLoader - Loading libgkl\_compression.so from jar:file:/usr/local/share/picard-2.18.2-0/picard.jar!/com/intel/gkl/native/libgkl\_compression.so
14:28:49.598 WARN  NativeLibraryLoader - Unable to load libgkl\_compression.so from native/libgkl\_compression.so (Read-only file system)
14:28:49.598 INFO  NativeLibraryLoader - Loading libgkl\_compression.so from jar:file:/usr/local/share/picard-2.18.2-0/picard.jar!/com/intel/gkl/native/libgkl\_compression.so
14:28:49.598 WARN  NativeLibraryLoader - Unable to load libgkl\_compression.so from native/libgkl\_compression.so (Read-only file system)
14:28:49.742 WARN  IntelDeflaterFactory - IntelInflater is not supported, using Java.util.zip.Inflater
Exception in thread "main" htsjdk.samtools.SAMException: Exception creating temporary directory.
at htsjdk.samtools.util.IOUtil.createTempDir(IOUtil.java:879)
at htsjdk.samtools.CoordinateSortedPairInfoMap.\<init>(CoordinateSortedPairInfoMap.java:59)
at picard.sam.markduplicates.util.DiskBasedReadEndsForMarkDuplicatesMap.\<init>(DiskBasedReadEndsForMarkDuplicatesMap.java:57)
at picard.sam.markduplicates.MarkDuplicates.buildSortedReadEndLists(MarkDuplicates.java:483)
at picard.sam.markduplicates.MarkDuplicates.doWork(MarkDuplicates.java:232)
at picard.cmdline.CommandLineProgram.instanceMain(CommandLineProgram.java:282)
at picard.cmdline.PicardCommandLine.instanceMain(PicardCommandLine.java:98)
at picard.cmdline.PicardCommandLine.main(PicardCommandLine.java:108)
Caused by: java.io.IOException: Read-only file system
at java.io.UnixFileSystem.createFileExclusively(Native Method)
at java.io.File.createTempFile(File.java:2024)
at java.io.File.createTempFile(File.java:2070)
at htsjdk.samtools.util.IOUtil.createTempDir(IOUtil.java:870)
... 7 more

```