### PR TITLE
Update uni-freiburg LLM model list

### DIFF
--- a/files/galaxy/config/llm/genai_models.loc
+++ b/files/galaxy/config/llm/genai_models.loc
@@ -17,6 +17,7 @@ qwen-30b-a3b-llmlb-freiburg	qwen-30b-a3b-llmlb	Strong all-rounder for technical 
 gpt-oss-20b-llmlb-freiburg	gpt-oss-20b-llmlb	Smooth for straightforward Q&A or text generation, efficient on small servers (GPT-OSS-20B) [uni-freiburg]	text	uni-freiburg	OpenAI
 qwen2.5-vl-7b-llmlb-freiburg	qwen2.5-vl-7b-llmlb	Budget-friendly image understanding, extract info from charts, UIs, or screenshots (Qwen2.5-VL-7B-Instruct) [uni-freiburg]	multimodal	uni-freiburg	Alibaba Cloud
 magistral-small-llmlb-freiburg	magistral-small-llmlb	Quick and lightweight text generation, best when speed and cost matter most (Magistral-Small-2507) [uni-freiburg]	multimodal	uni-freiburg	Mistral AI
+numarkdown-8b-thinking-llmlb-freiburg	numarkdown-8b-thinking-llmlb	Advanced OCR and document understanding, excels at extracting structured data from scanned images (NuMarkdown-8B-Thinking) [uni-freiburg]	image	uni-freiburg	NuMind
 glm45-air-llmlb-freiburg	glm45-air-llmlb	Balanced and efficient model for general-purpose tasks (GLM-4-Air) [uni-freiburg]	text	uni-freiburg	Zhipu AI
 glm-4.7-llmlb-freiburg	glm-4.7-llmlb	Latest generation model with enhanced reasoning and knowledge (GLM-4.7) [uni-freiburg]	text	uni-freiburg	Zhipu AI
 deepseek-r1-0528-qwen3-8b-llmlb-freiburg	deepseek-r1-0528-qwen3-8b-llmlb	Compact reasoning model with visible chain-of-thought process (DeepSeek-R1-0528-Qwen3-8B) [uni-freiburg]	text	uni-freiburg	DeepSeek

--- a/files/galaxy/config/llm/genai_models.loc
+++ b/files/galaxy/config/llm/genai_models.loc
@@ -19,7 +19,6 @@ gemma-3-12b-llmlb-freiburg	gemma-3-12b-llmlb	Handles text + images, great for de
 numarkdown-8b-thinking-llmlb-freiburg	numarkdown-8b-thinking-llmlb	Advanced OCR and document understanding, excels at extracting structured data from scanned images (NuMarkdown-8B-Thinking) [uni-freiburg]	image	uni-freiburg	NuMind
 gemma-3-27b-llmlb-freiburg	gemma-3-27b-llmlb	High-performance multimodal model for complex reasoning and image understanding (Gemma-3-27B-IT) [uni-freiburg]	multimodal	uni-freiburg	Google DeepMind
 glm-5.1-llmlb-freiburg	glm-5.1-llmlb	Latest GLM 5.1 generation model with enhanced reasoning and knowledge (GLM-5.1) [uni-freiburg]	text	uni-freiburg	Zhipu AI
-llama-3.1-8b-fp8-llmlb-freiburg	llama-3.1-8b-fp8-llmlb	Efficient 8B model with FP8 quantization for fast inference (Meta-Llama-3.1-8B-FP8) [uni-freiburg]	text	uni-freiburg	Meta AI
 nuextract3-llmlb-freiburg	nuextract3-llmlb	NuExtract3 is a unified 4B vision-language reasoning model for document understanding (NuExtract3) [uni-freiburg]	image	uni-freiburg	NuMind
 qwen-3.5-397b-llmlb-freiburg	qwen-3.5-397b-llmlb	Flagship 397B mixture-of-experts model for the most demanding reasoning, long-context, and visual tasks (Qwen3.5-397B) [uni-freiburg]	multimodal	uni-freiburg	Alibaba Cloud
 qwen-3.6-27b-llmlb-freiburg	qwen-3.6-27b-llmlb	Advanced reasoning and multimodal understanding with efficient 27B architecture (Qwen3.6-27B) [uni-freiburg]	multimodal	uni-freiburg	Alibaba Cloud

--- a/files/galaxy/config/llm/genai_models.loc
+++ b/files/galaxy/config/llm/genai_models.loc
@@ -14,19 +14,18 @@
 #
 gpt-oss-120b-llmlb-freiburg	gpt-oss-120b-llmlb	Most capable for complex tasks, deep reasoning, and detailed outputs (GPT-OSS-120B) [uni-freiburg]	text	uni-freiburg	OpenAI
 qwen-30b-a3b-llmlb-freiburg	qwen-30b-a3b-llmlb	Strong all-rounder for technical tasks, coding, and long structured outputs (Qwen3-30B-A3B) [uni-freiburg]	text	uni-freiburg	Alibaba Cloud
-mistral-3.2-24b-llmlb-freiburg	mistral-3.2-24b-llmlb	Balanced accuracy and speed, good for drafting documents and structured outputs (Mistral-Small-3.2-24B-Instruct-2506-FP8) [uni-freiburg]	multimodal	uni-freiburg	Mistral AI
 gpt-oss-20b-llmlb-freiburg	gpt-oss-20b-llmlb	Smooth for straightforward Q&A or text generation, efficient on small servers (GPT-OSS-20B) [uni-freiburg]	text	uni-freiburg	OpenAI
-gemma-3-12b-llmlb-freiburg	gemma-3-12b-llmlb	Handles text + images, great for describing photos, diagrams, or screenshots (Gemma-3-12B-IT) [uni-freiburg]	multimodal	uni-freiburg	Google DeepMind
 qwen2.5-vl-7b-llmlb-freiburg	qwen2.5-vl-7b-llmlb	Budget-friendly image understanding, extract info from charts, UIs, or screenshots (Qwen2.5-VL-7B-Instruct) [uni-freiburg]	multimodal	uni-freiburg	Alibaba Cloud
 magistral-small-llmlb-freiburg	magistral-small-llmlb	Quick and lightweight text generation, best when speed and cost matter most (Magistral-Small-2507) [uni-freiburg]	multimodal	uni-freiburg	Mistral AI
-numarkdown-8b-thinking-llmlb-freiburg	numarkdown-8b-thinking-llmlb	Advanced OCR and document understanding, excels at extracting structured data from scanned images (NuMarkdown-8B-Thinking) [uni-freiburg]	image	uni-freiburg	NuMind
-gemma-3-27b-llmlb-freiburg	gemma-3-27b-llmlb	High-performance multimodal model for complex reasoning and image understanding (Gemma-3-27B-IT) [uni-freiburg]	multimodal	uni-freiburg	Google DeepMind
-qwen3-coder-30b-a3b-instruct-llmlb-freiburg	qwen3-coder-30b-a3b-instruct-llmlb	Specialized code generation model with strong reasoning capabilities (Qwen3-Coder-30B-A3B) [uni-freiburg]	text	uni-freiburg	Alibaba Cloud
 glm45-air-llmlb-freiburg	glm45-air-llmlb	Balanced and efficient model for general-purpose tasks (GLM-4-Air) [uni-freiburg]	text	uni-freiburg	Zhipu AI
 glm-4.7-llmlb-freiburg	glm-4.7-llmlb	Latest generation model with enhanced reasoning and knowledge (GLM-4.7) [uni-freiburg]	text	uni-freiburg	Zhipu AI
 deepseek-r1-0528-qwen3-8b-llmlb-freiburg	deepseek-r1-0528-qwen3-8b-llmlb	Compact reasoning model with visible chain-of-thought process (DeepSeek-R1-0528-Qwen3-8B) [uni-freiburg]	text	uni-freiburg	DeepSeek
 llama-3.1-8b-fp8-llmlb-freiburg	llama-3.1-8b-fp8-llmlb	Efficient 8B model with FP8 quantization for fast inference (Meta-Llama-3.1-8B-FP8) [uni-freiburg]	text	uni-freiburg	Meta AI
 nuextract3-llmlb-freiburg	nuextract3-llmlb	NuExtract3 is a unified 4B vision-language reasoning model for document understanding (NuExtract3) [uni-freiburg]	image	uni-freiburg	NuMind
+qwen-3.5-llmlb-freiburg	qwen-3.5-llmlb	Flagship 397B mixture-of-experts model for the most demanding reasoning, long-context, and visual tasks (Qwen3.5-397B) [uni-freiburg]	multimodal	uni-freiburg	Alibaba Cloud
+qwen3.5-9b-llmlb-freiburg	qwen3.5-9b-llmlb	Efficient 9B native vision-language model for everyday tasks with fast inference (Qwen3.5-9B) [uni-freiburg]	multimodal	uni-freiburg	Alibaba Cloud
+mistral-small-4-llmlb-freiburg	mistral-small-4-llmlb	Latest Mistral Small generation with multimodal support and strong instruction following (Mistral-Small-4) [uni-freiburg]	multimodal	uni-freiburg	Mistral AI
+gemma-4-31b-llmlb-freiburg	gemma-4-31b-llmlb	High-performance 31B multimodal model for complex reasoning and image understanding (Gemma-4-31B-IT) [uni-freiburg]	multimodal	uni-freiburg	Google DeepMind
 gpt-oss-120b-e-infra.cz	gpt-oss-120b	Most capable for complex tasks, deep reasoning, and detailed outputs (GPT-OSS-120B) [e-INFRA CZ]	text	e-infra.cz	OpenAI
 deepseek-v3.2-e-infra.cz	deepseek-v3.2	High-performance model with advanced reasoning capabilities (DeepSeek-V3.2) [e-INFRA CZ]	text	e-infra.cz	DeepSeek
 deepseek-r1-e-infra.cz	deepseek-r1	Advanced reasoning model with chain-of-thought capabilities (DeepSeek-R1) [e-INFRA CZ]	text	e-infra.cz	DeepSeek

--- a/files/galaxy/config/llm/genai_models.loc
+++ b/files/galaxy/config/llm/genai_models.loc
@@ -13,17 +13,16 @@
 #
 #
 gpt-oss-120b-llmlb-freiburg	gpt-oss-120b-llmlb	Most capable for complex tasks, deep reasoning, and detailed outputs (GPT-OSS-120B) [uni-freiburg]	text	uni-freiburg	OpenAI
-qwen-30b-a3b-llmlb-freiburg	qwen-30b-a3b-llmlb	Strong all-rounder for technical tasks, coding, and long structured outputs (Qwen3-30B-A3B) [uni-freiburg]	text	uni-freiburg	Alibaba Cloud
+mistral-3.2-24b-llmlb-freiburg	mistral-3.2-24b-llmlb	Balanced accuracy and speed, good for drafting documents and structured outputs (Mistral-Small-3.2-24B-Instruct-2506-FP8) [uni-freiburg]	multimodal	uni-freiburg	Mistral AI
 gpt-oss-20b-llmlb-freiburg	gpt-oss-20b-llmlb	Smooth for straightforward Q&A or text generation, efficient on small servers (GPT-OSS-20B) [uni-freiburg]	text	uni-freiburg	OpenAI
-qwen2.5-vl-7b-llmlb-freiburg	qwen2.5-vl-7b-llmlb	Budget-friendly image understanding, extract info from charts, UIs, or screenshots (Qwen2.5-VL-7B-Instruct) [uni-freiburg]	multimodal	uni-freiburg	Alibaba Cloud
-magistral-small-llmlb-freiburg	magistral-small-llmlb	Quick and lightweight text generation, best when speed and cost matter most (Magistral-Small-2507) [uni-freiburg]	multimodal	uni-freiburg	Mistral AI
+gemma-3-12b-llmlb-freiburg	gemma-3-12b-llmlb	Handles text + images, great for describing photos, diagrams, or screenshots (Gemma-3-12B-IT) [uni-freiburg]	multimodal	uni-freiburg	Google DeepMind
 numarkdown-8b-thinking-llmlb-freiburg	numarkdown-8b-thinking-llmlb	Advanced OCR and document understanding, excels at extracting structured data from scanned images (NuMarkdown-8B-Thinking) [uni-freiburg]	image	uni-freiburg	NuMind
-glm45-air-llmlb-freiburg	glm45-air-llmlb	Balanced and efficient model for general-purpose tasks (GLM-4-Air) [uni-freiburg]	text	uni-freiburg	Zhipu AI
-glm-4.7-llmlb-freiburg	glm-4.7-llmlb	Latest generation model with enhanced reasoning and knowledge (GLM-4.7) [uni-freiburg]	text	uni-freiburg	Zhipu AI
-deepseek-r1-0528-qwen3-8b-llmlb-freiburg	deepseek-r1-0528-qwen3-8b-llmlb	Compact reasoning model with visible chain-of-thought process (DeepSeek-R1-0528-Qwen3-8B) [uni-freiburg]	text	uni-freiburg	DeepSeek
+gemma-3-27b-llmlb-freiburg	gemma-3-27b-llmlb	High-performance multimodal model for complex reasoning and image understanding (Gemma-3-27B-IT) [uni-freiburg]	multimodal	uni-freiburg	Google DeepMind
+glm-5.1-llmlb-freiburg	glm-5.1-llmlb	Latest GLM 5.1 generation model with enhanced reasoning and knowledge (GLM-5.1) [uni-freiburg]	text	uni-freiburg	Zhipu AI
 llama-3.1-8b-fp8-llmlb-freiburg	llama-3.1-8b-fp8-llmlb	Efficient 8B model with FP8 quantization for fast inference (Meta-Llama-3.1-8B-FP8) [uni-freiburg]	text	uni-freiburg	Meta AI
 nuextract3-llmlb-freiburg	nuextract3-llmlb	NuExtract3 is a unified 4B vision-language reasoning model for document understanding (NuExtract3) [uni-freiburg]	image	uni-freiburg	NuMind
-qwen-3.5-llmlb-freiburg	qwen-3.5-llmlb	Flagship 397B mixture-of-experts model for the most demanding reasoning, long-context, and visual tasks (Qwen3.5-397B) [uni-freiburg]	multimodal	uni-freiburg	Alibaba Cloud
+qwen-3.5-397b-llmlb-freiburg	qwen-3.5-397b-llmlb	Flagship 397B mixture-of-experts model for the most demanding reasoning, long-context, and visual tasks (Qwen3.5-397B) [uni-freiburg]	multimodal	uni-freiburg	Alibaba Cloud
+qwen-3.6-27b-llmlb-freiburg	qwen-3.6-27b-llmlb	Advanced reasoning and multimodal understanding with efficient 27B architecture (Qwen3.6-27B) [uni-freiburg]	multimodal	uni-freiburg	Alibaba Cloud
 qwen3.5-9b-llmlb-freiburg	qwen3.5-9b-llmlb	Efficient 9B native vision-language model for everyday tasks with fast inference (Qwen3.5-9B) [uni-freiburg]	multimodal	uni-freiburg	Alibaba Cloud
 mistral-small-4-llmlb-freiburg	mistral-small-4-llmlb	Latest Mistral Small generation with multimodal support and strong instruction following (Mistral-Small-4) [uni-freiburg]	multimodal	uni-freiburg	Mistral AI
 gemma-4-31b-llmlb-freiburg	gemma-4-31b-llmlb	High-performance 31B multimodal model for complex reasoning and image understanding (Gemma-4-31B-IT) [uni-freiburg]	multimodal	uni-freiburg	Google DeepMind


### PR DESCRIPTION
Remove 8 models (8 not on proxy):
- qwen-30b-a3b-llmlb
- qwen2.5-vl-7b-llmlb
- magistral-small-llmlb
- qwen3-coder-30b-a3b-instruct-llmlb
- glm45-air-llmlb
- glm-4.7-llmlb
- deepseek-r1-0528-qwen3-8b-llmlb
- llama-3.1-8b-fp8-llmlb

Add 6 new models:
- glm-5.1-llmlb (text)
- qwen-3.5-397b-llmlb (multimodal)
- qwen-3.6-27b-llmlb (multimodal)
- qwen3.5-9b-llmlb (multimodal)
- mistral-small-4-llmlb (multimodal)
- gemma-4-31b-llmlb (multimodal)