### PR TITLE
update handy version

### DIFF
--- a/requirements.yaml
+++ b/requirements.yaml
@@ -41,7 +41,7 @@ collections:
     source: https://galaxy.ansible.com
     type: galaxy
   - name: usegalaxy_eu.handy
-    version: 3.1.1
+    version: 3.3.0
     source: https://galaxy.ansible.com
   - name: ansible.windows
     version: 1.14.0


### PR DESCRIPTION
This should not affect any functionality. Check the comparison between the two versions here and I need the el10 support for Beacon migration 

https://github.com/usegalaxy-eu/ansible-collection-handy/compare/3.1.1...3.3.0