### PR TITLE
Redistribute load between job working directories

### DIFF
--- a/templates/galaxy/config/object_store_conf.yml.j2
+++ b/templates/galaxy/config/object_store_conf.yml.j2
@@ -245,7 +245,7 @@ backends:
     store_by: uuid
     device: "dnb12"
     name: "University of Freiburg storage (NetApp FabricPool, id=files33)"
-    weight: 1
+    weight: 2
     badges:
       - type: more_stable
     files_dir: "/data/dnb12/galaxy_db/files"
@@ -271,7 +271,7 @@ backends:
     store_by: uuid
     device: "dnb12"
     name: "University of Freiburg storage (NetApp FabricPool, id=files35)"
-    weight: 1
+    weight: 2
     badges:
       - type: more_stable
     files_dir: "/data/dnb12/galaxy_db/files"


### PR DESCRIPTION
From the ZFS storage Grafana dashboards, it seems that the load on zfs07 is significantly higher than that of zfs06 and zfs08. This makes sense, since zfs07 is home not only to job working directories (together with zfs06 and zfs08) but also to the object store cache (not the case for zfs06 and zfs08).

Reduce load on zfs07 from job working directories by 40%, increase load from job working directories on zfs06 and zfs08 by 20%.

Expected steady-state (used) storage size changes:
- zfs07: drop from 40-60 TiB to 24-36 TiB.
- zfs06/zfs08: Rise from 40-60 TiB to 48-72 TiB.

To maintain a ~50% free space safety margin, the capacity for jwd06 should be raised to 125 TiB (matching jwd08).

Once the 30-day cleanup period finishes on jwd07, its capacity can be reduced to ~75 TiB to adjust to the new steady state.