### PR TITLE
cleanup

### DIFF
--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -231,25 +231,15 @@ tools:
     mem: 20
 
   toolshed.g2.bx.psu.edu/repos/bgruening/3dtrees_segmentanytree/3dtrees_segmentanytree/.*:
-    inherits: _basic_docker_tool
     gpus: 1
     cores: 10
     mem: 20
-
-  toolshed.g2.bx.psu.edu/repos/imgteam/libcarna_render/libcarna_render/.*:
-    inherits: _basic_docker_tool
-    gpus: 1
-    cores: 1
-    mem: 4
-    params:
-      docker_run_extra_arguments: " --gpus all -e NVIDIA_VISIBLE_DEVICES=all -e NVIDIA_DRIVER_CAPABILITIES=graphics,compute "
 
   toolshed.g2.bx.psu.edu/repos/bgruening/3dtrees_standardization/3dtrees_standardization/.*:
     cores: 10
     mem: 4
 
   toolshed.g2.bx.psu.edu/repos/bgruening/3dtrees_detailview/3dtrees_detailview/.*:
-    inherits: _basic_docker_tool
     gpus: 1
     cores: 8
     mem: 20
@@ -261,6 +251,14 @@ tools:
   toolshed.g2.bx.psu.edu/repos/bgruening/3dtrees_potree/3dtrees_potree/.*:
     cores: 10
     mem: min(12 + (input_size * 4), 200)
+
+  toolshed.g2.bx.psu.edu/repos/imgteam/libcarna_render/libcarna_render/.*:
+    inherits: _basic_docker_tool
+    gpus: 1
+    cores: 1
+    mem: 4
+    params:
+      docker_run_extra_arguments: " --gpus all -e NVIDIA_VISIBLE_DEVICES=all -e NVIDIA_DRIVER_CAPABILITIES=graphics,compute "
 
   toolshed.g2.bx.psu.edu/repos/galaxyp/msconvert/msconvert/.*:
     ## seems to be still needed 2025/12


### PR DESCRIPTION
All the 3dtree tools are running in Docker containers, because they annotate a Docker container.

I assume that the container resolver will do the magic here. Should we still keep for us somewhere (comments?) a hint that its a Docker native tool?