### PR TITLE
Allow access to celery-cloud-0.galaxyproject.eu

### DIFF
--- a/group_vars/sn11.yml
+++ b/group_vars/sn11.yml
@@ -84,6 +84,7 @@ postgresql_pg_hba_conf:
   - 'host    galaxy          galaxy          10.5.67.188/32          md5'
   - 'host    galaxy          galaxy          10.5.67.216/32          md5'
   - 'host    galaxy          galaxy          10.4.68.198/32          md5'
+  - 'host    galaxy          galaxy          10.5.67.94/32           md5'
   - 'host    galaxy          galaxy          100.118.169.22/32       md5'
   - 'host    galaxy          galaxy-readonly 132.230.223.239/32      md5'
   - 'host    galaxy          galaxy-readonly 10.5.68.237/32          md5'


### PR DESCRIPTION
A new, temporary cloud instance has been created for celery, IP is 10.5.67.94 and it needs access to PG.