### PR TITLE
submit the email to the ufz pulsar

### DIFF
--- a/files/galaxy/tpv/destinations.yml.j2
+++ b/files/galaxy/tpv/destinations.yml.j2
@@ -445,7 +445,7 @@ destinations:
       jobs_directory: /work/songalax/pulsar-eu/staging
       persistence_directory: /work/songalax/pulsar-eu/persisted_data
       tool_dependency_dir: /data/galaxy_server/pulsar/deps
-      submit_user: $__user_name__
+      submit_user: $__user_email__
       submit_native_specification: "--qos=galaxy -p galaxy -t 24:00:00 --cpus-per-task={int(cores)} --mem-per-cpu={int(mem/cores)}"
     scheduling:
       require:


### PR DESCRIPTION
My idea would be to test this with https://github.com/galaxyproject/pulsar/pull/451 on out side. 

No idea if `__user_email__` really works, but it appears in the same dict in the Galaxy code where `__user_name__` can be found. 

Alternatively we could hardcode my email for a test. 