### PR TITLE
Patch 2

### DIFF
--- a/files/galaxy/tpv/interactive_tools.yml
+++ b/files/galaxy/tpv/interactive_tools.yml
@@ -36,10 +36,8 @@ tools:
 
   interactive_tool_anylabeling:
     inherits: interactive_tool
-    cores: 8
+    cores: 4
     mem: 32
-    gpu: 1
-
   interactive_tool_cellpose:
     inherits: interactive_tool
 


### PR DESCRIPTION
When using AnyLabeling, having many points can make the tool slow. Since the tool also uses AI, a GPU is necessary to get better performance. I am not sure if adding more CPU cores or memory has a big impact, but it could still help improve the overall performance.