### PR TITLE
Remove gops_cluster and _complement from conda-in-container

### DIFF
--- a/files/galaxy/tpv/conda_in_container.yml
+++ b/files/galaxy/tpv/conda_in_container.yml
@@ -169,8 +169,6 @@ tools:
   toolshed.g2.bx.psu.edu/repos/devteam/bwa_wrappers/bwa_wrapper/1.2.3: {inherits: _conda_in_container}
   toolshed.g2.bx.psu.edu/repos/devteam/cd_hit_dup/cd_hit_dup/0.0.1: {inherits: _conda_in_container}
   toolshed.g2.bx.psu.edu/repos/devteam/clustalw/clustalw/0.1: {inherits: _conda_in_container}
-  toolshed.g2.bx.psu.edu/repos/devteam/cluster/gops_cluster_1/1.0.0: {inherits: _conda_in_container}
-  toolshed.g2.bx.psu.edu/repos/devteam/complement/gops_complement_1/1.0.0: {inherits: _conda_in_container}
   toolshed.g2.bx.psu.edu/repos/devteam/concat/gops_concat_1/1.0.1: {inherits: _conda_in_container}
   toolshed.g2.bx.psu.edu/repos/devteam/coverage/gops_coverage_1/1.0.0: {inherits: _conda_in_container}
   toolshed.g2.bx.psu.edu/repos/devteam/cuff[^/]*/cuff[^/]*/0.0.[567]: {inherits: _conda_in_container}


### PR DESCRIPTION
These two exotic tools are currently not executable on .eu, perhaps this helps?