### PR TITLE
Run Helixer as Galaxy user

### DIFF
--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -752,3 +752,7 @@ tools:
     scheduling:
       require:
         - singularity  # can be removed after closing https://github.com/usegalaxy-eu/issues/issues/928
+
+  toolshed.g2.bx.psu.edu/repos/genouest/helixer/helixer/.*:
+    params:
+      docker_run_extra_arguments: --user 999


### PR DESCRIPTION
Pass `--user 999` to `docker run` to fix the following error.

```python
Traceback (most recent call last):
  File "/usr/local/bin/fetch_helixer_models.py", line 32, in <module>
    main(args.lineage, best_only=not args.all)
  File "/usr/local/bin/fetch_helixer_models.py", line 21, in main
    fetch_and_organize_models(models)
  File "/usr/local/lib/python3.8/dist-packages/helixer/core/data.py", line 22, in fetch_and_organize_models
    os.makedirs(model_path)
  File "/usr/lib/python3.8/os.py", line 213, in makedirs
    makedirs(head, exist_ok=exist_ok)
  File "/usr/lib/python3.8/os.py", line 213, in makedirs
    makedirs(head, exist_ok=exist_ok)
  File "/usr/lib/python3.8/os.py", line 213, in makedirs
    makedirs(head, exist_ok=exist_ok)
  File "/usr/lib/python3.8/os.py", line 223, in makedirs
    mkdir(name, mode)
PermissionError: [Errno 13] Permission denied: '/data/jwd**/main/***/***/********/home/.local'
```

Closes https://github.com/usegalaxy-eu/issues/issues/931.