### PR TITLE
racon - special case

### DIFF
--- a/files/galaxy/tpv/conda_in_container.yml
+++ b/files/galaxy/tpv/conda_in_container.yml
@@ -14,6 +14,11 @@ tools:
         - conda
         - singularity
 
+  toolshed.g2.bx.psu.edu/repos/bgruening/racon/racon/.*:
+    # Failed to find container when required, contact an admin.
+    # This tool is one of the rare exceptions that have GPU <requirement> annotations. Is this working with TPV?
+    inherits: _conda_in_container
+
   toolshed.g2.bx.psu.edu/repos/iuc/medaka_consensus_pipeline/medaka_consensus_pipeline/2.1.1\+galaxy0:
     # /cvmfs/singularity.galaxyproject.org/all/mulled-v2-1d9673528d7dd295349af77d8ecfaad41467ae6d:1ca2f7a3a82b59c664168f0ac84876075ccf17e5-0 seems problematic.
     # Most helpful error message is "import libmedaka ModuleNotFoundError: No module named '_cffi_backend'"


### PR DESCRIPTION
This tool is scheduled in a GPU location, but we do not annotate this.

However the requirement section looks like:

```
    <requirements>
        <requirement type="package" version="1.5.0">
            racon
        </requirement>
        <resource type="cuda_version_min">
            9.0
        </resource>
        <resource type="cuda_compute_capability">
            3.0
        </resource>
        <resource type="cuda_device_count_min">
            1
        </resource>
        <resource type="cuda_device_count_max">
            1
        </resource>
    </requirements>
```

Some magic TPV or Galaxy is doing?
In the end it fails to find any container. Bot Docker/Sing and Conda exist. Strange.

