### PR TITLE
Avoid /var/tmp for persistent files

### DIFF
--- a/roles/denbi.osiris/defaults/main.yml
+++ b/roles/denbi.osiris/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-backup_restore_base_dir: /var/tmp/backup/osiris
+backup_restore_base_dir: /var/backup/osiris
 backup_restore_dir: "{{ backup_restore_base_dir }}/denbi_dump"
 
 cron_bin_dir: /root/bin


### PR DESCRIPTION
Newer versions of systemd use systemd-tmpfiles-clean.service to delete files from /var/tmp every 30 days.

```
% cat /etc/tmpfiles.d/tmp.conf
(...)
q /var/tmp 1777 root root 30d
```

This explains why our backup semaphore file was vanishing after some time.