### PR TITLE
Make favicon work (globally)

### DIFF
--- a/templates/nginx/galaxy-main.j2
+++ b/templates/nginx/galaxy-main.j2
@@ -289,7 +289,7 @@ server {
     }
 
     location /favicon.ico {
-        alias {{ galaxy_server_dir }}/static/favicon.ico;
+        alias {{ galaxy_server_dir }}/static/favicon_eu.ico;
     }
 
     location /robots.txt {


### PR DESCRIPTION
We need to remove this from nginx if we want Galaxy to serve it. The question is if we want this.