### PR TITLE
add memory and cpu limit for flexynesis

### DIFF
--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -794,8 +794,13 @@ tools:
         - singularity  # can be removed after closing https://github.com/usegalaxy-eu/issues/issues/928
 
   toolshed.g2.bx.psu.edu/repos/bgruening/flexynesis/flexynesis/.*:
-    cores: 4
-    mem: 100
+    rules:
+      - id: flexynesis_gnn_high_mem
+        if: |
+          params = job.get_param_values(app)
+          params.get('training_type', {}).get('model_class', {}).get('model_class') == 'GNN'
+        cores: 4
+        mem: 100
 
   toolshed.g2.bx.psu.edu/repos/genouest/helixer/helixer/.*:
     params:

--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -793,6 +793,10 @@ tools:
       require:
         - singularity  # can be removed after closing https://github.com/usegalaxy-eu/issues/issues/928
 
+  toolshed.g2.bx.psu.edu/repos/bgruening/flexynesis/flexynesis/.*:
+    cores: 4
+    mem: 100
+
   toolshed.g2.bx.psu.edu/repos/genouest/helixer/helixer/.*:
     params:
       docker_run_extra_arguments: --user 999


### PR DESCRIPTION
With big network files as input, Flexynesis fails because of low memory. I'll bump the memory for the tool to fix it.