### PR TITLE
Update tools.yml to add Sam3 with GPU

### DIFF
--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -756,3 +756,8 @@ tools:
   toolshed.g2.bx.psu.edu/repos/genouest/helixer/helixer/.*:
     params:
       docker_run_extra_arguments: --user 999
+
+  toolshed.g2.bx.psu.edu/repos/ecology/sam3_semantic_segmentation/sam3_semantic_segmentation/.*:
+    inherits: basic_docker_tool
+    gpus: 1
+    mem: 20


### PR DESCRIPTION
Adding sam3 tool, it appears to me there is no more wildlife info on tpv (see below what was merged in december or wildlife), is it normal ? ;)

```
  toolshed.g2.bx.psu.edu/repos/ecology/wildlife_megadetector_huggingface/wildlife_megadetector_huggingface/.*:
    inherits: basic_docker_tool
    gpus: 1
    mem: 20
```