### PR TITLE
Omit installation of Ansible in the Celery cluster

### DIFF
--- a/group_vars/celerycluster.yml
+++ b/group_vars/celerycluster.yml
@@ -84,3 +84,9 @@ lp_logrotate_confd:
           /usr/bin/systemctl reload rsyslog >/dev/null 2>&1 || true
         endscript
       }
+
+# (handy.os_setup)
+software_groups_to_install:
+  - admin
+  - editors
+  - utils


### PR DESCRIPTION
Role `handy.os_setup` installs Ansible (the only package in the `configuration group) by default because it installs the `admin`, `configuration`, `editors` and `utils` groups by default.

As quick fix to have Celery running (specially Celery Beat), disable the `admin` group.