### PR TITLE
ansible validation fixes

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -4,6 +4,7 @@ profile: null # min, basic, moderate,safety, shared, production
 exclude_paths:
   - collections/
   - roles/
+  - files/traefik/rules/template-subdomains.yml
 skip_list:
   - var-naming
 

--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,0 +1,4 @@
+---
+exclude_paths:
+  - collections/
+  - roles/

--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,4 +1,16 @@
 ---
+profile: null # min, basic, moderate,safety, shared, production
+
 exclude_paths:
   - collections/
   - roles/
+skip_list:
+  - var-naming
+
+enable_list:
+  - args
+  - empty-string-compare # opt-in
+  - no-log-password # opt-in
+  - no-same-owner # opt-in
+  - name[prefix] # opt-in
+  - galaxy-version-incorrect # opt-in

--- a/.github/requirements-python-lint.txt
+++ b/.github/requirements-python-lint.txt
@@ -3,4 +3,3 @@ flake8~=6.0
 flake8-docstrings~=1.0
 yamllint~=1.35
 ansible-lint~=24.0
-ansible-core==2.15.9

--- a/.github/requirements-python-lint.txt
+++ b/.github/requirements-python-lint.txt
@@ -2,4 +2,5 @@ isort~=5.0
 flake8~=6.0
 flake8-docstrings~=1.0
 yamllint~=1.35
-ansible-lint~=25.0
+ansible-lint~=24.0
+ansible-core==2.15.9

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,11 +14,6 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
-    env:
-      REQUIREMENTS: |
-        infrastructure-playbook/requirements.txt
-        infrastructure-playbook/.github/requirements-python-lint.txt
-
     steps:
       - name: Check out the codebase.
         uses: actions/checkout@v2
@@ -30,7 +25,9 @@ jobs:
         with:
           python-version: '3.x'
           cache: 'pip'
-          cache-dependency-path: ${{ env.REQUIREMENTS }}
+          cache-dependency-path: |
+            infrastructure-playbook/requirements.txt
+            infrastructure-playbook/.github/requirements-python-lint.txt
 
       - name: Cache Ansible Galaxy content
         uses: actions/cache@v4
@@ -44,7 +41,7 @@ jobs:
 
       - name: Install test dependencies.
         run: |
-          pip3 install $(sed 's/^/-r /' <<< "$REQUIREMENTS")
+          pip3 install -r requirements.txt -r .github/requirements-python-lint.txt
 
       - name: Create fake vault password file.
         run: printf '%s\n' 'fake_password' > .vault_password

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,11 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    env:
+      REQUIREMENTS: |
+        infrastructure-playbook/requirements.txt
+        infrastructure-playbook/.github/requirements-python-lint.txt
+
     steps:
       - name: Check out the codebase.
         uses: actions/checkout@v2
@@ -25,9 +30,7 @@ jobs:
         with:
           python-version: '3.x'
           cache: 'pip'
-          cache-dependency-path: |
-            infrastructure-playbook/requirements.txt
-            infrastructure-playbook/.github/requirements-python-lint.txt
+          cache-dependency-path: ${{ env.REQUIREMENTS }}
 
       - name: Cache Ansible Galaxy content
         uses: actions/cache@v4
@@ -41,11 +44,10 @@ jobs:
 
       - name: Install test dependencies.
         run: |
-          pip3 install -r requirements.txt
-          pip3 install -r .github/requirements-python-lint.txt
+          pip3 install $(sed 's/^/-r /' <<< "$REQUIREMENTS")
 
       - name: Create fake vault password file.
         run: printf '%s\n' 'fake_password' > .vault_password
 
       - name: Validate repository.
-        run: make 
+        run: make validate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,5 +30,8 @@ jobs:
           pip3 install -r requirements.txt
           pip3 install -r .github/requirements-python-lint.txt
 
+      - name: Create fake vault password file.
+        run: printf '%s\n' 'fake_password' > .vault_password
+
       - name: Validate repository.
         run: make validate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,23 @@ jobs:
           path: 'infrastructure-playbook'
 
       - name: Set up Python 3.
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: '3.x'
+          cache: 'pip'
+          cache-dependency-path: |
+            infrastructure-playbook/requirements.txt
+            infrastructure-playbook/.github/requirements-python-lint.txt
+
+      - name: Cache Ansible Galaxy content
+        uses: actions/cache@v4
+        with:
+          path: |
+            infrastructure-playbook/roles
+            infrastructure-playbook/collections
+          key: ${{ runner.os }}-ansible-galaxy-${{ hashFiles('infrastructure-playbook/requirements.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-ansible-galaxy-
 
       - name: Install test dependencies.
         run: |

--- a/.yamllint
+++ b/.yamllint
@@ -2,6 +2,11 @@
 extends: default
 
 ignore: |
+  files/clouds.yaml
+  group_vars/all/ssh-keys_vault.yml
+  group_vars/beacon/vault.yml
+  group_vars/grafana/vault.yml
+  group_vars/htcondor/vault.yml
   roles
   collections
   one-off

--- a/.yamllint
+++ b/.yamllint
@@ -18,8 +18,13 @@ ignore: |
   files/traefik/rules/template*
 
 rules:
+  braces:
+    max-spaces-inside: 1
   line-length: disable
   comments-indentation: disable  # don't bother me with this rule
   comments:
     require-starting-space: false
     min-spaces-from-content: 1
+  octal-values:
+    forbid-implicit-octal: true
+    forbid-explicit-octal: true

--- a/apollo.yml
+++ b/apollo.yml
@@ -22,7 +22,7 @@
     #         Allow access by executing:
     #         # setsebool -P daemons_enable_cluster_mode 1
     - name: Put SELinux in permissive mode, logging actions that would be blocked.
-      selinux:
+      ansible.posix.selinux:
         policy: targeted
         state: permissive
   roles:

--- a/apollo.yml
+++ b/apollo.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: apollo
+- name: Apollo
+  hosts: apollo
   become: true
   vars_files:
     - "secret_group_vars/all.yml"

--- a/apollo.yml
+++ b/apollo.yml
@@ -2,12 +2,17 @@
 - name: Apollo
   hosts: apollo
   become: true
-  vars_files:
-    - "secret_group_vars/all.yml"
-    - "secret_group_vars/apollo.yml"
   vars:
     hostname: apollo.internal.galaxyproject.eu
+    playbook_secret_vars_files:
+      - secret_group_vars/all.yml
+      - secret_group_vars/apollo.yml
   pre_tasks:
+    - name: Load secret variables
+      ansible.builtin.include_vars:
+        file: "{{ item }}"
+      loop: "{{ playbook_secret_vars_files }}"
+      no_log: true
     # Apollo / tomcat need several exceptions currently.
     # setsebool -P tomcat_can_network_connect_db 1
     #

--- a/beacon.yml
+++ b/beacon.yml
@@ -8,8 +8,6 @@
     - group_vars/beacon/vars.yml
     - group_vars/beacon/vault.yml
   vars:
-  collections:
-    - devsec.hardening
   roles:
     - role: usegalaxy_eu.handy.os_setup
       vars:

--- a/beacon.yml
+++ b/beacon.yml
@@ -3,11 +3,18 @@
   become: true
   hosts:
     - beacon
-  vars_files:
-    - secret_group_vars/all.yml
-    - group_vars/beacon/vars.yml
-    - group_vars/beacon/vault.yml
   vars:
+    playbook_secret_vars_files:
+      - secret_group_vars/all.yml
+      - group_vars/beacon/vault.yml
+  vars_files:
+    - group_vars/beacon/vars.yml
+  pre_tasks:
+    - name: Load secret variables
+      ansible.builtin.include_vars:
+        file: "{{ item }}"
+      loop: "{{ playbook_secret_vars_files }}"
+      no_log: true
   roles:
     - role: usegalaxy_eu.handy.os_setup
       vars:

--- a/build.yml
+++ b/build.yml
@@ -21,8 +21,6 @@
       loop:
         - http
         - https
-  collections:
-    - devsec.hardening
   roles:
     - hostname
     - usegalaxy-eu.dynmotd

--- a/build.yml
+++ b/build.yml
@@ -4,10 +4,15 @@
   become: true
   vars:
     hostname: build.galaxyproject.eu
-  vars_files:
-    - "secret_group_vars/jenkins.yml"
-    - "secret_group_vars/all.yml"
+    playbook_secret_vars_files:
+      - secret_group_vars/jenkins.yml
+      - secret_group_vars/all.yml
   pre_tasks:
+    - name: Load secret variables
+      ansible.builtin.include_vars:
+        file: "{{ item }}"
+      loop: "{{ playbook_secret_vars_files }}"
+      no_log: true
     - name: Install Dependencies
       ansible.builtin.package:
         enablerepo: crb

--- a/build.yml
+++ b/build.yml
@@ -44,6 +44,6 @@
     ## END CUSTOM
     - dj-wasabi.telegraf
     - galaxyproject.miniconda
-    - os_hardening
+    - devsec.hardening.os_hardening
     # - nginx_hardening
-    - ssh_hardening
+    - devsec.hardening.ssh_hardening

--- a/build.yml
+++ b/build.yml
@@ -9,7 +9,7 @@
     - "secret_group_vars/all.yml"
   pre_tasks:
     - name: Install Dependencies
-      package:
+      ansible.builtin.package:
         enablerepo: crb
         name: ["policycoreutils-python-utils", "python3-wheel-wheel"]
       become: true

--- a/build.yml
+++ b/build.yml
@@ -13,7 +13,7 @@
         enablerepo: crb
         name: ["policycoreutils-python-utils", "python3-wheel-wheel"]
       become: true
-    - name: permit traffic in default zone for http and https service
+    - name: Permit traffic in default zone for HTTP and HTTPS service
       ansible.posix.firewalld:
         service: "{{ item }}"
         permanent: true

--- a/celery.yml
+++ b/celery.yml
@@ -2,16 +2,22 @@
 - name: Celery cluster
   vars:
     celerycluster_ansible_group: celerycluster
+    playbook_secret_vars_files:
+      - secret_group_vars/all.yml
+      - secret_group_vars/pulsar.yml
   hosts: "{{ celerycluster_ansible_group }}"
   gather_facts: true
   become: true
   become_user: root
   vars_files:
-    - "secret_group_vars/all.yml"
-    - "secret_group_vars/pulsar.yml"
     - mounts/mountpoints.yml
     - mounts/dest/all.yml
   pre_tasks:
+    - name: Load secret variables
+      ansible.builtin.include_vars:
+        file: "{{ item }}"
+      loop: "{{ playbook_secret_vars_files }}"
+      no_log: true
     - name: Select main node for the Celery cluster
       # The main node is the only one that runs Flower and Celery Beat. It is the first host defined in the inventory
       # for Celery Cluster group.

--- a/celery.yml
+++ b/celery.yml
@@ -25,7 +25,7 @@
             celerycluster_is_main_node: "{{ ansible_nodename == celerycluster_main_node }}"
 
         - name: Print main node information
-          debug:
+          ansible.builtin.debug:
             msg: "This host is the main node for the Celery cluster. It will be the only one running Celery Beat and Flower."
           when: celerycluster_is_main_node
 
@@ -46,7 +46,7 @@
         reload: true
 
     - name: Set SELinux to permissive mode
-      selinux:
+      ansible.posix.selinux:
         policy: targeted
         state: permissive
 

--- a/cvmfs.yml
+++ b/cvmfs.yml
@@ -14,7 +14,8 @@
       alternatives:
         name: python
         path: /usr/bin/python3
-    - file:
+    - name: Create /srv symlink to cvmfs data
+      file:
         src: /data/dnb01
         dest: /srv
         owner: root

--- a/cvmfs.yml
+++ b/cvmfs.yml
@@ -16,7 +16,7 @@
       loop: "{{ playbook_secret_vars_files }}"
       no_log: true
     - name: Set default version of Python
-      alternatives:
+      community.general.alternatives:
         name: python
         path: /usr/bin/python3
     - name: Create /srv symlink to cvmfs data

--- a/cvmfs.yml
+++ b/cvmfs.yml
@@ -56,8 +56,8 @@
     - hxr.monitor-cvmfs
     - dj-wasabi.telegraf
     # hardening
-    - os_hardening
-    - ssh_hardening
+    - devsec.hardening.os_hardening
+    - devsec.hardening.ssh_hardening
 
 #
 #    - hostname

--- a/cvmfs.yml
+++ b/cvmfs.yml
@@ -4,11 +4,17 @@
   become: true
   vars:
     hostname: cvmfs1-ufr0.internal.galaxyproject.eu
+    playbook_secret_vars_files:
+      - secret_group_vars/all.yml
   vars_files:
-    - "secret_group_vars/all.yml"
     - mounts/mountpoints.yml
     - mounts/dest/all.yml
   pre_tasks:
+    - name: Load secret variables
+      ansible.builtin.include_vars:
+        file: "{{ item }}"
+      loop: "{{ playbook_secret_vars_files }}"
+      no_log: true
     - name: Set default version of Python
       alternatives:
         name: python

--- a/cvmfs.yml
+++ b/cvmfs.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: cvmfsstratum1servers
+- name: CVMFS stratum1 servers
+  hosts: cvmfsstratum1servers
   become: true
   vars:
     hostname: cvmfs1-ufr0.internal.galaxyproject.eu

--- a/cvmfs.yml
+++ b/cvmfs.yml
@@ -13,7 +13,7 @@
         name: python
         path: /usr/bin/python3
     - name: Create /srv symlink to cvmfs data
-      file:
+      ansible.builtin.file:
         src: /data/dnb01
         dest: /srv
         owner: root
@@ -22,7 +22,7 @@
         force: true
   post_tasks:
     - name: Disable SELinux
-      selinux:
+      ansible.posix.selinux:
         state: disabled
       register:
         selinux_disabled

--- a/cvmfs.yml
+++ b/cvmfs.yml
@@ -7,8 +7,6 @@
     - "secret_group_vars/all.yml"
     - mounts/mountpoints.yml
     - mounts/dest/all.yml
-  collections:
-    - devsec.hardening
   pre_tasks:
     - name: Set default version of Python
       alternatives:

--- a/dnbd3.yml
+++ b/dnbd3.yml
@@ -2,10 +2,16 @@
 - name: DNBD3 Infrastructure
   hosts: dnbd3primary,dnbd3proxy
   become: true
-  vars_files:
-    - secret_group_vars/all.yml
+  vars:
+    playbook_secret_vars_files:
+      - secret_group_vars/all.yml
 
   pre_tasks:
+    - name: Load secret variables
+      ansible.builtin.include_vars:
+        file: "{{ item }}"
+      loop: "{{ playbook_secret_vars_files }}"
+      no_log: true
     - name: Install dependencies
       ansible.builtin.package:
         name:

--- a/dokku.yml
+++ b/dokku.yml
@@ -37,7 +37,7 @@
   pre_tasks:
     # make sure /data exists
     - name: Ensure /data exists
-      file:
+      ansible.builtin.file:
         path: /data
         state: directory
         owner: root
@@ -53,7 +53,7 @@
         opts: defaults
     # Create a symlink in /var/lib/docker to /data/docker
     - name: Create a symlink in /var/lib/docker to /data/docker
-      file:
+      ansible.builtin.file:
         src: /data/docker
         dest: /var/lib/docker
         state: link
@@ -75,51 +75,53 @@
       with_items: "{{ apps }}"
 
     - name: Check if DNAnalyzer postgres exists
-      shell: dokku postgres:exists dnanalyzer
+      ansible.builtin.command: dokku postgres:exists dnanalyzer
       register: pg_exists
       changed_when: false
       ignore_errors: true
 
     - name: Create DNAnalyzer postgres
-      shell: dokku postgres:create dnanalyzer
+      ansible.builtin.command: dokku postgres:create dnanalyzer
+      register: pg_create
       changed_when: pg_exists.rc == 1
       when: pg_exists.rc == 1
 
     - name: Check if DNAnalyzer postgres link exists
-      shell: dokku postgres:exists dnanalyzer
+      ansible.builtin.command: dokku postgres:exists dnanalyzer
       register: pg_link_exists
       changed_when: false
       failed_when: pg_link_exists.rc > 1
 
     - name: Create DNAnalyzer postgres link
-      shell: dokku postgres:link dnanalyzer dnanalyzer
+      ansible.builtin.command: dokku postgres:link dnanalyzer dnanalyzer
       changed_when: "'dnanalyzer' not in pg_link_exists.stdout"
       when: "'dnanalyzer' not in pg_link_exists.stdout"
 
     - name: Check if gtn-slack-bot postgres exists
-      shell: dokku postgres:exists gtn-slack-bot
+      ansible.builtin.command: dokku postgres:exists gtn-slack-bot
       register: pg_exists
       changed_when: false
       ignore_errors: true
 
     - name: Create gtn-slack-bot postgres
-      shell: dokku postgres:create gtn-slack-bot
+      ansible.builtin.command: dokku postgres:create gtn-slack-bot
       changed_when: pg_exists.rc == 1
       when: pg_exists.rc == 1
 
     - name: Check if gtn-slack-bot postgres link exists
-      shell: dokku postgres:exists gtn-slack-bot
+      ansible.builtin.command: dokku postgres:exists gtn-slack-bot
       register: pg_link_exists
       changed_when: false
       failed_when: pg_link_exists.rc > 1
 
     - name: Create gtn-slack-bot postgres link
-      shell: dokku postgres:link gtn-slack-bot gtn-slack-bot
+      ansible.builtin.command: dokku postgres:link gtn-slack-bot gtn-slack-bot
       changed_when: "'gtn-slack-bot' not in pg_link_exists.stdout"
       when: "'gtn-slack-bot' not in pg_link_exists.stdout"
 
     - name: Set LE email
-      command: dokku letsencrypt:set --global email helena.rasche@gmail.com
+      ansible.builtin.command: dokku letsencrypt:set --global email helena.rasche@gmail.com
+      changed_when: true
 
     - name: Setup Certs
       dokku_letsencrypt:

--- a/dokku.yml
+++ b/dokku.yml
@@ -45,7 +45,7 @@
         mode: "0755"
     # Mount /dev/vdb1 to /data
     - name: Mount /dev/vdb1 to /data
-      mount:
+      ansible.posix.mount:
         path: /data
         src: /dev/vdb1
         fstype: xfs

--- a/dokku.yml
+++ b/dokku.yml
@@ -42,7 +42,7 @@
         state: directory
         owner: root
         group: root
-        mode: 0755
+        mode: "0755"
     # Mount /dev/vdb1 to /data
     - name: Mount /dev/vdb1 to /data
       mount:

--- a/files/traefik/rules/apollo-mw.yml
+++ b/files/traefik/rules/apollo-mw.yml
@@ -1,3 +1,4 @@
+---
 http:
   middlewares:
     apollo-mw:

--- a/files/traefik/rules/apollo-router.yml
+++ b/files/traefik/rules/apollo-router.yml
@@ -1,3 +1,4 @@
+---
 http:
   routers:
     apollo-rtr:

--- a/files/traefik/rules/apollo-service.yml
+++ b/files/traefik/rules/apollo-service.yml
@@ -1,3 +1,4 @@
+---
 http:
   serversTransports:
     apollo-transport:

--- a/files/traefik/rules/gdpr-router.yml
+++ b/files/traefik/rules/gdpr-router.yml
@@ -1,3 +1,4 @@
+---
 http:
   routers:
     gdpr-rtr:

--- a/files/traefik/rules/influxdb-router.yml
+++ b/files/traefik/rules/influxdb-router.yml
@@ -1,3 +1,4 @@
+---
 http:
   routers:
     influxdb-rtr:

--- a/files/traefik/rules/influxdb-service.yml
+++ b/files/traefik/rules/influxdb-service.yml
@@ -1,3 +1,4 @@
+---
 http:
   serversTransports:
     influxdb-transport:

--- a/files/traefik/rules/mq-router.yml
+++ b/files/traefik/rules/mq-router.yml
@@ -1,3 +1,4 @@
+---
 tcp:
   routers:
     mq-rtr:

--- a/files/traefik/rules/mq-service.yml
+++ b/files/traefik/rules/mq-service.yml
@@ -1,3 +1,4 @@
+---
 tcp:
   services:
     mq:

--- a/files/traefik/rules/tpv-broker-router.yml
+++ b/files/traefik/rules/tpv-broker-router.yml
@@ -1,3 +1,4 @@
+---
 http:
   routers:
     tpv-broker-rtr:

--- a/files/traefik/rules/tpv-broker-service.yml
+++ b/files/traefik/rules/tpv-broker-service.yml
@@ -1,3 +1,4 @@
+---
 http:
   serversTransports:
     tpv-broker-transport:

--- a/files/traefik/rules/usegalaxy-eu-router.yml
+++ b/files/traefik/rules/usegalaxy-eu-router.yml
@@ -1,3 +1,4 @@
+---
 http:
   routers:
     usegalaxy-eu-rtr:

--- a/files/traefik/rules/usegalaxy-eu-service.yml
+++ b/files/traefik/rules/usegalaxy-eu-service.yml
@@ -1,3 +1,4 @@
+---
 http:
   services:
     usegalaxy-eu:

--- a/files/traefik/rules/usegalaxy-github-service.yml
+++ b/files/traefik/rules/usegalaxy-github-service.yml
@@ -1,3 +1,4 @@
+---
 http:
   services:
     usegalaxy-github:

--- a/grafana.yml
+++ b/grafana.yml
@@ -60,7 +60,7 @@
       become: true
       vars:
         hostname: "{{ grafana_domain }}"
-    - grafana
+    - grafana.grafana.grafana
     - role: pgs
       become: true
 

--- a/grafana.yml
+++ b/grafana.yml
@@ -24,9 +24,6 @@
       ansible.builtin.package:
         name:
           - git
-  collections:
-    - devsec.hardening
-    - grafana.grafana
   roles:
     ## Starting configuration of the operating system
     - role: usegalaxy_eu.firewall

--- a/grafana.yml
+++ b/grafana.yml
@@ -1,9 +1,15 @@
 ---
 - name: Grafana
   hosts: grafana
-  vars_files:
-    - secret_group_vars/all.yml
+  vars:
+    playbook_secret_vars_files:
+      - secret_group_vars/all.yml
   pre_tasks:
+    - name: Load secret variables
+      ansible.builtin.include_vars:
+        file: "{{ item }}"
+      loop: "{{ playbook_secret_vars_files }}"
+      no_log: true
     #- name: Put SELinux in permissive mode, logging actions that would be blocked.
     #  # Putting SELinux in permissive mode should not be necessary. But if
     #  # certs fail, then do it. It is supposed to be properly handled by

--- a/group_vars/all/ssh-keys.yml
+++ b/group_vars/all/ssh-keys.yml
@@ -1,1 +1,2 @@
+---
 ssh_manager_authorized_persons: "{{ ssh_manager_authorized_persons_vault }}"

--- a/group_vars/all/vars.yml
+++ b/group_vars/all/vars.yml
@@ -54,8 +54,8 @@ telegraf_user:
 
 cloud_network_prefix: 10.5.67
 # Certbot defaults
-certbot_auto_renew_hour: "{{ 23 |random(seed=inventory_hostname)  }}"
-certbot_auto_renew_minute: "{{ 59 |random(seed=inventory_hostname)  }}"
+certbot_auto_renew_hour: "{{ 23 | random(seed=inventory_hostname) }}"
+certbot_auto_renew_minute: "{{ 59 | random(seed=inventory_hostname) }}"
 certbot_install_method: virtualenv
 certbot_auto_renew: true
 certbot_auto_renew_user: root

--- a/group_vars/celerycluster.yml
+++ b/group_vars/celerycluster.yml
@@ -23,8 +23,9 @@ galaxy_config_dir: "{{ galaxy_root }}/config"
 galaxy_config_file: "{{ galaxy_config_dir }}/galaxy.yml"
 
 # Autofs
-autofs_service.install: true
-autofs_service.enable: true
+autofs_service:
+  install: true
+  enable: true
 nfs_kernel_tuning: true
 
 autofs_mount_points:

--- a/group_vars/cvmfsstratum1servers.yml
+++ b/group_vars/cvmfsstratum1servers.yml
@@ -7,8 +7,9 @@ autofs_conf_files:
   data:
     - dnb01   -rw,hard,nosuid      ufr-dyn.isi1.public.ads.uni-freiburg.de:/ifs/isi1/ufr/bronze/nfs/denbi/&
 
-autofs_service.install: true
-autofs_service.enable: true
+autofs_service:
+  install: true
+  enable: true
 nfs_kernel_tuning: true
 
 # CVMFS

--- a/group_vars/gxconfig.yml
+++ b/group_vars/gxconfig.yml
@@ -2521,7 +2521,7 @@ base_app_main: &BASE_APP_MAIN
   # which Galaxy processes should schedule workflows.
   # The value of this option will be resolved with respect to
   # <config_dir>.
-  workflow_schedulers_config_file: "{{ galaxy_config_dir  }}/workflow_schedulers_conf.xml"
+  workflow_schedulers_config_file: "{{ galaxy_config_dir }}/workflow_schedulers_conf.xml"
 
   # Workflows launched with URI/URL inputs that are not marked as
   # 'deferred' are "materialized" (or undeferred) by the workflow

--- a/group_vars/incoming.yml
+++ b/group_vars/incoming.yml
@@ -10,8 +10,9 @@ autofs_mount_points:
 #     - jwd     -rw,hard,nosuid      denbi.svm.bwsfs.uni-freiburg.de:/ws01/&
 #     - jwd01   -rw,hard,nosuid       noads1.svm.bwsfs.uni-freiburg.de:/galaxy-mwd01/
 
-autofs_service.install: true
-autofs_service.enable: true
+autofs_service:
+  install: true
+  enable: true
 nfs_kernel_tuning: true
 
 # GALAXY

--- a/group_vars/incoming.yml
+++ b/group_vars/incoming.yml
@@ -30,8 +30,8 @@ galaxy_user:
 server_names:
   - 'ftp.usegalaxy.eu'
   - 'incoming.galaxyproject.eu'
-certbot_auto_renew_hour: "{{ 23 |random(seed=inventory_hostname)  }}"
-certbot_auto_renew_minute: "{{ 59 |random(seed=inventory_hostname)  }}"
+certbot_auto_renew_hour: "{{ 23 | random(seed=inventory_hostname) }}"
+certbot_auto_renew_minute: "{{ 59 | random(seed=inventory_hostname) }}"
 certbot_auth_method: --webroot
 certbot_install_method: virtualenv
 certbot_auto_renew: true

--- a/group_vars/mq.yml
+++ b/group_vars/mq.yml
@@ -18,8 +18,8 @@ certbot_dns_provider: route53
 certbot_auth_method: --standalone
 certbot_auto_renew: true
 certbot_auto_renew_user: root
-certbot_auto_renew_hour: "{{ 23 |random(seed=inventory_hostname)  }}"
-certbot_auto_renew_minute: "{{ 59 |random(seed=inventory_hostname)  }}"
+certbot_auto_renew_hour: "{{ 23 | random(seed=inventory_hostname) }}"
+certbot_auto_renew_minute: "{{ 59 | random(seed=inventory_hostname) }}"
 certbot_domains:
   - "{{ hostname }}"
   - "{{ inventory_hostname }}"

--- a/group_vars/sn09/sn09.yml
+++ b/group_vars/sn09/sn09.yml
@@ -14,8 +14,9 @@ docker_users:
   - galaxy
 
 # Autofs
-autofs_service.install: true
-autofs_service.enable: true
+autofs_service:
+  install: true
+  enable: true
 nfs_kernel_tuning: true
 
 autofs_mount_points:

--- a/group_vars/sn09/sn09.yml
+++ b/group_vars/sn09/sn09.yml
@@ -312,7 +312,7 @@ galaxy_user:
   shell: /bin/bash
 
 # Galaxy configuration files will be written with these permissions (mode argument to Ansible copy/template module)
-galaxy_config_perms: 0644
+galaxy_config_perms: "0644"
 
 galaxy_root: /opt/galaxy
 galaxy_workflow_scheduler_count: '{{ galaxy_systemd_workflow_schedulers }}'

--- a/group_vars/sn11.yml
+++ b/group_vars/sn11.yml
@@ -1,7 +1,8 @@
 ---
 # Autofs
-autofs_service.install: true
-autofs_service.enable: true
+autofs_service:
+  install: true
+  enable: true
 
 autofs_mount_points:
   - data

--- a/host_vars/celery-cloud-0.galaxyproject.eu.yml
+++ b/host_vars/celery-cloud-0.galaxyproject.eu.yml
@@ -1,2 +1,3 @@
+---
 galaxy_systemd_celery_internal_workers: 4
 galaxy_systemd_celery_external_workers: 1

--- a/host_vars/celery-cloud-1.galaxyproject.eu.yml
+++ b/host_vars/celery-cloud-1.galaxyproject.eu.yml
@@ -1,2 +1,3 @@
+---
 galaxy_systemd_celery_internal_workers: 4
 galaxy_systemd_celery_external_workers: 1

--- a/host_vars/celery-cloud-2.galaxyproject.eu.yml
+++ b/host_vars/celery-cloud-2.galaxyproject.eu.yml
@@ -1,2 +1,3 @@
+---
 galaxy_systemd_celery_internal_workers: 4
 galaxy_systemd_celery_external_workers: 1

--- a/htcondor.yml
+++ b/htcondor.yml
@@ -96,18 +96,18 @@
       register: service_facts
   roles:
     - usegalaxy_eu.handy.os_setup
-    - name: usegalaxy-eu.bashrc
+    - role: usegalaxy-eu.bashrc
       when: htcondor_role_submit
-    - name: hxr.postgres-connection
+    - role: hxr.postgres-connection
       when: htcondor_role_submit
-    - name: galaxyproject.gxadmin
+    - role: galaxyproject.gxadmin
       when: htcondor_role_submit
     - grycap.htcondor
-    - name: usegalaxy-eu.htcondor_release
+    - role: usegalaxy-eu.htcondor_release
       when: htcondor_role_submit and inventory_hostname == "sn09.galaxyproject.eu"
-    - name: usegalaxy-eu.fix-stop-ITs
+    - role: usegalaxy-eu.fix-stop-ITs
       when: htcondor_role_submit and inventory_hostname != "maintenance.galaxyproject.eu"
-    - name: usegalaxy-eu.remove-orphan-condor-jobs
+    - role: usegalaxy-eu.remove-orphan-condor-jobs
       when: htcondor_role_submit and inventory_hostname != "maintenance.galaxyproject.eu"
   post_tasks:
     - name: Add /usr/local/bin to Galaxy's PATH in bashrc file. (usegalaxy-eu.fix-stop-ITs)

--- a/htcondor.yml
+++ b/htcondor.yml
@@ -106,7 +106,7 @@
     - name: Add /usr/local/bin to Galaxy's PATH in bashrc file. (usegalaxy-eu.fix-stop-ITs)
       become: true
       when: htcondor_role_submit
-      lineinfile:
+      ansible.builtin.lineinfile:
         path: "{{ galaxy_user.home }}/.bashrc"
         line: 'export PATH="/usr/local/bin:$PATH"'
 

--- a/htcondor.yml
+++ b/htcondor.yml
@@ -11,10 +11,17 @@
         name: condor
         state: reloaded
   vars_files:
-    - secret_group_vars/db-main.yml  # PostgreSQL password (galaxyproject.gxadmin)
     - mounts/dest/all.yml
     - mounts/mountpoints.yml
+  vars:
+    playbook_secret_vars_files:
+      - secret_group_vars/db-main.yml
   pre_tasks:
+    - name: Load secret variables
+      ansible.builtin.include_vars:
+        file: "{{ item }}"
+      loop: "{{ playbook_secret_vars_files }}"
+      no_log: true
     - name: Ensure findutils is installed. (handy.os_setup)
       become: true
       ansible.builtin.package:

--- a/incoming.yml
+++ b/incoming.yml
@@ -9,8 +9,6 @@
     - secret_group_vars/all.yml
     - mounts/mountpoints.yml
     - mounts/dest/all.yml
-  collections:
-    - devsec.hardening
   pre_tasks:
     - name: Set timezone to Europe/Berlin
       community.general.timezone:

--- a/incoming.yml
+++ b/incoming.yml
@@ -72,5 +72,5 @@
     - galaxyproject.proftpd
 
     - dj-wasabi.telegraf
-    - os_hardening
-    - ssh_hardening
+    - devsec.hardening.os_hardening
+    - devsec.hardening.ssh_hardening

--- a/incoming.yml
+++ b/incoming.yml
@@ -14,7 +14,7 @@
       community.general.timezone:
         name: Europe/Berlin
     - name: Install Dependencies
-      package:
+      ansible.builtin.package:
         name: ['postgresql', 'proftpd-utils']
     - name: Configure SELinux
       ansible.posix.seboolean:

--- a/incoming.yml
+++ b/incoming.yml
@@ -5,11 +5,17 @@
   vars:
     hostname: incoming.galaxyproject.eu
     proftpd_modules_config_file: /etc/proftpd/modules.conf
+    playbook_secret_vars_files:
+      - secret_group_vars/all.yml
   vars_files:
-    - secret_group_vars/all.yml
     - mounts/mountpoints.yml
     - mounts/dest/all.yml
   pre_tasks:
+    - name: Load secret variables
+      ansible.builtin.include_vars:
+        file: "{{ item }}"
+      loop: "{{ playbook_secret_vars_files }}"
+      no_log: true
     - name: Set timezone to Europe/Berlin
       community.general.timezone:
         name: Europe/Berlin

--- a/influxdb.yml
+++ b/influxdb.yml
@@ -39,8 +39,6 @@
       ansible.builtin.service:
         name: firewalld
         state: reloaded
-  collections:
-    - devsec.hardening
   roles:
     ## Starting configuration of the operating system
     - geerlingguy.swap

--- a/influxdb.yml
+++ b/influxdb.yml
@@ -1,6 +1,6 @@
 ---
-- hosts: influxdb
-  name: InfluxDB
+- name: InfluxDB
+  hosts: influxdb
   become: true
   vars:
     hostname: influxdb.galaxyproject.eu
@@ -67,5 +67,5 @@
     - usegalaxy_eu.influxdbserver
     - dj-wasabi.telegraf
     # hardening
-    - os_hardening
-    - ssh_hardening
+    - devsec.hardening.os_hardening
+    - devsec.hardening.ssh_hardening

--- a/influxdb.yml
+++ b/influxdb.yml
@@ -4,10 +4,15 @@
   become: true
   vars:
     hostname: influxdb.galaxyproject.eu
-  vars_files:
-    - "secret_group_vars/all.yml"
-    - secret_group_vars/aws.yml # AWS creds
+    playbook_secret_vars_files:
+      - secret_group_vars/all.yml
+      - secret_group_vars/aws.yml
   pre_tasks:
+    - name: Load secret variables
+      ansible.builtin.include_vars:
+        file: "{{ item }}"
+      loop: "{{ playbook_secret_vars_files }}"
+      no_log: true
     - name: Install Dependencies
       become: true
       ansible.builtin.package:

--- a/maintenance.yml
+++ b/maintenance.yml
@@ -165,7 +165,7 @@
     - usegalaxy-eu.fix-ancient-ftp-data
     # - usegalaxy-eu.fix-user-quotas
     - usegalaxy-eu.remove-orphan-condor-jobs
-    - ssh_hardening
+    - devsec.hardening.ssh_hardening
     - usegalaxy-eu.job-radar-stats-influxdb
     - dj-wasabi.telegraf
     # - usegalaxy-eu.fix-stop-ITs

--- a/maintenance.yml
+++ b/maintenance.yml
@@ -8,8 +8,6 @@
     - secret_group_vars/all.yml
     - mounts/dest/all.yml
     - mounts/mountpoints.yml
-  collections:
-    - devsec.hardening
   handlers:
     - name: Restart rsyslog
       service:

--- a/maintenance.yml
+++ b/maintenance.yml
@@ -11,7 +11,7 @@
   collections:
     - devsec.hardening
   handlers:
-    - name: restart rsyslog
+    - name: Restart rsyslog
       service:
         name: rsyslog
         state: restarted
@@ -57,7 +57,7 @@
         - '{{ galaxy_user.name }}'
         - 'telegraf'
 
-    - name: rsyslog configuration
+    - name: Rsyslog configuration
       copy:
         content: |
           # Accept logs on TCP port 514

--- a/maintenance.yml
+++ b/maintenance.yml
@@ -3,9 +3,11 @@
   hosts: maintenance
   become: true
   become_user: root
+  vars:
+    playbook_secret_vars_files:
+      - secret_group_vars/db-main.yml
+      - secret_group_vars/all.yml
   vars_files:
-    - secret_group_vars/db-main.yml
-    - secret_group_vars/all.yml
     - mounts/dest/all.yml
     - mounts/mountpoints.yml
   handlers:
@@ -23,6 +25,11 @@
         minute: "0"
 
   pre_tasks:
+    - name: Load secret variables
+      ansible.builtin.include_vars:
+        file: "{{ item }}"
+      loop: "{{ playbook_secret_vars_files }}"
+      no_log: true
     - name: Install EPEL-release
       ansible.builtin.package:
         name: epel-release

--- a/maintenance.yml
+++ b/maintenance.yml
@@ -10,7 +10,7 @@
     - mounts/mountpoints.yml
   handlers:
     - name: Restart rsyslog
-      service:
+      ansible.builtin.service:
         name: rsyslog
         state: restarted
   tasks:
@@ -28,10 +28,10 @@
         name: epel-release
         state: present
     - name: Set additional local mount point
-      set_fact:
+      ansible.builtin.set_fact:
         autofs_conf_files: "{{ autofs_conf_files | combine({'usrlocal': autofs_conf_files['usrlocal'] + galaxy_mount}) }}"
     - name: Install Dependencies
-      package:
+      ansible.builtin.package:
         name:
           [
             'git',
@@ -47,7 +47,7 @@
       become: true
   post_tasks:
     - name: Append some users to the systemd-journal group
-      user:
+      ansible.builtin.user:
         name: '{{ item }}'
         groups: systemd-journal
         append: true
@@ -56,7 +56,7 @@
         - 'telegraf'
 
     - name: Rsyslog configuration
-      copy:
+      ansible.builtin.copy:
         content: |
           # Accept logs on TCP port 514
           module(load="imtcp")
@@ -119,7 +119,7 @@
         enabled: true
       become: true
     - name: Configure firewalld to open ports
-      firewalld:
+      ansible.posix.firewalld:
         port: "{{ item }}"
         immediate: true
         permanent: true

--- a/maintenance.yml
+++ b/maintenance.yml
@@ -31,7 +31,7 @@
         state: present
     - name: Set additional local mount point
       set_fact:
-        autofs_conf_files: "{{ autofs_conf_files | combine({ 'usrlocal': autofs_conf_files['usrlocal'] + galaxy_mount }) }}"
+        autofs_conf_files: "{{ autofs_conf_files | combine({'usrlocal': autofs_conf_files['usrlocal'] + galaxy_mount}) }}"
     - name: Install Dependencies
       package:
         name:

--- a/maintenance.yml
+++ b/maintenance.yml
@@ -91,6 +91,7 @@
             state: directory
             owner: root
             group: root
+            mode: "0755"
         - name: Ensure OpenStack configuration directory exists.
           become: true
           ansible.builtin.file:
@@ -134,6 +135,7 @@
         regexp: "^export OPENAI_API_KEY_TELEGRAF"
         line: 'export OPENAI_API_KEY_TELEGRAF="{{ openai_api_key_telegraf }}"'
         create: true
+        mode: "0644"
       no_log: true
   roles:
     - usegalaxy-eu.vgcn-monitoring

--- a/mq.yml
+++ b/mq.yml
@@ -6,8 +6,6 @@
     - secret_group_vars/all.yml
     - secret_group_vars/aws.yml # AWS creds
     - secret_group_vars/pulsar.yml     # Pulsar + MQ Connections
-  collections:
-    - devsec.hardening
   pre_tasks:
     #    - name: Set default version of Python
     #      alternatives:

--- a/mq.yml
+++ b/mq.yml
@@ -2,11 +2,17 @@
 - name: MQ
   hosts: mq
   become: true
-  vars_files:
-    - secret_group_vars/all.yml
-    - secret_group_vars/aws.yml # AWS creds
-    - secret_group_vars/pulsar.yml     # Pulsar + MQ Connections
+  vars:
+    playbook_secret_vars_files:
+      - secret_group_vars/all.yml
+      - secret_group_vars/aws.yml
+      - secret_group_vars/pulsar.yml
   pre_tasks:
+    - name: Load secret variables
+      ansible.builtin.include_vars:
+        file: "{{ item }}"
+      loop: "{{ playbook_secret_vars_files }}"
+      no_log: true
     #    - name: Set default version of Python
     #      alternatives:
     #        name: python

--- a/mq.yml
+++ b/mq.yml
@@ -104,5 +104,5 @@
     - geerlingguy.redis
     - dj-wasabi.telegraf
     # hardening
-    - os_hardening
-    - ssh_hardening
+    - devsec.hardening.os_hardening
+    - devsec.hardening.ssh_hardening

--- a/mq.yml
+++ b/mq.yml
@@ -64,21 +64,21 @@
         #        owner: redis
         #        group: redis
         #        state: directory
-        #        mode: 755
+        #        mode: "0755"
     - name: Create redis log dir
       ansible.builtin.file:
         path: /var/log/redis
         owner: redis
         group: redis
         state: directory
-        mode: 755
+        mode: "0755"
     - name: Touches redis
       ansible.builtin.file:
         path: /var/log/redis/redis-server.log
         owner: redis
         group: redis
         state: touch
-        mode: 644
+        mode: "0644"
   roles:
     ## Starting configuration of the operating system
     - role: usegalaxy_eu.handy.os_setup

--- a/one-off/cvmfs-stratum0.yml
+++ b/one-off/cvmfs-stratum0.yml
@@ -12,7 +12,8 @@
   vars_files:
     - "secret_group_vars/all.yml"
   pre_tasks:
-    - authorized_key:
+    - name: Add CVMFS admin SSH key
+      authorized_key:
         user: centos
         state: present
         key: https://github.com/natefoo.keys

--- a/one-off/cvmfs-stratum0.yml
+++ b/one-off/cvmfs-stratum0.yml
@@ -13,7 +13,7 @@
     - "secret_group_vars/all.yml"
   pre_tasks:
     - name: Add CVMFS admin SSH key
-      authorized_key:
+      ansible.posix.authorized_key:
         user: centos
         state: present
         key: https://github.com/natefoo.keys

--- a/one-off/cvmfs-stratum0.yml
+++ b/one-off/cvmfs-stratum0.yml
@@ -10,9 +10,14 @@
     usegalaxy_eu_autofs_mounts:
       - vdb
       - data
-  vars_files:
-    - "secret_group_vars/all.yml"
+    playbook_secret_vars_files:
+      - secret_group_vars/all.yml
   pre_tasks:
+    - name: Load secret variables
+      ansible.builtin.include_vars:
+        file: "{{ item }}"
+      loop: "{{ playbook_secret_vars_files }}"
+      no_log: true
     - name: Add CVMFS admin SSH key
       ansible.posix.authorized_key:
         user: centos

--- a/one-off/cvmfs-stratum0.yml
+++ b/one-off/cvmfs-stratum0.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: cvmfs-stratum0
+- name: CVMFS stratum0
+  hosts: cvmfs-stratum0
   become: true
   vars:
     chrony_port:  # 123

--- a/one-off/denbi-stratum0.yml
+++ b/one-off/denbi-stratum0.yml
@@ -6,9 +6,14 @@
     cvmfs_role: 'stratum0'
     usegalaxy_eu_autofs_mounts:
       - vdb
-  vars_files:
-    - "secret_group_vars/all.yml"
+    playbook_secret_vars_files:
+      - secret_group_vars/all.yml
   pre_tasks:
+    - name: Load secret variables
+      ansible.builtin.include_vars:
+        file: "{{ item }}"
+      loop: "{{ playbook_secret_vars_files }}"
+      no_log: true
     - name: Create /srv symlink to mounted data
       ansible.builtin.file:
         src: /data/vol/

--- a/one-off/denbi-stratum0.yml
+++ b/one-off/denbi-stratum0.yml
@@ -8,7 +8,8 @@
   vars_files:
     - "secret_group_vars/all.yml"
   pre_tasks:
-    - file:
+    - name: Create /srv symlink to mounted data
+      file:
         src: /data/vol/
         dest: /srv
         owner: root

--- a/one-off/denbi-stratum0.yml
+++ b/one-off/denbi-stratum0.yml
@@ -9,7 +9,7 @@
     - "secret_group_vars/all.yml"
   pre_tasks:
     - name: Create /srv symlink to mounted data
-      file:
+      ansible.builtin.file:
         src: /data/vol/
         dest: /srv
         owner: root

--- a/one-off/denbi-stratum0.yml
+++ b/one-off/denbi-stratum0.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: denbistratum0
+- name: Denbi stratum0
+  hosts: denbistratum0
   become: true
   vars:
     cvmfs_role: 'stratum0'

--- a/one-off/hicbrowser.yml
+++ b/one-off/hicbrowser.yml
@@ -2,8 +2,15 @@
 - name: Hicbrowser
   hosts: hicbrowser
   become: true
-  vars_files:
-    - "secret_group_vars/all.yml"
+  vars:
+    playbook_secret_vars_files:
+      - secret_group_vars/all.yml
+  pre_tasks:
+    - name: Load secret variables
+      ansible.builtin.include_vars:
+        file: "{{ item }}"
+      loop: "{{ playbook_secret_vars_files }}"
+      no_log: true
   roles:
     - hxr.admin-tools
     - influxdata.chrony

--- a/one-off/hicbrowser.yml
+++ b/one-off/hicbrowser.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: hicbrowser
+- name: Hicbrowser
+  hosts: hicbrowser
   become: true
   vars_files:
     - "secret_group_vars/all.yml"

--- a/one-off/job-working-dir.yml
+++ b/one-off/job-working-dir.yml
@@ -4,8 +4,14 @@
   become: true
   vars:
     hostname: job-working-dir.internal.galaxyproject.eu
-  vars_files:
-    - "secret_group_vars/all.yml"
+    playbook_secret_vars_files:
+      - secret_group_vars/all.yml
+  pre_tasks:
+    - name: Load secret variables
+      ansible.builtin.include_vars:
+        file: "{{ item }}"
+      loop: "{{ playbook_secret_vars_files }}"
+      no_log: true
   roles:
     - hostname
     - usegalaxy-eu.dynmotd

--- a/one-off/job-working-dir.yml
+++ b/one-off/job-working-dir.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: job-working-dir
+- name: Job working dir
+  hosts: job-working-dir
   become: true
   vars:
     hostname: job-working-dir.internal.galaxyproject.eu

--- a/one-off/org-jenkins-nodes.yml
+++ b/one-off/org-jenkins-nodes.yml
@@ -5,7 +5,7 @@
   gather_facts: false
   pre_tasks:
     - name: Bootsrap Python2 for Ansible
-      raw: bash -c "test -e /usr/bin/python || (apt -qqy update && apt install -qqy python2.7 python)"
+      ansible.builtin.raw: bash -c "test -e /usr/bin/python || (apt -qqy update && apt install -qqy python2.7 python)"
       register: output
       changed_when: output.stdout != ""
 
@@ -17,17 +17,17 @@
     - group_vars/jenkins-org
   pre_tasks:
     - name: Update repos
-      apt:
+      ansible.builtin.apt:
         update_cache: yes
         cache_valid_time: 900
 
     - name: Upgrade packages
-      apt:
+      ansible.builtin.apt:
         upgrade: yes
         autoremove: yes
 
     - name: Upgrade packages
-      apt:
+      ansible.builtin.apt:
         packages:
         - git
         - docker-engine

--- a/one-off/org-jenkins-nodes.yml
+++ b/one-off/org-jenkins-nodes.yml
@@ -28,13 +28,13 @@
 
     - name: Upgrade packages
       ansible.builtin.apt:
-        packages:
-        - git
-        - docker-engine
-        - openjdk-8-jre-headless
-        - build-essential
-        - curl
-        - pandoc
+        name:
+          - git
+          - docker-engine
+          - openjdk-8-jre-headless
+          - build-essential
+          - curl
+          - pandoc
 
   roles:
     - hxr.autofs-format-n-mount

--- a/one-off/ssds1.yml
+++ b/one-off/ssds1.yml
@@ -4,8 +4,14 @@
   become: true
   vars:
     hostname: cvmfs1-ufr1-nfs.galaxyproject.eu
-  vars_files:
-    - "secret_group_vars/all.yml"
+    playbook_secret_vars_files:
+      - secret_group_vars/all.yml
+  pre_tasks:
+    - name: Load secret variables
+      ansible.builtin.include_vars:
+        file: "{{ item }}"
+      loop: "{{ playbook_secret_vars_files }}"
+      no_log: true
   roles:
     - hostname
     - geerlingguy.repo-epel

--- a/osiris.yml
+++ b/osiris.yml
@@ -25,8 +25,6 @@
         # - policycoreutils-python-utils
     - name: "Install system packages needed for installation"
       ansible.builtin.command: "pip install pymongo"
-  collections:
-    - community.mongodb
   roles:
     - hostname
     - geerlingguy.repo-epel

--- a/osiris.yml
+++ b/osiris.yml
@@ -11,10 +11,16 @@
     # Can also be a commit hash so long it is part of a branch
     # osiris_version: "v1.6.2"
     osiris_version: "v1.8.1"
+    playbook_secret_vars_files:
+      - secret_group_vars/osiris.yml
   vars_files:
     - group_vars/osiris.yml
-    - secret_group_vars/osiris.yml
   pre_tasks:
+    - name: Load secret variables
+      ansible.builtin.include_vars:
+        file: "{{ item }}"
+      loop: "{{ playbook_secret_vars_files }}"
+      no_log: true
     - name: "Install system packages needed for installation"
       ansible.builtin.dnf:
         name: "{{ item }}"

--- a/osiris.yml
+++ b/osiris.yml
@@ -24,7 +24,8 @@
         # We need these for SELinux but they are installed by mongodb_selinux
         # - policycoreutils-python-utils
     - name: "Install system packages needed for installation"
-      ansible.builtin.command: "pip install pymongo"
+      ansible.builtin.pip:
+        name: pymongo
   roles:
     - hostname
     - geerlingguy.repo-epel

--- a/plausible.yml
+++ b/plausible.yml
@@ -7,8 +7,6 @@
   vars_files:
     - secret_group_vars/all.yml
     - secret_group_vars/plausible.yml
-  collections:
-    - devsec.hardening
   roles:
     - hostname
     - usegalaxy-eu.dynmotd

--- a/plausible.yml
+++ b/plausible.yml
@@ -4,9 +4,15 @@
   become: true
   vars:
     hostname: plausible.galaxyproject.eu
-  vars_files:
-    - secret_group_vars/all.yml
-    - secret_group_vars/plausible.yml
+    playbook_secret_vars_files:
+      - secret_group_vars/all.yml
+      - secret_group_vars/plausible.yml
+  pre_tasks:
+    - name: Load secret variables
+      ansible.builtin.include_vars:
+        file: "{{ item }}"
+      loop: "{{ playbook_secret_vars_files }}"
+      no_log: true
   roles:
     - hostname
     - usegalaxy-eu.dynmotd

--- a/proxy.yml
+++ b/proxy.yml
@@ -6,8 +6,6 @@
     hostname: proxy.galaxyproject.eu
   vars_files:
     - secret_group_vars/all.yml
-  collections:
-    - devsec.hardening
   pre_tasks:
     - name: Set default version of Python
       alternatives:

--- a/proxy.yml
+++ b/proxy.yml
@@ -31,5 +31,5 @@
     - galaxyproject.nginx
     - dj-wasabi.telegraf
     # hardening
-    - os_hardening
-    - ssh_hardening
+    - devsec.hardening.os_hardening
+    - devsec.hardening.ssh_hardening

--- a/proxy.yml
+++ b/proxy.yml
@@ -13,7 +13,7 @@
       loop: "{{ playbook_secret_vars_files }}"
       no_log: true
     - name: Set default version of Python
-      alternatives:
+      community.general.alternatives:
         name: python
         path: /usr/bin/python3
   roles:

--- a/proxy.yml
+++ b/proxy.yml
@@ -4,9 +4,14 @@
   become: true
   vars:
     hostname: proxy.galaxyproject.eu
-  vars_files:
-    - secret_group_vars/all.yml
+    playbook_secret_vars_files:
+      - secret_group_vars/all.yml
   pre_tasks:
+    - name: Load secret variables
+      ansible.builtin.include_vars:
+        file: "{{ item }}"
+      loop: "{{ playbook_secret_vars_files }}"
+      no_log: true
     - name: Set default version of Python
       alternatives:
         name: python

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -51,6 +51,11 @@ collections:
     source: https://galaxy.ansible.com
   - name: community.crypto
     version: 2.26.5
+  ## should be updated
+  - name: devsec.hardening
+    version: 8.7.0
+  - name: devsec.hardening
+    version: 8.7.0
 
 roles:
   - name: dev-sec.os-hardening
@@ -181,6 +186,8 @@ roles:
     version: 1.1.0
   - name: geerlingguy.php
     version: 6.0.0
+  - name: geerlingguy.nfs
+    version: 2.1.1
   - name: usegalaxy_eu.ssh_manager
     version: 0.0.2
   - name: l3d.restic

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -54,8 +54,6 @@ collections:
   ## should be updated
   - name: devsec.hardening
     version: 8.7.0
-  - name: devsec.hardening
-    version: 8.7.0
 
 roles:
   - name: dev-sec.os-hardening

--- a/resign-keys.yml
+++ b/resign-keys.yml
@@ -1,5 +1,5 @@
 ---
-- name: resign all ssh keys
+- name: Resign all SSH keys
   hosts: all
   become: true
   roles:

--- a/roles/devops.tomcat7/handlers/main.yml
+++ b/roles/devops.tomcat7/handlers/main.yml
@@ -2,4 +2,6 @@
 # handlers file for ansible-role-tomcat7
 
 - name: restart tomcat
-  service: name=tomcat state=restarted
+  ansible.builtin.service:
+    name: tomcat
+    state: restarted

--- a/roles/devops.tomcat7/tasks/configure.yml
+++ b/roles/devops.tomcat7/tasks/configure.yml
@@ -2,7 +2,7 @@
 # tasks for tomcat 7 Configure
 
 - name: Copy tomcat server.xml.
-  template:
+  ansible.builtin.template:
     src: server.xml.j2
     dest: "{{ tomcat7_conf_dir }}/server.xml"
     owner: root
@@ -12,7 +12,7 @@
   notify: restart tomcat
 
 - name: Copy tomcat tomcat-users.xml.
-  template:
+  ansible.builtin.template:
     src: tomcat-users.xml.j2
     dest: "{{ tomcat7_conf_dir }}/tomcat-users.xml"
     owner: root

--- a/roles/galaxyprojectdotorg.proftpd/tasks/galaxy_auth.yml
+++ b/roles/galaxyprojectdotorg.proftpd/tasks/galaxy_auth.yml
@@ -48,7 +48,7 @@
   when: galaxy_user_gid is undefined
 
 - name: Configure Galaxy authentication options
-  template:
+  ansible.builtin.template:
     src: galaxy_auth.conf.j2
     dest: "{{ proftpd_config_include_dir }}/10_galaxy_auth.conf"
   notify:

--- a/roles/galaxyprojectdotorg.proftpd/tasks/main.yml
+++ b/roles/galaxyprojectdotorg.proftpd/tasks/main.yml
@@ -31,7 +31,7 @@
     - reload proftpd
 
 - name: Create base proftpd.conf options in include
-  template:
+  ansible.builtin.template:
     src: server.conf.j2
     dest: "{{ proftpd_config_include_dir }}/00_server.conf"
     backup: yes
@@ -59,7 +59,7 @@
   when: proftpd_display_connect is defined
 
 - name: Create global config options in include
-  template:
+  ansible.builtin.template:
     src: global.conf.j2
     dest: "{{ proftpd_config_include_dir }}/03_global.conf"
     backup: yes
@@ -76,7 +76,7 @@
   when: proftpd_galaxy_auth is defined
 
 - name: Create VirtualHost configurations
-  template:
+  ansible.builtin.template:
     src: virtualhost.conf.j2
     dest: "{{ proftpd_config_include_dir }}/15_virtualhost_{{ item.id }}.conf"
     backup: yes

--- a/roles/galaxyprojectdotorg.proftpd/tasks/tls.yml
+++ b/roles/galaxyprojectdotorg.proftpd/tasks/tls.yml
@@ -2,7 +2,7 @@
 # tasks file for galaxyprojectdotorg.proftpd
 
 - name: Configure TLS options
-  template:
+  ansible.builtin.template:
     src: tls.conf.j2
     dest: "{{ proftpd_config_include_dir }}/05_tls.conf"
     backup: yes

--- a/roles/geerlingguy.haproxy/handlers/main.yml
+++ b/roles/geerlingguy.haproxy/handlers/main.yml
@@ -1,3 +1,5 @@
 ---
 - name: restart haproxy
-  service: name=haproxy state=restarted
+  ansible.builtin.service:
+    name: haproxy
+    state: restarted

--- a/roles/geerlingguy.haproxy/tasks/main.yml
+++ b/roles/geerlingguy.haproxy/tasks/main.yml
@@ -40,7 +40,7 @@
     haproxy_version: "{{ '1.5' if '1.5.' in haproxy_version_result.stdout else '1.4' }}"
 
 - name: Copy HAProxy configuration in place.
-  template:
+  ansible.builtin.template:
     src: haproxy.cfg.j2
     dest: /etc/haproxy/haproxy.cfg
     mode: 0644

--- a/roles/geerlingguy.haproxy/tasks/main.yml
+++ b/roles/geerlingguy.haproxy/tasks/main.yml
@@ -48,4 +48,7 @@
   notify: restart haproxy
 
 - name: Ensure HAProxy is started and enabled on boot.
-  service: name=haproxy state=started enabled=yes
+  ansible.builtin.service:
+    name: haproxy
+    state: started
+    enabled: true

--- a/roles/geerlingguy.nginx/handlers/main.yml
+++ b/roles/geerlingguy.nginx/handlers/main.yml
@@ -1,10 +1,14 @@
 ---
 - name: restart nginx
-  service: name=nginx state=restarted
+  ansible.builtin.service:
+    name: nginx
+    state: restarted
 
 - name: validate nginx configuration
   command: nginx -t -c /etc/nginx/nginx.conf
   changed_when: False
 
 - name: reload nginx
-  service: name=nginx state=reloaded
+  ansible.builtin.service:
+    name: nginx
+    state: reloaded

--- a/roles/geerlingguy.nginx/tasks/main.yml
+++ b/roles/geerlingguy.nginx/tasks/main.yml
@@ -51,4 +51,7 @@
     - reload nginx
 
 - name: Ensure nginx is started and enabled to start at boot.
-  service: name=nginx state=started enabled=yes
+  ansible.builtin.service:
+    name: nginx
+    state: started
+    enabled: true

--- a/roles/geerlingguy.nginx/tasks/main.yml
+++ b/roles/geerlingguy.nginx/tasks/main.yml
@@ -41,7 +41,7 @@
 
 # Nginx setup.
 - name: Copy nginx configuration in place.
-  template:
+  ansible.builtin.template:
     src: "{{ nginx_conf_template }}"
     dest: "{{ nginx_conf_file_path }}"
     owner: root

--- a/roles/geerlingguy.nginx/tasks/setup-RedHat.yml
+++ b/roles/geerlingguy.nginx/tasks/setup-RedHat.yml
@@ -1,6 +1,6 @@
 ---
 - name: Enable nginx repo.
-  template:
+  ansible.builtin.template:
     src: nginx.repo.j2
     dest: /etc/yum.repos.d/nginx.repo
     owner: root

--- a/roles/geerlingguy.nginx/tasks/vhosts.yml
+++ b/roles/geerlingguy.nginx/tasks/vhosts.yml
@@ -13,7 +13,7 @@
   notify: reload nginx
 
 - name: Add managed vhost config files.
-  template:
+  ansible.builtin.template:
     src: "{{ item.template|default(nginx_vhost_template) }}"
     dest: "{{ nginx_vhost_path }}/{{ item.filename|default(item.server_name.split(' ')[0] ~ '.conf') }}"
     force: yes

--- a/roles/hostname/tasks/main.yml
+++ b/roles/hostname/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
 - name: Set system hostname
-  hostname:
+  ansible.builtin.hostname:
     name: "{{ hostname }}"
   #notify: 'Restart Telegraf'

--- a/roles/hostname/tasks/main.yml
+++ b/roles/hostname/tasks/main.yml
@@ -1,4 +1,5 @@
 ---
-- hostname:
+- name: Set system hostname
+  hostname:
     name: "{{ hostname }}"
   #notify: 'Restart Telegraf'

--- a/roles/htcondor/tasks/main.yml
+++ b/roles/htcondor/tasks/main.yml
@@ -64,7 +64,7 @@
   notify: reload condor
 
 - name: Send local config
-  template:
+  ansible.builtin.template:
     src: condor_config.j2
     dest: /etc/condor/condor_config.local
     owner: root

--- a/roles/hxr.api-check/tasks/main.yml
+++ b/roles/hxr.api-check/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: install dependencies
+- name: Install dependencies
   package:
     name: "{{ item }}"
     state: present

--- a/roles/hxr.api-check/tasks/main.yml
+++ b/roles/hxr.api-check/tasks/main.yml
@@ -7,7 +7,7 @@
     - curl
 
 - name: "Install http-api-check script"
-  template:
+  ansible.builtin.template:
     src: http-api-check.sh
     dest: /usr/bin/http-api-check
     owner: root

--- a/roles/hxr.apollo/tasks/main.yml
+++ b/roles/hxr.apollo/tasks/main.yml
@@ -46,7 +46,7 @@
   notify: 'restart tomcat'
 
 - name: Deploy config file
-  template:
+  ansible.builtin.template:
     src: apollo-config.groovy
     dest: "{{ tomcat_apollo_webapp_dir }}/{{ item }}"
     owner: tomcat

--- a/roles/hxr.autofs/tasks/main.yml
+++ b/roles/hxr.autofs/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: autofs package install
+- name: Autofs package install
   package:
     name: autofs
     state: latest
@@ -52,7 +52,7 @@
   when: '"vdb" in usegalaxy_eu_autofs_mounts'
   notify: autofs restart
 
-- name: autofs service enable
+- name: Autofs service enable
   service:
     name: autofs
     enabled: yes

--- a/roles/hxr.autofs/tasks/main.yml
+++ b/roles/hxr.autofs/tasks/main.yml
@@ -5,7 +5,7 @@
     state: latest
 
 - name: Copy main autofs file
-  template:
+  ansible.builtin.template:
     src: data.autofs.j2
     dest: "/etc/auto.master.d/data.autofs"
     owner: root
@@ -14,7 +14,7 @@
   notify: autofs restart
 
 - name: Copy data conf file
-  template:
+  ansible.builtin.template:
     src: "data.conf.j2"
     dest: "/etc/auto.data"
     owner: root
@@ -23,7 +23,7 @@
   notify: autofs restart
 
 - name: Copy discontinued conf file
-  template:
+  ansible.builtin.template:
     src: "discontinued.conf.j2"
     dest: "/etc/auto.discontinued"
     owner: root
@@ -33,7 +33,7 @@
   notify: autofs restart
 
 - name: Copy usrlocal conf file
-  template:
+  ansible.builtin.template:
     src: "usrlocal.conf.j2"
     dest: "/etc/auto.usrlocal"
     owner: root
@@ -43,7 +43,7 @@
   notify: autofs restart
 
 - name: Copy vols conf file
-  template:
+  ansible.builtin.template:
     src: "vols.conf.j2"
     dest: "/etc/auto.vols"
     owner: root

--- a/roles/hxr.dns/tasks/main.yml
+++ b/roles/hxr.dns/tasks/main.yml
@@ -20,7 +20,7 @@
   when: set_dns | default(true)
 
 - name: Template cert refresh command
-  template:
+  ansible.builtin.template:
     src: refresh.sh
     dest: /usr/sbin/cert-refresh
     owner: root

--- a/roles/hxr.docker-ssl-client/tasks/main.yml
+++ b/roles/hxr.docker-ssl-client/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 # Certs
 - name: Create directory
-  file:
+  ansible.builtin.file:
     path: "~/.docker"
     state: directory
     mode: '0750'

--- a/roles/hxr.docker-ssl-client/tasks/main.yml
+++ b/roles/hxr.docker-ssl-client/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 # Certs
-- name: mkdir
+- name: Create directory
   file:
     path: "~/.docker"
     state: directory
@@ -15,4 +15,3 @@
     - ca.pem
     - cert.pem
     - key.pem
-

--- a/roles/hxr.docker-ssl/tasks/main.yml
+++ b/roles/hxr.docker-ssl/tasks/main.yml
@@ -30,7 +30,7 @@
     mode: 0755
 
 - name: Deploy systemd environment override
-  template:
+  ansible.builtin.template:
     src: docker-env.conf
     dest: /etc/systemd/system/docker.service.d/custom.conf
     owner: root

--- a/roles/hxr.galaxy-echo-tool/tasks/main.yml
+++ b/roles/hxr.galaxy-echo-tool/tasks/main.yml
@@ -8,7 +8,7 @@
     mode: 0755
 
 - name: "Template nagios tools"
-  template:
+  ansible.builtin.template:
     src: echo.xml
     dest: "{{ galaxy_tool_dir }}/nagios/{{ item }}.xml"
     owner: "{{ galaxy_user.name }}"
@@ -17,7 +17,7 @@
   with_items: "{{ galaxy_test_user.handlers }}"
 
 - name: "Nagios tool conf"
-  template:
+  ansible.builtin.template:
     src: nagios_tool_conf.xml
     dest: "{{ galaxy_conf_dir }}/nagios_tool_conf.xml"
     owner: "{{ galaxy_user.name }}"

--- a/roles/hxr.grafana-gitter-bridge/tasks/main.yml
+++ b/roles/hxr.grafana-gitter-bridge/tasks/main.yml
@@ -53,7 +53,7 @@
   notify: 'reload ggb'
 
 - name: Send runner script
-  template:
+  ansible.builtin.template:
     src: "run.sh"
     dest: "{{ ggb_dir }}/run.sh"
     owner: "{{ ggb_user }}"
@@ -71,7 +71,7 @@
   notify: 'reload ggb'
 
 - name: Install systemd unit file
-  template:
+  ansible.builtin.template:
     src: ggb.service
     dest: /etc/systemd/system/ggb.service
   notify: setup ggb systemd

--- a/roles/hxr.gx-cookie-proxy/tasks/main.yml
+++ b/roles/hxr.gx-cookie-proxy/tasks/main.yml
@@ -19,7 +19,7 @@
     mode: 0755
 
 - name: Deploy env file
-  template:
+  ansible.builtin.template:
     src: env
     dest: /etc/sysconfig/gx-cookie-proxy
     owner: gxp

--- a/roles/hxr.monitor-cvmfs/tasks/main.yml
+++ b/roles/hxr.monitor-cvmfs/tasks/main.yml
@@ -13,7 +13,8 @@
     mode: 0755
   notify: 'Restart Telegraf'
 
-- set_fact:
+- name: Build CVMFS telegraf plugin config
+  set_fact:
     check_cvmfs_telegraf:
       check_cvmfs_telegraf:
         plugin: exec
@@ -23,5 +24,6 @@
           - data_format = "influx"
           - interval = "5m"
 
-- set_fact:
+- name: Merge CVMFS telegraf plugin config
+  set_fact:
     telegraf_plugins_extra: "{{ telegraf_plugins_extra | combine(check_cvmfs_telegraf) }}"

--- a/roles/hxr.monitor-cvmfs/tasks/main.yml
+++ b/roles/hxr.monitor-cvmfs/tasks/main.yml
@@ -5,7 +5,7 @@
     state: present
 
 - name: Deploy CVMFS data processor
-  template:
+  ansible.builtin.template:
     src: main.sh
     dest: /usr/bin/check_cvmfs_repos
     owner: root

--- a/roles/hxr.monitor-cvmfs/tasks/main.yml
+++ b/roles/hxr.monitor-cvmfs/tasks/main.yml
@@ -14,7 +14,7 @@
   notify: 'Restart Telegraf'
 
 - name: Build CVMFS telegraf plugin config
-  set_fact:
+  ansible.builtin.set_fact:
     check_cvmfs_telegraf:
       check_cvmfs_telegraf:
         plugin: exec

--- a/roles/hxr.monitor-email/tasks/main.yml
+++ b/roles/hxr.monitor-email/tasks/main.yml
@@ -16,7 +16,8 @@
     line: 'telegraf ALL=(ALL) NOPASSWD: /usr/bin/check_mail_counts'
   notify: 'Restart Telegraf'
 
-- set_fact:
+- name: Build mail counter telegraf plugin config
+  set_fact:
     plugin_config:
       email_counter:
         plugin: "exec"
@@ -26,5 +27,6 @@
           - data_format = "influx"
           - interval = "1h"
 
-- set_fact:
+- name: Merge mail counter telegraf plugin config
+  set_fact:
     telegraf_plugins_extra: "{{ telegraf_plugins_extra | combine(plugin_config) }}"

--- a/roles/hxr.monitor-squid/tasks/main.yml
+++ b/roles/hxr.monitor-squid/tasks/main.yml
@@ -22,7 +22,8 @@
     mode: 0755
   notify: 'Restart Telegraf'
 
-- set_fact:
+- name: Build squid telegraf plugin config
+  set_fact:
     check_squid_telegraf:
       check_squid_telegraf:
         plugin: "exec"
@@ -32,5 +33,6 @@
           - data_format = "influx"
           - interval = "5m"
 
-- set_fact:
+- name: Merge squid telegraf plugin config
+  set_fact:
     telegraf_plugins_extra: "{{ telegraf_plugins_extra | combine(check_squid_telegraf) }}"

--- a/roles/hxr.sentry/tasks/main.yml
+++ b/roles/hxr.sentry/tasks/main.yml
@@ -58,7 +58,7 @@
 - name: Template config files
   become: true
   become_user: "{{ hxr_sentry_user }}"
-  template:
+  ansible.builtin.template:
     src: "{{ item }}.j2"
     dest: "{{ hxr_sentry_repodir }}/{{ item }}"
     owner: "{{ hxr_sentry_user }}"

--- a/roles/hxr.sentry/tasks/main.yml
+++ b/roles/hxr.sentry/tasks/main.yml
@@ -11,7 +11,7 @@
     groups: docker
     append: yes
 
-- name: reset ssh connection to allow user changes to affect 'current login user'
+- name: Reset SSH connection to allow user changes to affect 'current login user'
   meta: reset_connection
 
 - name: "Make data dir"

--- a/roles/hxr.simple-nagios/tasks/main.yml
+++ b/roles/hxr.simple-nagios/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: install dependencies
+- name: Install dependencies
   package:
     name: "{{ item }}"
     state: present

--- a/roles/hxr.simple-nagios/tasks/main.yml
+++ b/roles/hxr.simple-nagios/tasks/main.yml
@@ -10,7 +10,7 @@
     - python-pip
 
 - name: "Install credentials for FTP access"
-  template:
+  ansible.builtin.template:
     src: ftp-creds.txt
     dest: /etc/ftp-creds.txt
     owner: telegraf
@@ -18,7 +18,7 @@
     mode: 0640
 
 - name: "Install galaxy API creds"
-  template:
+  ansible.builtin.template:
     src: gx-api-creds.json
     dest: /etc/gx-api-creds.json
     owner: telegraf
@@ -46,7 +46,7 @@
     mode: 0755
 
 - name: "Install simple-nagios-executor script"
-  template:
+  ansible.builtin.template:
     src: simple-nagios.sh
     dest: /usr/bin/simple-nagios
     owner: root

--- a/roles/jasonroyle.rabbitmq/tasks/configure-cluster.yml
+++ b/roles/jasonroyle.rabbitmq/tasks/configure-cluster.yml
@@ -6,7 +6,7 @@
   with_items: "{{ ansible_play_hosts }}"
 
 - name: set erlang cookie
-  template:
+  ansible.builtin.template:
     src: erlang.cookie.j2
     dest: "{{ rabbitmq_erlang_cookie_file }}"
     owner: rabbitmq

--- a/roles/jasonroyle.rabbitmq/tasks/configure.yml
+++ b/roles/jasonroyle.rabbitmq/tasks/configure.yml
@@ -1,6 +1,6 @@
 ---
 - name: configure rabbitmq
-  template:
+  ansible.builtin.template:
     src: rabbitmq.config.j2
     dest: /etc/rabbitmq/rabbitmq.config
   when: rabbitmq_config is defined

--- a/roles/jasonroyle.rabbitmq/templates/config-encoder-macros/site.yaml
+++ b/roles/jasonroyle.rabbitmq/templates/config-encoder-macros/site.yaml
@@ -6,7 +6,7 @@
     - vars/apache_test.yaml
   tasks:
     - name: Create test.apache file
-      template:
+      ansible.builtin.template:
         src: templates/test.apache.j2
         dest: /tmp/test.apache
       tags:
@@ -18,7 +18,7 @@
     - vars/erlang_test.yaml
   tasks:
     - name: Create test.erlang file
-      template:
+      ansible.builtin.template:
         src: templates/test.erlang.j2
         dest: /tmp/test.erlang
       tags:
@@ -30,7 +30,7 @@
     - vars/ini_test.yaml
   tasks:
     - name: Create test.ini file
-      template:
+      ansible.builtin.template:
         src: templates/test.ini.j2
         dest: /tmp/test.ini
       tags:
@@ -42,7 +42,7 @@
     - vars/ini_test.yaml
   tasks:
     - name: Create test.simple file
-      template:
+      ansible.builtin.template:
         src: templates/test.ini_simple.j2
         dest: /tmp/test.ini_simple
       tags:
@@ -54,7 +54,7 @@
     - vars/json_test.yaml
   tasks:
     - name: Create test.json file
-      template:
+      ansible.builtin.template:
         src: templates/test.json.j2
         dest: /tmp/test.json
       tags:
@@ -66,7 +66,7 @@
     - vars/logstash_test.yaml
   tasks:
     - name: Create test.logstash file
-      template:
+      ansible.builtin.template:
         src: templates/test.logstash.j2
         dest: /tmp/test.logstash
       tags:
@@ -78,7 +78,7 @@
     - vars/toml_test.yaml
   tasks:
     - name: Create test.toml file
-      template:
+      ansible.builtin.template:
         src: templates/test.toml.j2
         dest: /tmp/test.toml
       tags:
@@ -90,7 +90,7 @@
     - vars/xml_test.yaml
   tasks:
     - name: Create test.xml file
-      template:
+      ansible.builtin.template:
         src: templates/test.xml.j2
         dest: /tmp/test.xml
       tags:
@@ -102,7 +102,7 @@
     - vars/yaml_test.yaml
   tasks:
     - name: Create test.yaml file
-      template:
+      ansible.builtin.template:
         src: templates/test.yaml.j2
         dest: /tmp/test.yaml
       tags:

--- a/roles/linuxhq.yum_cron/tasks/main.yml
+++ b/roles/linuxhq.yum_cron/tasks/main.yml
@@ -10,7 +10,7 @@
 - name: Attempting to overlay yum-cron configurations
   tags: yum_cron
   become: true
-  template:
+  ansible.builtin.template:
     src: "{{ item.src }}"
     dest: "{{ item.dst }}"
     owner: root

--- a/roles/multinic/tasks/main.yml
+++ b/roles/multinic/tasks/main.yml
@@ -49,7 +49,7 @@
     group: root
     mode: 0644
 
-- template:
+- ansible.builtin.template:
     src: rule-eth1.j2
     dest: /etc/sysconfig/network-scripts/rule-eth1
     owner: root

--- a/roles/pgs/tasks/main.yml
+++ b/roles/pgs/tasks/main.yml
@@ -27,7 +27,7 @@
 - name: "Template runner script"
   become: true
   become_user: centos
-  template:
+  ansible.builtin.template:
     src: script.sh.j2
     dest: "{{ pgs_dir }}/run.sh"
     mode: 0755

--- a/roles/sentry/tasks/main.yml
+++ b/roles/sentry/tasks/main.yml
@@ -2,7 +2,7 @@
   file: path=/opt/sentry/ state=directory
 
 - name: Copy configuration file
-  template:
+  ansible.builtin.template:
     src: config.yml
     dest: /opt/sentry/config.yml
     owner: root
@@ -10,7 +10,7 @@
     mode: 0644
 
 - name: Copy sentry.conf.py file
-  template:
+  ansible.builtin.template:
     src: sentry.conf.py
     dest: /opt/sentry/sentry.conf.py
     owner: root
@@ -18,7 +18,7 @@
     mode: 0644
 
 - name: Copy Dockerfile
-  template:
+  ansible.builtin.template:
     src: Dockerfile
     dest: /opt/sentry/Dockerfile
     owner: root

--- a/roles/usegalaxy-eu.fix-stop-ITs/tasks/main.yml
+++ b/roles/usegalaxy-eu.fix-stop-ITs/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: "Deploy IT stopper script"
-  template:
+  ansible.builtin.template:
     src: stop-ITs.sh.j2
     dest: /usr/bin/stop-ITs
     owner: root

--- a/roles/usegalaxy-eu.galactic-radio-telescope/tasks/config.yml
+++ b/roles/usegalaxy-eu.galactic-radio-telescope/tasks/config.yml
@@ -8,7 +8,7 @@
     mode: 0750
 
 - name: Send templates
-  template:
+  ansible.builtin.template:
     src: "{{ item }}"
     dest: "{{ grt_dir }}/config/{{ item }}"
     owner: root

--- a/roles/usegalaxy-eu.galactic-radio-telescope/tasks/cron.yml
+++ b/roles/usegalaxy-eu.galactic-radio-telescope/tasks/cron.yml
@@ -16,7 +16,7 @@
     job: "cd {{ grt_queries_dir }}  && . {{ grt_dir }}/config/env.sh && {{ grt_dir }}/venv/bin/python {{ grt_dir }}/code/manage.py queries"
 
 - name: Send influx script
-  template:
+  ansible.builtin.template:
     src: "export-to-influx.sh"
     dest: "/usr/bin/export-grt-to-influx"
     owner: root

--- a/roles/usegalaxy-eu.galactic-radio-telescope/tasks/main.yml
+++ b/roles/usegalaxy-eu.galactic-radio-telescope/tasks/main.yml
@@ -1,10 +1,12 @@
 ---
 #- include_tasks: account.yml
   #when: grt_create_group or grt_create_user
-- include_tasks: user.yml
+- name: Include user tasks
+  include_tasks: user.yml
   when: grt_create_user
 
-- include_tasks: dirs.yml
+- name: Include directory setup tasks
+  include_tasks: dirs.yml
 
 - name: Clone repository
   git:
@@ -15,13 +17,18 @@
   register: repo_cloned
   notify: 'reload grt'
 
-- include_tasks: dependencies.yml
+- name: Include dependency installation tasks
+  include_tasks: dependencies.yml
 
-- include_tasks: django.yml
+- name: Include Django setup tasks
+  include_tasks: django.yml
   when: repo_cloned.changed
 
-- include_tasks: config.yml
+- name: Include configuration tasks
+  include_tasks: config.yml
 
-- include_tasks: systemd.yml
+- name: Include systemd tasks
+  include_tasks: systemd.yml
 
-- include_tasks: cron.yml
+- name: Include cron tasks
+  include_tasks: cron.yml

--- a/roles/usegalaxy-eu.galactic-radio-telescope/tasks/systemd.yml
+++ b/roles/usegalaxy-eu.galactic-radio-telescope/tasks/systemd.yml
@@ -1,6 +1,6 @@
 ---
 - name: Send runner script
-  template:
+  ansible.builtin.template:
     src: "run.sh"
     dest: "{{ grt_dir }}/run.sh"
     owner: "{{ grt_user.name }}"
@@ -9,7 +9,7 @@
   notify: 'reload grt'
 
 - name: Install systemd unit file
-  template:
+  ansible.builtin.template:
     src: grt.service
     dest: /etc/systemd/system/galactic-radio-telescope.service
   notify: setup grt systemd

--- a/roles/usegalaxy-eu.galactic-radio-telescope/tasks/systemd.yml
+++ b/roles/usegalaxy-eu.galactic-radio-telescope/tasks/systemd.yml
@@ -12,4 +12,5 @@
   ansible.builtin.template:
     src: grt.service
     dest: /etc/systemd/system/galactic-radio-telescope.service
+    mode: "0644"
   notify: setup grt systemd

--- a/roles/usegalaxy-eu.galaxy-procstat/tasks/main.yml
+++ b/roles/usegalaxy-eu.galaxy-procstat/tasks/main.yml
@@ -1,5 +1,5 @@
 - name: "Copy procstat setup"
-  template:
+  ansible.builtin.template:
     src: "telegraf-procstat.conf.j2"
     dest: "/etc/telegraf/telegraf.d/galaxy_procstat.conf"
     owner: telegraf

--- a/roles/usegalaxy-eu.galaxy-slurp/tasks/main.yml
+++ b/roles/usegalaxy-eu.galaxy-slurp/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Deploy slurp script
-  template:
+  ansible.builtin.template:
     src: galaxy-slurp.j2
     dest: /usr/bin/galaxy-slurp
     owner: "{{ galaxy_slurper }}"
@@ -16,7 +16,7 @@
     user: "{{ galaxy_slurper }}"
 
 - name: Deploy slurp script (upto)
-  template:
+  ansible.builtin.template:
     src: galaxy-slurp-upto.j2
     dest: /usr/bin/galaxy-slurp-upto
     owner: "{{ galaxy_slurper }}"

--- a/roles/usegalaxy-eu.gapars-galaxy/tasks/main.yml
+++ b/roles/usegalaxy-eu.gapars-galaxy/tasks/main.yml
@@ -52,7 +52,7 @@
   notify: 'reload gapars'
 
 - name: Send runner script
-  template:
+  ansible.builtin.template:
     src: "run.sh"
     dest: "{{ gapars_dir }}/run.sh"
     owner: "{{ gapars_user }}"
@@ -70,7 +70,7 @@
   notify: 'reload gapars'
 
 - name: Install systemd unit file
-  template:
+  ansible.builtin.template:
     src: service
     dest: /etc/systemd/system/gapars.service
   notify: setup gapars systemd

--- a/roles/usegalaxy-eu.gie-node-proxy/tasks/main.yml
+++ b/roles/usegalaxy-eu.gie-node-proxy/tasks/main.yml
@@ -16,7 +16,7 @@
     - gie systemd restart
 
 - name: Copy main systemd file
-  template:
+  ansible.builtin.template:
     src: galaxy-gie-proxy.service.j2
     dest: "/etc/systemd/system/galaxy-gie-proxy.service"
     owner: root

--- a/roles/usegalaxy-eu.grt-client/tasks/main.yml
+++ b/roles/usegalaxy-eu.grt-client/tasks/main.yml
@@ -1,13 +1,13 @@
 ---
 - name: Deploy export
-  template:
+  ansible.builtin.template:
     src: grt-export.sh
     dest: /usr/bin/grt-export
     owner: "{{ galaxy_grt_exporter }}"
     mode: 0750
 
 - name: Deploy upload
-  template:
+  ansible.builtin.template:
     src: grt-eupload.sh
     dest: /usr/bin/grt-upload
     owner: "{{ galaxy_grt_uploader }}"

--- a/roles/usegalaxy-eu.plausible/tasks/main.yml
+++ b/roles/usegalaxy-eu.plausible/tasks/main.yml
@@ -8,7 +8,7 @@
   register: repo_cloned
 
 - name: Template config
-  template:
+  ansible.builtin.template:
     src: plausible.j2
     dest: "{{ plausible_dir }}/plausible-conf.env"
     owner: root
@@ -16,7 +16,7 @@
     mode: '0640'
 
 - name: Template config for mail
-  template:
+  ansible.builtin.template:
     src: plausible-mail.j2
     dest: "{{ plausible_dir }}/plausible-mail-conf.env"
     owner: root

--- a/roles/usegalaxy-eu.vgcn-monitoring/tasks/main.yml
+++ b/roles/usegalaxy-eu.vgcn-monitoring/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: copy vgcn_monitoring template
-  template:
+  ansible.builtin.template:
     src: vgcn_monitoring.py.j2
     dest: /usr/local/bin/vgcn_monitoring.py
     owner: root
@@ -17,7 +17,7 @@
   notify: restart telegraf
 
 - name: Add VGCN monitoring Telegraf configuration
-  template:
+  ansible.builtin.template:
     src: vgcn_monitoring.conf.j2
     dest: /etc/telegraf/telegraf.d/vgcn_monitoring.conf
     owner: telegraf

--- a/roles/usegalaxy_eu.galaxy_cleanup/tasks/main.yml
+++ b/roles/usegalaxy_eu.galaxy_cleanup/tasks/main.yml
@@ -11,7 +11,7 @@
     success_msg: "All objectstore_id values contain 'scratch'"
 
 - name: Install cleanup scratch script
-  template:
+  ansible.builtin.template:
     src: "clean_scratch_storage.sh.j2"
     dest: "/usr/local/bin/clean_scratch_storage.sh"
     mode: "0555"

--- a/sn09.yml
+++ b/sn09.yml
@@ -67,8 +67,6 @@
     - templates/galaxy/config/job_conf.yml
     - mounts/dest/all.yml
     - mounts/mountpoints.yml
-  collections:
-    - devsec.hardening
   handlers:
     - name: Restart Galaxy
       ansible.builtin.shell: |

--- a/sn09.yml
+++ b/sn09.yml
@@ -116,7 +116,7 @@
         state: present
 
     - name: Install pgdg repository package (RedHat)
-      ansible.builtin.yum:
+      ansible.builtin.dnf:
         name: >-
           https://download.postgresql.org/pub/repos/yum/reporpms/{{ postgresql_pgdg_shortfamilies[ansible_distribution]
             | default("EL") }}-{{ ansible_distribution_major_version }}-{{ ansible_architecture }}/pgdg-{{

--- a/sn09.yml
+++ b/sn09.yml
@@ -70,7 +70,8 @@
     - mounts/mountpoints.yml
   handlers:
     - name: Restart Galaxy
-      ansible.builtin.command: /bin/bash -lc 'cd /opt/galaxy/ && source /opt/galaxy/.bashrc && /usr/bin/gxadmin gunicorn handler-restart && sudo -u galaxy /usr/bin/galaxy-sync-to-nfs && systemctl restart galaxy-handler@* && systemctl restart galaxy-workflow-scheduler@*'
+      ansible.builtin.shell: |
+        cd /opt/galaxy/ && source /opt/galaxy/.bashrc && /usr/bin/gxadmin gunicorn handler-restart && sudo -u galaxy /usr/bin/galaxy-sync-to-nfs && systemctl restart galaxy-handler@* && systemctl restart galaxy-workflow-scheduler@*
       changed_when: false
       listen: 'restart galaxy'
   pre_tasks:

--- a/sn09.yml
+++ b/sn09.yml
@@ -233,7 +233,7 @@
         group: galaxy
         mode: '0755'
 
-    - name: Ensure database directory exists and is owned by galaxy user: {{ galaxy_server_dir }}/database
+    - name: "Ensure database directory exists and is owned by galaxy user for {{ galaxy_server_dir }}/database"
       ansible.builtin.file:
         path: "{{ galaxy_server_dir }}/database"
         state: directory

--- a/sn09.yml
+++ b/sn09.yml
@@ -47,6 +47,16 @@
       - '*.ep.interactivetool.earth-system.usegalaxy.eu'
       - '*.eirene.usegalaxy.eu'
       - '*.ep.interactivetool.eirene.usegalaxy.eu'
+    playbook_secret_vars_files:
+      - secret_group_vars/sentry.yml
+      - secret_group_vars/aws.yml
+      - secret_group_vars/pulsar.yml
+      - secret_group_vars/oidc.yml
+      - secret_group_vars/object_store.yml
+      - secret_group_vars/db-main.yml
+      - secret_group_vars/file_sources.yml
+      - secret_group_vars/all.yml
+      - secret_group_vars/keys.yml
   vars_files:
     - group_vars/sn09/sn09.yml
     - group_vars/sn09/themes_conf.yml
@@ -55,15 +65,6 @@
     - group_vars/tiaas.yml # All of the training infrastructure
     - group_vars/gxconfig.yml # The base galaxy configuration
     - group_vars/toolbox.yml # User controlled toolbox
-    - secret_group_vars/sentry.yml # Sentry SDK init url
-    - secret_group_vars/aws.yml # AWS creds
-    - secret_group_vars/pulsar.yml # Pulsar + MQ Connections
-    - secret_group_vars/oidc.yml # OIDC credentials (ELIXIR, keycloak)
-    - secret_group_vars/object_store.yml # Object Store credentils (S3 etc ...)
-    - secret_group_vars/db-main.yml # DB URL + some postgres stuff
-    - secret_group_vars/file_sources.yml # file_sources_conf.yml creds
-    - secret_group_vars/all.yml # All of the other assorted secrets...
-    - secret_group_vars/keys.yml # SSH keys
     - templates/galaxy/config/job_conf.yml
     - mounts/dest/all.yml
     - mounts/mountpoints.yml
@@ -73,6 +74,12 @@
       changed_when: false
       listen: 'restart galaxy'
   pre_tasks:
+     # We are loading the secrets as pre_task, because the ansible-lint is otherwise failing
+    - name: Load secret variables
+      ansible.builtin.include_vars:
+        file: "{{ item }}"
+      loop: "{{ playbook_secret_vars_files }}"
+      no_log: true
     # This should be the 1st pretask as the rest of the tasks are dependent on it.
     - name: Install EPEL-release
       ansible.builtin.package:

--- a/sn09.yml
+++ b/sn09.yml
@@ -69,8 +69,8 @@
     - mounts/mountpoints.yml
   handlers:
     - name: Restart Galaxy
-      ansible.builtin.shell: |
-        cd /opt/galaxy/ && source /opt/galaxy/.bashrc  && /usr/bin/gxadmin gunicorn handler-restart && sudo -u galaxy /usr/bin/galaxy-sync-to-nfs && systemctl restart galaxy-handler@* && systemctl restart galaxy-workflow-scheduler@*
+      ansible.builtin.command: /bin/bash -lc 'cd /opt/galaxy/ && source /opt/galaxy/.bashrc && /usr/bin/gxadmin gunicorn handler-restart && sudo -u galaxy /usr/bin/galaxy-sync-to-nfs && systemctl restart galaxy-handler@* && systemctl restart galaxy-workflow-scheduler@*'
+      changed_when: false
       listen: 'restart galaxy'
   pre_tasks:
     # This should be the 1st pretask as the rest of the tasks are dependent on it.
@@ -100,7 +100,7 @@
         state: present
 
     - name: Disable SELinux
-      selinux:
+      ansible.posix.selinux:
         state: disabled
 
     - name: Install repository key (PostgreSQL v11 and above)
@@ -146,7 +146,7 @@
         mode: "0644"
 
     - name: Append some users to the systemd-journal group
-      user:
+      ansible.builtin.user:
         name: '{{ item }}'
         groups: systemd-journal
         append: true

--- a/sn09.yml
+++ b/sn09.yml
@@ -130,11 +130,13 @@
       ansible.builtin.copy:
         content: '{{ firewall_mosh_service }}'
         dest: /etc/firewalld/services/mosh.xml
+        mode: "0644"
 
     - name: Add HTcondor shared port service config for FirewallD
       ansible.builtin.copy:
         content: '{{ firewall_htcondor_shared_port_service }}'
         dest: /etc/firewalld/services/htcondor-shared-port.xml
+        mode: "0644"
   post_tasks:
     - name: Write Galaxy __galaxy_client_build_version and __galaxy_current_commit_id
       delegate_to: 127.0.0.1
@@ -143,6 +145,7 @@
           client_build_version={{ __galaxy_client_build_version }}
           current_commit_id={{ __galaxy_current_commit_id }}
         dest: '{{ playbook_dir }}/galaxy_update.properties'
+        mode: "0644"
 
     - name: Append some users to the systemd-journal group
       user:

--- a/sn09.yml
+++ b/sn09.yml
@@ -240,7 +240,7 @@
         group: galaxy
         mode: '0755'
 
-    - name: "Ensure database directory exists and is owned by galaxy user for {{ galaxy_server_dir }}/database"
+    - name: Ensure database directory exists and is owned by galaxy user
       ansible.builtin.file:
         path: "{{ galaxy_server_dir }}/database"
         state: directory
@@ -379,6 +379,6 @@
     - usegalaxy-eu.log-cleaner # do not retain journalctl logs, they are unnecessary/risky under GDPR
     - dj-wasabi.telegraf
     - usegalaxy-eu.galaxy-procstat # Some custom telegraf monitoring that's templated
-    - ssh_hardening #dev-sec.hardening collection
+    - devsec.hardening.ssh_hardening
     - usegalaxy-eu.fix-stop-ITs
     - usegalaxy_eu.firewall

--- a/sn09.yml
+++ b/sn09.yml
@@ -223,7 +223,7 @@
         path: '{{ galaxy_server_dir }}/compliance.log'
         owner: galaxy
         group: root
-        mode: 0644
+        mode: "0644"
 
     - name: Ensure .config directory exists for galaxy user
       ansible.builtin.file:

--- a/sn09.yml
+++ b/sn09.yml
@@ -233,7 +233,7 @@
         group: galaxy
         mode: '0755'
 
-    - name: "Ensure {{ galaxy_server_dir }}/database directory exists and is owned by galaxy user"
+    - name: Ensure database directory exists and is owned by galaxy user: {{ galaxy_server_dir }}/database
       ansible.builtin.file:
         path: "{{ galaxy_server_dir }}/database"
         state: directory

--- a/sn11.yml
+++ b/sn11.yml
@@ -9,8 +9,6 @@
     - group_vars/sn11.yml
     - mounts/dest/all.yml
     - mounts/mountpoints.yml
-  collections:
-    - devsec.hardening
   pre_tasks:
     - name: Add mosh service config for FirewallD
       ansible.builtin.copy:

--- a/sn11.yml
+++ b/sn11.yml
@@ -17,7 +17,7 @@
         mode: "0644"
   post_tasks:
     - name: Ensure PostgreSQL is allowed on the firewall
-      ansible.builtin.firewalld:
+      ansible.posix.firewalld:
         service: postgresql
         permanent: true
         state: enabled

--- a/sn11.yml
+++ b/sn11.yml
@@ -4,12 +4,18 @@
   become: true
   vars:
     hostname: sn11.galaxyproject.eu
+    playbook_secret_vars_files:
+      - secret_group_vars/all.yml
   vars_files:
-    - secret_group_vars/all.yml
     - group_vars/sn11.yml
     - mounts/dest/all.yml
     - mounts/mountpoints.yml
   pre_tasks:
+    - name: Load secret variables
+      ansible.builtin.include_vars:
+        file: "{{ item }}"
+      loop: "{{ playbook_secret_vars_files }}"
+      no_log: true
     - name: Add mosh service config for FirewallD
       ansible.builtin.copy:
         content: '{{ firewall_mosh_service }}'

--- a/sn11.yml
+++ b/sn11.yml
@@ -16,6 +16,7 @@
       ansible.builtin.copy:
         content: '{{ firewall_mosh_service }}'
         dest: /etc/firewalld/services/mosh.xml
+        mode: "0644"
   post_tasks:
     - name: Ensure PostgreSQL is allowed on the firewall
       ansible.builtin.firewalld:

--- a/sn11.yml
+++ b/sn11.yml
@@ -43,6 +43,6 @@
     - ssh-host-sign
     - usegalaxy-eu.ansible-postgresql
     - dj-wasabi.telegraf
-    - ssh_hardening
+    - devsec.hardening.ssh_hardening
     - usegalaxy_eu.disable_memory_overcommit
     - usegalaxy_eu.firewall

--- a/subdomains.yml
+++ b/subdomains.yml
@@ -28,8 +28,7 @@
     - mounts/mountpoints.yml
   handlers:
     - name: Restart Galaxy
-      shell: |
-        cd /opt/galaxy/ && source /opt/galaxy/.bashrc  && /usr/bin/gxadmin gunicorn handler-restart && sudo -u galaxy /usr/bin/galaxy-sync-to-nfs
+      ansible.builtin.command: cd /opt/galaxy/ && source /opt/galaxy/.bashrc && /usr/bin/gxadmin gunicorn handler-restart && sudo -u galaxy /usr/bin/galaxy-sync-to-nfs
   roles:
     - role: galaxyproject.galaxy
       vars:

--- a/subdomains.yml
+++ b/subdomains.yml
@@ -30,6 +30,7 @@
   handlers:
     - name: Restart Galaxy
       ansible.builtin.command: cd /opt/galaxy/ && source /opt/galaxy/.bashrc && /usr/bin/gxadmin gunicorn handler-restart && sudo -u galaxy /usr/bin/galaxy-sync-to-nfs
+      changed_when: false
   pre_tasks:
     - name: Load secret variables
       ansible.builtin.include_vars:

--- a/subdomains.yml
+++ b/subdomains.yml
@@ -5,6 +5,16 @@
   become_user: root
   vars:
     hostname: sn09.galaxyproject.eu
+    playbook_secret_vars_files:
+      - secret_group_vars/sentry.yml
+      - secret_group_vars/aws.yml
+      - secret_group_vars/pulsar.yml
+      - secret_group_vars/oidc.yml
+      - secret_group_vars/object_store.yml
+      - secret_group_vars/db-main.yml
+      - secret_group_vars/file_sources.yml
+      - secret_group_vars/all.yml
+      - secret_group_vars/keys.yml
 
   vars_files:
     # Just keep the same as sn09, so nothing gets messed up ;)
@@ -14,21 +24,18 @@
     - group_vars/tiaas.yml # All of the training infrastructure
     - group_vars/gxconfig.yml # The base galaxy configuration
     - group_vars/toolbox.yml # User controlled toolbox
-    - secret_group_vars/sentry.yml # Sentry SDK init url
-    - secret_group_vars/aws.yml # AWS creds
-    - secret_group_vars/pulsar.yml # Pulsar + MQ Connections
-    - secret_group_vars/oidc.yml # OIDC credentials (ELIXIR, keycloak)
-    - secret_group_vars/object_store.yml # Object Store credentils (S3 etc ...)
-    - secret_group_vars/db-main.yml # DB URL + some postgres stuff
-    - secret_group_vars/file_sources.yml # file_sources_conf.yml creds
-    - secret_group_vars/all.yml # All of the other assorted secrets...
-    - secret_group_vars/keys.yml # SSH keys
     - templates/galaxy/config/job_conf.yml
     - mounts/dest/all.yml
     - mounts/mountpoints.yml
   handlers:
     - name: Restart Galaxy
       ansible.builtin.command: cd /opt/galaxy/ && source /opt/galaxy/.bashrc && /usr/bin/gxadmin gunicorn handler-restart && sudo -u galaxy /usr/bin/galaxy-sync-to-nfs
+  pre_tasks:
+    - name: Load secret variables
+      ansible.builtin.include_vars:
+        file: "{{ item }}"
+      loop: "{{ playbook_secret_vars_files }}"
+      no_log: true
   roles:
     - role: galaxyproject.galaxy
       vars:

--- a/subdomains.yml
+++ b/subdomains.yml
@@ -29,7 +29,8 @@
     - mounts/mountpoints.yml
   handlers:
     - name: Restart Galaxy
-      ansible.builtin.command: cd /opt/galaxy/ && source /opt/galaxy/.bashrc && /usr/bin/gxadmin gunicorn handler-restart && sudo -u galaxy /usr/bin/galaxy-sync-to-nfs
+      ansible.builtin.shell: |
+        cd /opt/galaxy/ && source /opt/galaxy/.bashrc && /usr/bin/gxadmin gunicorn handler-restart && sudo -u galaxy /usr/bin/galaxy-sync-to-nfs
       changed_when: false
   pre_tasks:
     - name: Load secret variables

--- a/telescope.yml
+++ b/telescope.yml
@@ -6,7 +6,8 @@
   vars_files:
     - "secret_group_vars/all.yml"
   pre_tasks:
-    - package:
+    - name: Install telescope database client dependency
+      package:
         name: ['python-psycopg2']
   roles:
     - hostname

--- a/telescope.yml
+++ b/telescope.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: telescope
+- name: Telescope
+  hosts: telescope
   become: true
   vars:
     hostname: telescope.internal.galaxyproject.eu

--- a/telescope.yml
+++ b/telescope.yml
@@ -4,9 +4,14 @@
   become: true
   vars:
     hostname: telescope.internal.galaxyproject.eu
-  vars_files:
-    - "secret_group_vars/all.yml"
+    playbook_secret_vars_files:
+      - secret_group_vars/all.yml
   pre_tasks:
+    - name: Load secret variables
+      ansible.builtin.include_vars:
+        file: "{{ item }}"
+      loop: "{{ playbook_secret_vars_files }}"
+      no_log: true
     - name: Install telescope database client dependency
       ansible.builtin.package:
         name: ['python-psycopg2']
@@ -21,7 +26,7 @@
     - galaxyproject.nginx
     - hxr.autofs
     # BEGIN custom
-    - usegalaxy-eu.gxadmin
+    - galaxyproject.gxadmin
     - usegalaxy-eu.galactic-radio-telescope
     # END custom
     - dj-wasabi.telegraf

--- a/telescope.yml
+++ b/telescope.yml
@@ -7,7 +7,7 @@
     - "secret_group_vars/all.yml"
   pre_tasks:
     - name: Install telescope database client dependency
-      package:
+      ansible.builtin.package:
         name: ['python-psycopg2']
   roles:
     - hostname

--- a/templates/encoder/site.yaml
+++ b/templates/encoder/site.yaml
@@ -6,7 +6,7 @@
     - vars/apache_test.yaml
   tasks:
     - name: Create test.apache file
-      template:
+      ansible.builtin.template:
         src: templates/test.apache.j2
         dest: /tmp/test.apache
       tags:
@@ -18,7 +18,7 @@
     - vars/erlang_test.yaml
   tasks:
     - name: Create test.erlang file
-      template:
+      ansible.builtin.template:
         src: templates/test.erlang.j2
         dest: /tmp/test.erlang
       tags:
@@ -30,7 +30,7 @@
     - vars/ini_test.yaml
   tasks:
     - name: Create test.ini file
-      template:
+      ansible.builtin.template:
         src: templates/test.ini.j2
         dest: /tmp/test.ini
       tags:
@@ -42,7 +42,7 @@
     - vars/ini_test.yaml
   tasks:
     - name: Create test.simple file
-      template:
+      ansible.builtin.template:
         src: templates/test.ini_simple.j2
         dest: /tmp/test.ini_simple
       tags:
@@ -54,7 +54,7 @@
     - vars/json_test.yaml
   tasks:
     - name: Create test.json file
-      template:
+      ansible.builtin.template:
         src: templates/test.json.j2
         dest: /tmp/test.json
       tags:
@@ -66,7 +66,7 @@
     - vars/logstash_test.yaml
   tasks:
     - name: Create test.logstash file
-      template:
+      ansible.builtin.template:
         src: templates/test.logstash.j2
         dest: /tmp/test.logstash
       tags:
@@ -78,7 +78,7 @@
     - vars/toml_test.yaml
   tasks:
     - name: Create test.toml file
-      template:
+      ansible.builtin.template:
         src: templates/test.toml.j2
         dest: /tmp/test.toml
       tags:
@@ -90,7 +90,7 @@
     - vars/xml_test.yaml
   tasks:
     - name: Create test.xml file
-      template:
+      ansible.builtin.template:
         src: templates/test.xml.j2
         dest: /tmp/test.xml
       tags:
@@ -102,7 +102,7 @@
     - vars/yaml_test.yaml
   tasks:
     - name: Create test.yaml file
-      template:
+      ansible.builtin.template:
         src: templates/test.yaml.j2
         dest: /tmp/test.yaml
       tags:

--- a/tpv-broker.yml
+++ b/tpv-broker.yml
@@ -12,8 +12,6 @@
     - group_vars/tpv-broker.yml
     - secret_group_vars/all.yml
     - secret_group_vars/aws.yml
-  collections:
-    - devsec.hardening
   pre_tasks:
     - name: Install Dependencies
       package:

--- a/tpv-broker.yml
+++ b/tpv-broker.yml
@@ -8,11 +8,17 @@
     nginx_conf_user: galaxy
     server_names:
       - '{{ inventory_hostname }}'
+    playbook_secret_vars_files:
+      - secret_group_vars/all.yml
+      - secret_group_vars/aws.yml
   vars_files:
     - group_vars/tpv-broker.yml
-    - secret_group_vars/all.yml
-    - secret_group_vars/aws.yml
   pre_tasks:
+    - name: Load secret variables
+      ansible.builtin.include_vars:
+        file: "{{ item }}"
+      loop: "{{ playbook_secret_vars_files }}"
+      no_log: true
     - name: Install Dependencies
       ansible.builtin.package:
         name:

--- a/tpv-broker.yml
+++ b/tpv-broker.yml
@@ -14,7 +14,7 @@
     - secret_group_vars/aws.yml
   pre_tasks:
     - name: Install Dependencies
-      package:
+      ansible.builtin.package:
         name:
           [
             'git',
@@ -23,12 +23,12 @@
           ]
         state: present
     - name: Enable and start firewalld
-      service:
+      ansible.builtin.service:
         name: firewalld
         state: started
         enabled: true
     - name: Allow http and https services
-      firewalld:
+      ansible.posix.firewalld:
         service: '{{ item }}'
         permanent: true
         state: enabled
@@ -38,7 +38,7 @@
         - https
   post_tasks:
     - name: Append some users to the systemd-journal group
-      user:
+      ansible.builtin.user:
         name: '{{ item }}'
         groups: systemd-journal
         append: true

--- a/traefik-proxy.yml
+++ b/traefik-proxy.yml
@@ -2,11 +2,17 @@
 - name: Traefik
   become: true
   hosts: traefik
-  vars_files:
-    - secret_group_vars/all.yml
-    - secret_group_vars/traefik.yml
-    - secret_group_vars/keys.yml
+  vars:
+    playbook_secret_vars_files:
+      - secret_group_vars/all.yml
+      - secret_group_vars/traefik.yml
+      - secret_group_vars/keys.yml
   pre_tasks:
+    - name: Load secret variables
+      ansible.builtin.include_vars:
+        file: "{{ item }}"
+      loop: "{{ playbook_secret_vars_files }}"
+      no_log: true
     - name: Install ansible dependencies
       ansible.builtin.package:
         name: "{{ item }}"

--- a/upload.yml
+++ b/upload.yml
@@ -3,12 +3,19 @@
   hosts: upload
   become: true
   become_user: root
+  vars:
+    playbook_secret_vars_files:
+      - secret_group_vars/all.yml
+      - secret_group_vars/sentry.yml
   vars_files:
-    - secret_group_vars/all.yml
-    - secret_group_vars/sentry.yml
     - mounts/mountpoints.yml
     - mounts/dest/all.yml
   pre_tasks:
+    - name: Load secret variables
+      ansible.builtin.include_vars:
+        file: "{{ item }}"
+      loop: "{{ playbook_secret_vars_files }}"
+      no_log: true
     - name: Open Rustus firewall ports
       ansible.posix.firewalld:
         zone: public

--- a/upload.yml
+++ b/upload.yml
@@ -37,7 +37,7 @@
 
     - usegalaxy_eu.rustus
   post_tasks:
-    - name: add telegraf to systemd-journal
+    - name: Add telegraf to systemd-journal
       ansible.builtin.user:
         name: telegraf
         groups:

--- a/upload.yml
+++ b/upload.yml
@@ -9,7 +9,8 @@
     - mounts/mountpoints.yml
     - mounts/dest/all.yml
   pre_tasks:
-    - ansible.posix.firewalld:
+    - name: Open Rustus firewall ports
+      ansible.posix.firewalld:
         zone: public
         port: 1080-1081/tcp
         permanent: true


### PR DESCRIPTION
This needs https://github.com/usegalaxy-eu/infrastructure-playbook/pull/1998

It implements basic YAML validation but also `ansible-lint` validation.
To make `ansible-lint` work on public CI without vaults, I move the loading of vault-files into a pre_task. I hope this is ok, given the nice syntax checks that we get. I tried then to fix all remaining lints and hits and I think the playbook is with this in a better shape. I recommend reviewing this PR after https://github.com/usegalaxy-eu/infrastructure-playbook/pull/1998 and then commit-by-commit.

Closes https://github.com/usegalaxy-eu/issues/issues/362.