### PR TITLE
Include `$host` in NGINX proxy cache key

### DIFF
--- a/templates/nginx/galaxy-main.j2
+++ b/templates/nginx/galaxy-main.j2
@@ -26,6 +26,8 @@ proxy_set_header Upgrade            $http_upgrade;
 {# Must be used together with `upstream_galaxy()`. #}
 proxy_cache galaxy;
 
+proxy_cache_key $scheme$host$proxy_host$request_uri;
+
 proxy_cache_valid 200 30m;
 proxy_cache_valid 404 5m;
 proxy_cache_valid any 10m;


### PR DESCRIPTION
There have been reports of users intermittently seeing welcome pages from subdomains on the Galaxy EU site.

According to the [NGINX docs](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_cache_key), the default value of `proxy_cache_key` is `$scheme$proxy_host$request_uri;`. Since `$proxy_host` is the same for all subdomains, that explains the issue.

Including `$host` in the cache key should make it distinguish subdomains.