### PR TITLE
Run `__.*__` and `param_value_from_file` jobs without Singularity

### DIFF
--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -17,6 +17,11 @@ tools:
       require:
         - upload
 
+  param_value_from_file:
+    scheduling:
+      require:
+        - upload
+
   __DATA_FETCH__:
     cores: 1
     mem: 3


### PR DESCRIPTION
Require the `upload` scheduling tag for the `__SET_METADATA__`, `__EXPORT_HISTORY__` and `param_value_from_file` tools so that jobs run `condor_upload` destination, which does not use Singularity.