### PR TITLE
add missing environment variables to singularity

### DIFF
--- a/roles/usegalaxy-eu.bashrc/tasks/bashrc_tasks.yml
+++ b/roles/usegalaxy-eu.bashrc/tasks/bashrc_tasks.yml
@@ -143,6 +143,9 @@
         - "export GALAXY_ROOT={{ bashrc_galaxy_root }}"
         - "export VIRTUAL_ENV={{ bashrc_galaxy_venv_dir }}"
         - "export GALAXY_PULSAR_APP_CONF={{ bashrc_galaxy_pulsar_app_conf }}"
+        - "export SINGULARITY_CACHEDIR=/scratch/singularity/"
+        - "export APPTAINER_CACHEDIR=/scratch/singularity/"
+
       loop_control:
         loop_var: task_item
 


### PR DESCRIPTION
ref:  https://github.com/usegalaxy-eu/issues/issues/924

This adds defines `SINGULARITY_CACHEDIR` and `APPTAINER_CACHEDIR` to `/scratch/singularity/`.
I manually created the directory in all hosts and and changed the permissions to `galaxy` (to test).

Interestingly enough, the last file seen in the cache was in `2026-02-19 07:45:49` witch matches the first time we tried the `cached_explicit_singularity` and `mulled_singularity` with `cache_dir` in [this](https://github.com/usegalaxy-eu/infrastructure-playbook/pull/1892/changes) PR.

We can also see the changes where deployed in the `2026-02-19 07:45:49` + 1h: https://build.galaxyproject.eu/job/usegalaxy-eu/job/playbooks/job/sn09/326/

xref: https://github.com/usegalaxy-eu/vgcn-infrastructure-playbook/pull/66