### PR TITLE
patch galaxy-volumes macro

### DIFF
--- a/files/galaxy/tpv/destinations.yml.j2
+++ b/files/galaxy/tpv/destinations.yml.j2
@@ -5,9 +5,8 @@
             {%- if vol.name not in exclude_volumes %}
                 {%- if 'db' in vol.name %}
         {{ vol.path }}/databases/:{{ vol.docker_perm }},
-                {%- else %}
-        {{ vol.path }}/galaxy_db/:{{ vol.docker_perm }},
                 {%- endif %}
+        {{ vol.path }}/galaxy_db/:{{ vol.docker_perm }},
             {%- endif %}
         {%- endfor %}
         {%- for vol in cache.values() %}


### PR DESCRIPTION
closes https://github.com/usegalaxy-eu/issues/issues/926

 changes `dnb.db` mount-point path name. See [comment](https://github.com/usegalaxy-eu/issues/issues/926#issuecomment-3974208918). 