### PR TITLE
temporary patch for canu

### DIFF
--- a/files/galaxy/tpv/conda_in_container.yml
+++ b/files/galaxy/tpv/conda_in_container.yml
@@ -16,7 +16,7 @@ tools:
 
 
   # Quick fix for the last bug fix/ tool doens't finish running
-  toolshed.g2.bx.psu.edu/repos/bgruening/canu/canu/.*:
+  toolshed.g2.bx.psu.edu/repos/bgruening/canu/canu/2.3\+galaxy0:
     inherits: _conda_in_container
 
   toolshed.g2.bx.psu.edu/repos/iuc/medaka_consensus_pipeline/medaka_consensus_pipeline/2.1.1\+galaxy0:


### PR DESCRIPTION
This temporary fixes a problem with the tool where it doesn't terminate. 