### PR TITLE
Serve favicon from gunicorns, but cache it

### DIFF
--- a/templates/nginx/galaxy-main.j2
+++ b/templates/nginx/galaxy-main.j2
@@ -10,6 +10,17 @@ upstream galaxy {
     {% endfor %}
 }
 
+{% macro upstream_galaxy() -%}
+
+# This is the backend to send the requests to.
+proxy_pass          http://galaxy;
+
+proxy_set_header Host               $host;
+proxy_set_header X-Forwarded-For    $proxy_add_x_forwarded_for;
+proxy_set_header X-Forwarded-Proto  $scheme;
+proxy_set_header Upgrade            $http_upgrade;
+{%- endmacro %}
+
 server {
     listen 443 default_server;
     listen [::]:443 default_server;
@@ -41,12 +52,7 @@ server {
     client_body_buffer_size 1024m;
 
     location / {
-        # This is the backend to send the requests to.
-        proxy_pass       http://galaxy;
-        proxy_set_header Host               $host;
-        proxy_set_header X-Forwarded-For    $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto  $scheme;
-        proxy_set_header Upgrade            $http_upgrade;
+        {{ upstream_galaxy() | indent(8, false) }}
         proxy_set_header Connection         $connection_upgrade;
 
         # Throttle downloads. First 100Mb are free, after that 5Mb/s.
@@ -66,14 +72,11 @@ server {
     #}
 
     location ~ ^/api/dataset_collections/([^/]+)/download/?$ {
+        {{ upstream_galaxy() | indent(8, false) }}
+
         proxy_read_timeout 1200s;
 
         proxy_buffering off;
-        proxy_pass          http://galaxy;
-        proxy_set_header    Host               $host;
-        proxy_set_header    X-Forwarded-For    $proxy_add_x_forwarded_for;
-        proxy_set_header    X-Forwarded-Proto  $scheme;
-        proxy_set_header    Upgrade            $http_upgrade;
     }
 
     location /_x_accel_redirect {
@@ -235,9 +238,9 @@ server {
         rewrite ^/beacon/?(.*)$ /$1 break;
         proxy_pass http://beacon.galaxyproject.eu;
         proxy_http_version 1.1;
-        proxy_set_header    X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header    X-Real-IP       $remote_addr;
-        proxy_set_header    Host            beacon.galaxyproject.eu;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Real-IP       $remote_addr;
+        proxy_set_header Host            beacon.galaxyproject.eu;
     }
 
     location /external/phdcomics/ {
@@ -289,7 +292,10 @@ server {
     }
 
     location /favicon.ico {
-        alias {{ galaxy_server_dir }}/static/favicon.ico;
+        {{ upstream_galaxy() | indent(8, false) }}
+
+        expires 5d;
+        add_header Cache-Control "public, immutable";
     }
 
     location /robots.txt {


### PR DESCRIPTION
In addition, move `proxy_pass` and Galaxy upstream headers to a macro.

This approach has the downside of asking the gunicorns for the favicon once every five days per-user, but the impact is minimal (most other static content is retrieved from the gunicorns at the moment). The upside is that favicon config is no longer managed in two different places. Also allows different favicons per subdomain (see https://github.com/usegalaxy-eu/infrastructure-playbook/pull/1996#issuecomment-4215756078).

The important bit is that it paves the way for https://github.com/usegalaxy-eu/issues/issues/927. A `/static` block can be added that uses the macro and includes a couple of caching headers for all static content).

Closes https://github.com/usegalaxy-eu/issues/issues/919. Supersedes https://github.com/usegalaxy-eu/infrastructure-playbook/pull/1997.
