### PR TITLE
Replace `condor_container` with `condor_container_magic`

### DIFF
--- a/files/galaxy/tpv/destinations.yml.j2
+++ b/files/galaxy/tpv/destinations.yml.j2
@@ -169,6 +169,9 @@ destinations:
       singularity_volumes: "{{ pulsar_base_volumes() }}"
       singularity_enabled: true
       singularity_default_container_id: "{{ cvmfs.singularity.path }}/all/centos:8.3.2011"
+      container_resolvers:
+        - type: explicit
+        - type: mulled_singularity
     scheduling:
       accept:
         - pulsar
@@ -427,7 +430,7 @@ destinations:
   #############################
 
 
-  condor_container_magic:
+  condor_container:
     runner: condor
     max_accepted_cores: 64
     max_accepted_mem: 1000
@@ -464,23 +467,6 @@ destinations:
         {{ cvmfs.data.path }}:{{ cvmfs.data.docker_perm }}"
 
       # let's move our config to destinations and forget about the global YAML file
-      container_resolvers:
-        ## use Docker if <container type="docker"> and use Singularity if <container type="singularity">
-        - type: explicit
-
-        ## it is so nice, they do it twice, with different dirs
-        - type: cached_mulled_singularity
-          cache_directory: /cvmfs/singularity.galaxyproject.org/all/
-          cache_directory_cacher_type: dir_mtime
-        - type: cached_mulled_singularity
-          cache_directory: {{ cache.cache08.path }}/container_cache/singularity/mulled/
-          cache_directory_cacher_type: dir_mtime
-
-        ## this will create a container, the "auto_install: false" will ensure that the function returns a `path` to a sif file and NOT a docker://quay.io/ URL (as with auto_install: true)
-        - type: mulled_singularity
-          cache_directory: {{ cache.cache08.path }}/container_cache/singularity/mulled/
-          auto_install: false
-
       # If no resolver finds a container, this base container will be taken and resolve_dependencies=true will force conda deps usage
       ## "container" is a fallback, when no resolver is working - in contrast "container_override" is forcing to come before the any resolver
       container:
@@ -491,62 +477,10 @@ destinations:
           # Most times this fallback is needed for very old tools
           # Centos 7 has libncurses.so.5.9 and python 2.7
           identifier: "/cvmfs/main.galaxyproject.org/singularity/usegalaxy.org-legacy-environment--0"
-
-      scheduling:
-        require:
-          - foo_test_me
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-  condor_container:
-    runner: condor
-    max_accepted_cores: 64
-    max_accepted_mem: 1000
-    min_accepted_gpus: 0
-    max_accepted_gpus: 0
-    params:
-      require_container: true
-      #
-      # singularity config
-      #
-      singularity_enabled: true
-      singularity_volumes: "$_CONDOR_SCRATCH_DIR:rw,
-        $job_directory:rw,
-        $tool_directory:ro,
-        $job_directory/outputs:rw,
-        $working_directory:rw,
-        $_GALAXY_JOB_TMP_DIR:/tmp:rw,
-        {{ galaxy_volumes(exclude_volumes=['db', 'dnb04', 'dnb-ds01', '5']) }}
-        {{ dnb.5.path }}/galaxy_import/galaxy_user_data/:{{ dnb.5.docker_perm }},
-        {{ dnb.db.path }}/:{{ dnb.db.docker_perm }},
-        {{ tools.tools.path }}/:{{ tools.tools.docker_perm }}"
-      singularity_default_container_id: "{{ cvmfs.singularity.path }}/all/python:3"
-      #
-      # Docker config
-      #
-      docker_enabled: true
-      docker_set_user: ""
-      docker_volumes: "$_CONDOR_SCRATCH_DIR:rw,
-        $defaults,
-        {{ galaxy_volumes(exclude_volumes=['dnb04', 'dnb-ds01']) }}
-        {{ cvmfs.data.path }}:{{ cvmfs.data.docker_perm }}"
-      scheduling:
-        accept:
-          - docker
-          - singularity
+    scheduling:
+      accept:
+        - docker
+        - singularity
 
   condor_singularity_with_conda:
     inherits: basic_singularity_destination

--- a/templates/galaxy/config/container_resolvers_conf.yml.j2
+++ b/templates/galaxy/config/container_resolvers_conf.yml.j2
@@ -1,25 +1,18 @@
 ---
-# Config Sample file: https://github.com/galaxyproject/galaxy/blob/dev/lib/galaxy/config/sample/container_resolvers.yml.sample
+# WARNING: Job destinations may override this configuration.
 
+# use Docker if <container type="docker"> and use Singularity if <container type="singularity">
 - type: explicit
 
-# Pull singularity image from cvac - CVMFS
-- type: cached_explicit_singularity
-  cache_directory: {{ cache.cache08.path }}/container_cache/singularity/explicit/
-  cache_directory_cacher_type: dir_mtime
-
+# it is so nice, they do it twice, with different dirs
 - type: cached_mulled_singularity
   cache_directory: /cvmfs/singularity.galaxyproject.org/all/
   cache_directory_cacher_type: dir_mtime
+- type: cached_mulled_singularity
+  cache_directory: {{ cache.cache08.path }}/container_cache/singularity/mulled/
+  cache_directory_cacher_type: dir_mtime
 
-#- type: mulled_singularity
-#  # kicks in when the mulled image is not available on CVMFS
-#  cache_directory: {{ cache.cache08.path }}/container_cache/singularity/mulled/
-#  cache_directory_cacher_type: dir_mtime
-#  auto_install: true
-
-- type: cached_mulled
-  # only kicks in if `singularity_enabled: false`
-
-- type: mulled
-  # only kicks in if `singularity_enabled: false`
+# this will create a container, the "auto_install: false" will ensure that the function returns a `path` to a sif file and NOT a docker://quay.io/ URL (as with auto_install: true)
+- type: mulled_singularity
+  cache_directory: {{ cache.cache08.path }}/container_cache/singularity/mulled/
+  auto_install: true


### PR DESCRIPTION
Make the changes from https://github.com/usegalaxy-eu/infrastructure-playbook/pull/1904 (commits 7d4c59b, c7a3080, e0847c6) permanent.

In addition, define a basic list of `container_resolvers` for Pulsar destinations to make sure that:
  - Containers do not break for Pulsar destinations when we make changes to our own configuration.
  - They are not left empty-handed without any resolver if they have not defined their own configuration.

Closes https://github.com/usegalaxy-eu/issues/issues/921.
