### PR TITLE
Update resources for 3dtrees_raycloudtools

### DIFF
--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -269,7 +269,7 @@ tools:
 
   toolshed.g2.bx.psu.edu/repos/bgruening/3dtrees_raycloudtools/3dtrees_raycloudtools/.*:
     # Devereux et al., 2026 (DOI: 10.1016/j.rse.2025.115162): 28 cores, 128 GB
-    cores: min((input_size * 2 // 1 + 1), 28)
+    cores: min(int(input_size * 2 // 1 + 1), 28)
     mem: min(19 + (input_size * 8.5 // 1 + 1), 128)
 
   toolshed.g2.bx.psu.edu/repos/bgruening/3dtrees_segmentanytree/3dtrees_segmentanytree/.*:

--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -268,8 +268,9 @@ tools:
     mem: 20
 
   toolshed.g2.bx.psu.edu/repos/bgruening/3dtrees_raycloudtools/3dtrees_raycloudtools/.*:
-    cores: 10
-    mem: 20
+    # Devereux et al., 2026 (DOI: 10.1016/j.rse.2025.115162): 28 cores, 128 GB
+    cores: 28
+    mem: min(19 + (input_size * 8.5 // 1 + 1), 128)
 
   toolshed.g2.bx.psu.edu/repos/bgruening/3dtrees_segmentanytree/3dtrees_segmentanytree/.*:
     gpus: 1

--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -269,7 +269,7 @@ tools:
 
   toolshed.g2.bx.psu.edu/repos/bgruening/3dtrees_raycloudtools/3dtrees_raycloudtools/.*:
     # Devereux et al., 2026 (DOI: 10.1016/j.rse.2025.115162): 28 cores, 128 GB
-    cores: 28
+    cores: min((input_size * 2 // 1 + 1), 28)
     mem: min(19 + (input_size * 8.5 // 1 + 1), 128)
 
   toolshed.g2.bx.psu.edu/repos/bgruening/3dtrees_segmentanytree/3dtrees_segmentanytree/.*:


### PR DESCRIPTION
This PR updates the requested resources for bgruening/3dtrees_raycloudtools following [Devereux et al. (2026)](https://doi.org/10.1016/j.rse.2025.115162), who used 28 cores and 128 GB RAM. It implements dynamic memory scaling between 20-128 GB depending on input size.