### PR TITLE
run remuRNA:1.0.0 as legacy tool

### DIFF
--- a/files/galaxy/tpv/conda_in_container.yml
+++ b/files/galaxy/tpv/conda_in_container.yml
@@ -17,6 +17,9 @@ tools:
   gbk_to_orf:
     inherits: _conda_in_container
 
+  toolshed.g2.bx.psu.edu/repos/rnateam/remurna/remurna/1.0.0:
+    inherits: _conda_in_container
+
   toolshed.g2.bx.psu.edu/repos/iuc/vardict_java/vardict_java/.*:
     inherits: _conda_in_container
 


### PR DESCRIPTION
The default container does not have python but it is required https://github.com/usegalaxy-eu/infrastructure-playbook/issues/1907

I guess one should add python to the tool wrapper as dependency and rebuild the container to fix this properly?
~~~
    <requirements>
        <requirement type="package" version="1.0">
            remurna
        </requirement>
    </requirements>
~~~