### PR TITLE
Restrict user file source utilization query to active ones

### DIFF
--- a/roles/hxr.monitor-galaxy/files/galaxy_user_file_source_utilisation.sh
+++ b/roles/hxr.monitor-galaxy/files/galaxy_user_file_source_utilisation.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-# Description: This script retrieves the count of distinct user file sources, grouped by template ID, that are currently in use within the Galaxy instance.
+# Description: This script retrieves the count of configured user file sources, grouped by template ID, that are currently in use within the Galaxy instance.
 
-gxadmin query q "COPY (select template_id, count(*) as user_count from user_file_source GROUP BY template_id) TO STDOUT WITH (FORMAT CSV, HEADER FALSE, DELIMITER ',');" | awk -F, '{printf "user_file_source_utilisation,template_id=%s user_count=%d\n", $1, $2}'
+gxadmin query q "COPY (SELECT template_id, count(*) AS user_count FROM user_file_source WHERE active=true AND purged=false GROUP BY template_id) TO STDOUT WITH (FORMAT CSV, HEADER FALSE, DELIMITER ',');" | awk -F, '{printf "user_file_source_utilisation,template_id=%s user_count=%d\n", $1, $2}'


### PR DESCRIPTION
The Grafana dashboard ["Galaxy file source utilisation"](https://stats.galaxyproject.eu/d/000000004/galaxy?orgId=1&from=now-24h&to=now&timezone=browser&var-host=sn09.galaxyproject.eu&refresh=1m&viewPanel=panel-110) is populated from the query `select template_id, count(*) as user_count from user_file_source GROUP BY template_id` in [roles/hxr.monitor-galaxy/files/galaxy_user_file_source_utilisation.sh](https://github.com/usegalaxy-eu/infrastructure-playbook/blob/066c1e754ab400368853bba3ff48c77333127380/roles/hxr.monitor-galaxy/files/galaxy_user_file_source_utilisation.sh).

This query, however, does not take into account the fields `hidden`, `active` nor `purged`. 

According to [their meaning](https://github.com/galaxyproject/galaxy/blob/2b30c9f26d4506144762294601f48cee54755945/lib/galaxy/model/__init__.py#L12399-L12403),

```python
    # active but doesn't appear in user selection
    hidden: Mapped[bool] = mapped_column(default=False)
    # set to False to deactive the source
    active: Mapped[bool] = mapped_column(default=True)
    # a purged file source cannot be re-activated because secrets have been purged
    purged: Mapped[bool] = mapped_column(default=False)
```

the query should filter by `active=true AND purged=false`.

Motivation: the "fine print" on [this issue](https://github.com/usegalaxy-eu/issues/issues/912#issuecomment-4328646941).