### PR TITLE
Install `ipython` to Galaxy venv

### DIFF
--- a/group_vars/sn09/sn09.yml
+++ b/group_vars/sn09/sn09.yml
@@ -107,6 +107,7 @@ telegraf_plugins_extra:
 # Custom pip installer
 pip_venv_path: '{{ galaxy_venv_dir }}'
 pip_install_dependencies:
+  - ipython  # for debugging
   - rspace-client==2.6.1 # RSpace support for Galaxy (workaround for issue https://github.com/galaxyproject/galaxy/issues/20483, remove when fixed)
   # celery and flower
   - redis


### PR DESCRIPTION
Install `ipython` to the Galaxy virtual environment to help debug the behavior of Galaxy (e.g. containers resolvers).