### PR TITLE
Override `static_favicon_dir_by_host` setting built by `galaxyproject.galaxy` role

### DIFF
--- a/group_vars/gxconfig.yml
+++ b/group_vars/gxconfig.yml
@@ -1255,6 +1255,13 @@ base_app_main: &BASE_APP_MAIN
   # Path to favicon.ico, not the directory that contains it (the name is
   # a misnomer). Ignored if static_enabled is false.
   static_favicon_dir: static/favicon_eu.ico
+  static_favicon_dir_by_host: >
+    {
+    '{{ galaxy_themes_instance_domain }}': 'static/favicon_eu.ico',
+    {% for subdomain in galaxy_themes_subdomains %}
+    '{{ subdomain.name }}.{{ galaxy_themes_instance_domain }}': '{{ galaxy_themes_static_path }}/static-{{ subdomain.name }}/favicon_eu.ico',
+    {% endfor %}
+    }
 
   # Path to the static scripts directory. Ignored if static_enabled is
   # false.


### PR DESCRIPTION
The Galaxy role `galaxyproject.galaxy` builds values for the setting `static_favicon_dir_by_host` that point to `'{{ galaxy_themes_static_path }}/static-{{ subdomain.name }}'` for each subdomain.

That is by itself wrong, because `static_favicon_dir` is expected to point to the ICO file, not the directory that contains it. Even if that problem was fixed appending "/favicon.ico" to the built values, the configuration values would still not work if the favicon is not located at `'{{ galaxy_themes_static_path }}/static-{{ subdomain.name }}/favicon.ico'`, as it is the case for us.

Therefore, use a loop to define `static_favicon_dir_by_host` so that it points to the right location for each subdomain.

Closes https://github.com/usegalaxy-eu/issues/issues/919.

**EDIT:** ⚠️ Requires https://github.com/usegalaxy-eu/infrastructure-playbook/pull/2003.