### PR TITLE
Quickfix: Change default container to python:3

### DIFF
--- a/files/galaxy/tpv/destinations.yml.j2
+++ b/files/galaxy/tpv/destinations.yml.j2
@@ -448,7 +448,7 @@ destinations:
         {{ dnb.5.path }}/galaxy_import/galaxy_user_data/:{{ dnb.5.docker_perm }},
         {{ dnb.db.path }}/:{{ dnb.db.docker_perm }},
         {{ tools.tools.path }}/:{{ tools.tools.docker_perm }}"
-      singularity_default_container_id: "{{ cvmfs.singularity.path }}/all/centos:8.3.2011"
+      singularity_default_container_id: "{{ cvmfs.singularity.path }}/all/python:3"
       #
       # Docker config
       #


### PR DESCRIPTION
We'll probably merge #1904 soon, so this is more a quickfix
The tool I was testing this for was `toolshed.g2.bx.psu.edu/repos/bgruening/column_arrange_by_header/bg_column_arrange_by_header/0.2` which is *not* an expression tool, but has `<command interpreter="python">` as the only "requirement".
I don't think centos:8 ever helped here(?)
If it would run there the required `resolve_dependencies=true` for tools that specify requirements would be missing.