### PR TITLE
Comment out Tailscale role in celery.yml

### DIFF
--- a/celery.yml
+++ b/celery.yml
@@ -72,8 +72,7 @@
             mode: "0644"
   roles:
     - geerlingguy.repo-epel
-    - role: artis3n.tailscale  # broken (invalid API key)
-      when: celerycluster_is_main_node  # mitigates breakage (doesn't fail on the main node)
+    # - artis3n.tailscale  # broken (invalid API key)
     - role: usegalaxy_eu.handy.os_setup
       vars:
         enable_remap_user: true


### PR DESCRIPTION
Comment out Tailscale role to work around a missing API key error `fatal: [celery-1.bi.privat]: FAILED! => {"changed": false, "msg": ["backend error: invalid key: API key does not exist"]}`.

@gsaudade99 I want to have Celery up, then we can look into the issue.