### PR TITLE
RFC: one destination to rule them all

### DIFF
--- a/files/galaxy/tpv/destinations.yml.j2
+++ b/files/galaxy/tpv/destinations.yml.j2
@@ -493,7 +493,7 @@ destinations:
           identifier: "/cvmfs/main.galaxyproject.org/singularity/usegalaxy.org-legacy-environment--0"
 
       scheduling:
-        accept:
+        require:
           - foo_test_me
 
 


### PR DESCRIPTION
This destination will try a bunch of container resolvers, primarily around Singularity and if all resolvers fail, it will use Conda-in-singularity.

My aim was:

* Explicit <container type="docker"> will run with Docker.
* Package-based requirements try cached/pulled/cvmfs Singularity mulled images.
* If no resolver matches, fallback container: (Singularity) is used with resolve_dependencies: true (Conda inside container).