### PR TITLE
Set `JAVA_JAR_PATH` for `sam_merge2`

### DIFF
--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -580,6 +580,10 @@ tools:
     cores: 8
     mem: 20
 
+  toolshed.g2.bx.psu.edu/repos/devteam/sam_merge/sam_merge2/(1\.1\.2|1\.2\.0):
+    env:
+      SINGULARITYENV_JAVA_JAR_PATH: /usr/local/share/picard-1.56-1/
+
   toolshed.g2.bx.psu.edu/repos/bgruening/diamond/diamond/.*:
     cores: 6
     mem: 90


### PR DESCRIPTION
Environment variable `JAVA_JAR_PATH` is undefined for `toolshed.g2.bx.psu.edu/repos/devteam/sam_merge/sam_merge2/.*`. This triggers `Error: Unable to access jarfile /MergeSamFiles.jar` when launching the tool.

Set `JAVA_JAR_PATH` to `/usr/local/share/picard-1.56-1/` for versions 1.1.2 and 1.2.0 of the tool (which are all versions that exist right now).

Closes https://github.com/usegalaxy-eu/issues/issues/932.

Tested with both [1.1.2](https://usegalaxy.eu/datasets/26c75dcccb616ac8581b35372d1151b0/details) and [1.2.0](https://usegalaxy.eu/datasets/26c75dcccb616ac8a8e36159598017b6/details).