### PR TITLE
Deprecate `sam_merge2`

### DIFF
--- a/group_vars/sn09/toolmsg.yml
+++ b/group_vars/sn09/toolmsg.yml
@@ -44,7 +44,7 @@ toolmsg_messages:
     class: warning
   - tool_id: toolshed.g2.bx.psu.edu/repos/devteam/sam_merge/sam_merge2
     message: >
-      <strong>This tool is deprecated, please use <a href="https://usegalaxy.eu/?tool_id=toolshed.g2.bx.psu.edu/repos/iuc/samtools_merge/samtools_merge/">samtools merge</a> instead.</strong>
+      <strong>This tool is deprecated, please use <a href="https://usegalaxy.eu/?tool_id=samtools_merge">samtools merge</a> instead.</strong>
     class: warning
   - tool_id: toolshed.g2.bx.psu.edu/repos/devteam/ncbi_blast_plus/ncbi_blastp_wrapper
     message: >

--- a/group_vars/sn09/toolmsg.yml
+++ b/group_vars/sn09/toolmsg.yml
@@ -42,6 +42,10 @@ toolmsg_messages:
       <a href="https://usegalaxy.eu/?tool_id=falco">Falco</a>
       instead. Falco is 3 times faster and offers the same functionality as FASTQC.</strong>
     class: warning
+  - tool_id: toolshed.g2.bx.psu.edu/repos/devteam/sam_merge/sam_merge2
+    message: >
+      <strong>This tool is deprecated, please use <a href="https://usegalaxy.eu/?tool_id=toolshed.g2.bx.psu.edu/repos/iuc/samtools_merge/samtools_merge/">samtools merge</a> instead.</strong>
+    class: warning
   - tool_id: toolshed.g2.bx.psu.edu/repos/devteam/ncbi_blast_plus/ncbi_blastp_wrapper
     message: >
       <strong>We recommend using


### PR DESCRIPTION
The recommended tool now is `toolshed.g2.bx.psu.edu/repos/iuc/samtools_merge/samtools_merge`.

Closes https://github.com/usegalaxy-eu/issues/issues/932.