### PR TITLE
Add 3dtrees_raycloudtools ressource specification

### DIFF
--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -223,7 +223,7 @@ tools:
     mem: 20
 
   toolshed.g2.bx.psu.edu/repos/bgruening/3dtrees_raycloudtools/3dtrees_raycloudtools/.*:
-    inherits: _container_tool
+    inherits: _basic_docker_tool
     cores: 10
     mem: 20
 

--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -222,6 +222,11 @@ tools:
     cores: 10
     mem: 20
 
+    toolshed.g2.bx.psu.edu/repos/bgruening/3dtrees_raycloudtools/3dtrees_raycloudtools/.*:
+    inherits: _container_tool
+    cores: 10
+    mem: 20
+
   toolshed.g2.bx.psu.edu/repos/imgteam/libcarna_render/libcarna_render/.*:
     inherits: _basic_docker_tool
     gpus: 1

--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -222,7 +222,7 @@ tools:
     cores: 10
     mem: 20
 
-    toolshed.g2.bx.psu.edu/repos/bgruening/3dtrees_raycloudtools/3dtrees_raycloudtools/.*:
+  toolshed.g2.bx.psu.edu/repos/bgruening/3dtrees_raycloudtools/3dtrees_raycloudtools/.*:
     inherits: _container_tool
     cores: 10
     mem: 20


### PR DESCRIPTION
This PR adds configuration for a new tool in the Galaxy TPV tool registry. The main change is the inclusion of resource specifications for the `3dtrees_raycloudtools` tool.

__New tool configuration:__

Added resource settings (`cores: 10`, `mem: 20`) for `toolshed.g2.bx.psu.edu/repos/bgruening/3dtrees_raycloudtools/3dtrees_raycloudtools/.*` in `files/galaxy/tpv/tools.yml`, inheriting from `_container_tool`.