### PR TITLE
Patch singularity default container and singularity auto-install

### DIFF
--- a/files/galaxy/tpv/destinations.yml.j2
+++ b/files/galaxy/tpv/destinations.yml.j2
@@ -448,7 +448,7 @@ destinations:
         {{ dnb.5.path }}/galaxy_import/galaxy_user_data/:{{ dnb.5.docker_perm }},
         {{ dnb.db.path }}/:{{ dnb.db.docker_perm }},
         {{ tools.tools.path }}/:{{ tools.tools.docker_perm }}"
-      singularity_default_container_id: "{{ cvmfs.singularity.path }}/all/centos:8.3.2011"
+      singularity_default_container_id: "{{ cvmfs.singularity.path }}/all/python:3.8.3"
       #
       # Docker config
       #

--- a/templates/galaxy/config/container_resolvers_conf.yml.j2
+++ b/templates/galaxy/config/container_resolvers_conf.yml.j2
@@ -12,11 +12,11 @@
   cache_directory: /cvmfs/singularity.galaxyproject.org/all/
   cache_directory_cacher_type: dir_mtime
 
-#- type: mulled_singularity
-#  # kicks in when the mulled image is not available on CVMFS
-#  cache_directory: {{ cache.cache08.path }}/container_cache/singularity/mulled/
-#  cache_directory_cacher_type: dir_mtime
-#  auto_install: true
+- type: mulled_singularity
+  # kicks in when the mulled image is not available on CVMFS
+  cache_directory: {{ cache.cache08.path }}/container_cache/singularity/mulled/
+  cache_directory_cacher_type: dir_mtime
+  auto_install: true
 
 - type: cached_mulled
   # only kicks in if `singularity_enabled: false`


### PR DESCRIPTION
Would this fix https://github.com/usegalaxy-eu/issues/issues/921 ?

Is matching the default singularity container for .[org](https://github.com/galaxyproject/usegalaxy-playbook/blob/b3502bee9c3132ffb5b82d0c27441f6a2aff4166/env/main/group_vars/galaxyservers/vars.yml#L128) that comes with python.

Also it's confusing that in the container_resolver.yml example we have the following description:

>  if auto_install is True the result will point to the cached image file
    and to quay.io/NAMESPACE/MULLED_HASH otherwise
    
And I think that's way the reason we opted for `auto_install: False` so we could point to  `quay.io/NAMESPACE/MULLED_HASH` and effectively retrieve the mulled container. However, that is wrong, given  auto_install=True will allways try to pull the image with `singularity pull quay.io/NAMESPACE/MULLED_HASH`

>  [...]The caching is done by a call to docker pull and singularity pull, respectively. Note that, by default the URI is returned in any case, i.e. even if the image just has been downloaded or if the image is already in the cache. Only if the resolves are initialized with auto_install=True the resolve function returns a container description pointing to the cached image

To avoid unnecessary image pulls, we could duplicate the `cached_mulled_singularity` resolver so that Galaxy checks multiple locations before attempting a pull. For exampe:

```
# 1. CVMFS shared cache
- type: cached_mulled_singularity
  cache_directory: /cvmfs/singularity.galaxyproject.org/all
  cache_directory_cacher_type: dir_mtime

# 2. Local cache lookup
- type: cached_mulled_singularity
  cache_directory: /container_cache/singularity/mulled
  cache_directory_cacher_type: dir_mtime

# 3. Pull if missing
- type: mulled_singularity
  cache_directory: /container_cache/singularity/mulled
  cache_directory_cacher_type: dir_mtime
  auto_install: true
```

That said, this last seems over complex. If the SIF file already exists, I would imagine the `singularity pull` would take a couple seconds to verify the existence of the image in the cache (I could be wrong here).

Now its the question if we want to run the `quay.io/NAMESPACE/MULLED_HASH` in docker - we would remove the `mulled_singularity` resolver entirely and let docker resolve the quay.io image instead. Alternatively, we can keep `auto_install: true` and run with singularity. 

Finally, I suspect the [error](https://usegalaxy.eu/datasets/26c75dcccb616ac824dc7ad53735861d/details) occurs because, in this configuration, the mulled container may never resolve successfully when Singularity cannot find it with `auto_install: False`. In that case, Galaxy would fall back to `singularity_default_container_id` witch may not be appropriate for the tool. 

Does this make sense??