### PR TITLE
Remove fbqs_integrator from conda-in-container tools

### DIFF
--- a/files/galaxy/tpv/conda_in_container.yml
+++ b/files/galaxy/tpv/conda_in_container.yml
@@ -25,9 +25,6 @@ tools:
     # for now:
     inherits: _conda_in_container
 
-  toolshed.g2.bx.psu.edu/repos/maciek/fbqs_integrator/fbqs_integrator/.*:
-    inherits: _conda_in_container
-
   gbk_to_orf:
     inherits: _conda_in_container
 


### PR DESCRIPTION
We now have mulled-v2-8721813441724028886a198e2be57f4003d00413:81d74931d72be7e2feff4793856549df9c8fa891-0 to use instead so the temporary fix should no longer be necessary.