### PR TITLE
Fix regex typo for medaka_consensus_pipeline 2.1.1 in conda_in_container.yml

### DIFF
--- a/files/galaxy/tpv/conda_in_container.yml
+++ b/files/galaxy/tpv/conda_in_container.yml
@@ -14,7 +14,7 @@ tools:
         - conda
         - singularity
 
-  toolshed.g2.bx.psu.edu/repos/iuc/medaka_consensus_pipeline/medaka_consensus_pipeline/2.1.1+galaxy0:
+  toolshed.g2.bx.psu.edu/repos/iuc/medaka_consensus_pipeline/medaka_consensus_pipeline/2.1.1\+galaxy0:
     # /cvmfs/singularity.galaxyproject.org/all/mulled-v2-1d9673528d7dd295349af77d8ecfaad41467ae6d:1ca2f7a3a82b59c664168f0ac84876075ccf17e5-0 seems problematic.
     # Most helpful error message is "import libmedaka ModuleNotFoundError: No module named '_cffi_backend'"
     # for now:


### PR DESCRIPTION
The tool identifiers in TPV config files are read as regexes, the `+` sign breaks the match.