### PR TITLE
Mount /data/db/data_managers/ in docker containers for Parabricks

### DIFF
--- a/files/galaxy/tpv/destinations.yml.j2
+++ b/files/galaxy/tpv/destinations.yml.j2
@@ -5,6 +5,7 @@
             {%- if vol.name not in exclude_volumes %}
                 {%- if 'db' in vol.name %}
         {{ vol.path }}/databases/:{{ vol.docker_perm }},
+        {{ vol.path }}/data_managers/:{{ vol.docker_perm }},
                 {%- endif %}
         {{ vol.path }}/galaxy_db/:{{ vol.docker_perm }},
             {%- endif %}


### PR DESCRIPTION
This fixes an issue where Parabricks fq2bam tool fails because
`/data/db/data_managers/` is not mounted in Docker containers.

Similar to #1928 which added `/databases/` mount, this adds
`/data_managers/` mount needed by Parabricks fq2bam tool.

The fix follows the same pattern as #1928: for any dnb volume whose name contains 'db' (like `dnb.db` which has path `/data/db/`), the `/data/db/data_managers/` directory will be mounted at `/data/db/data_managers/:ro` in Docker containers.

EDIT: This was an AI demo for @mira-miracoli (just in case it looks strange).