### PR TITLE
fixing ci with a default value for tool attributes

### DIFF
--- a/files/galaxy/tpv/tool_defaults.yml.j2
+++ b/files/galaxy/tpv/tool_defaults.yml.j2
@@ -98,7 +98,7 @@ tools:
         execute: |
           entity.params['requirements'] = '(GalaxyGroup == "compute")'
       - id: remote_resources
-        if: user is not None and not (tool.tool_type in  ["expression", "data_source"] or tool.requires_galaxy_python_environment)
+        if: user is not None and not (getattr(tool, 'tool_type', None) in ["expression", "data_source"] or getattr(tool, 'requires_galaxy_python_environment', False))
         execute: |
           from tpv.core.entities import SchedulingTags, Tag, TagType
 


### PR DESCRIPTION
If we default the attributes of tool to a default value when it not exists should fix the tpv dry-run... Testing