### PR TITLE
Quick/Temporary fix for expression and data source tools

### DIFF
--- a/files/galaxy/tpv/tool_defaults.yml
+++ b/files/galaxy/tpv/tool_defaults.yml
@@ -83,7 +83,7 @@ tools:
         fail: |
           Invalid 'Remote resources id' selected in the config menu under 'User -> Preferences -> Manage Information -> Use distributed compute resources'. Please reselect either 'default' or an appropriate remote resource then click 'Save' and rerun your job.
       - id: tool_requires_galaxy
-        if: tool.tool_type in ("expression") or tool.requires_galaxy_python_environment
+        if: tool.tool_type in ["expression", "data_source"] or tool.requires_galaxy_python_environment
         # ORG has a more fine-grained alternative, we just run all those tools locally with the venv
         # params:
         #   container_override:


### PR DESCRIPTION
This is a temporary fix, we should remove the _basic_internal_tool and replace it by this rule in tool_defaults.yml but we should run expression tools in a container to increase security.

edit: 
closes https://github.com/usegalaxy-eu/issues/issues/923