### PR TITLE
Consolidate GPU destinations

### DIFF
--- a/files/galaxy/tpv/destinations.yml.j2
+++ b/files/galaxy/tpv/destinations.yml.j2
@@ -522,10 +522,13 @@ destinations:
     inherits: condor_container_gpu
     max_accepted_gpus: 1
     params:
+      singularity_enabled: false  # sharing GPUs has not been tested with Singularity
       requirements: 'GalaxyGroup == "pxe-gpu-div4"'
     scheduling:
       require:
         - gpu-divided
+      reject:
+        - singularity  # sharing GPUs has not been tested with Singularity
 
   condor_singularity_with_conda:
     inherits: basic_singularity_destination


### PR DESCRIPTION
Replace `condor_docker_gpu_pxe` and `condor_singularity_gpu_pxe` with a single containerized GPU destination `condor_container_gpu` that inherits from `condor_container`.

In addition, make `condor_docker_gpu_pxe_divide4` inherit from `condor_container`.

Simplifies the TPV configuration for GPU jobs (and fixes problems with a few edge cases), closing https://github.com/usegalaxy-eu/issues/issues/928.