### PR TITLE
patch converter tool

### DIFF
--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -91,6 +91,9 @@ tools:
     env:
       TEMP: /data/1/galaxy_db/tmp
 
+  CONVERTER_gff_to_bed_0:
+    inherits: _basic_internal_tool
+
   toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_replace_in_line/*:
     env:
       - name: SINGULARITYENV_LC_ALL


### PR DESCRIPTION
```
  File "/opt/galaxy/server/lib/galaxy/datatypes/converters/gff_to_bed_converter.py", line 27
    out.write(f"{elems[0]}\t{start}\t{elems[4]}\t{name}\t0\t{strand}\n")
                                                                      ^
SyntaxError: invalid syntax
```

This is because the tool was running with the legacy container with an older version of python. We can either run it as an internal tool or add a specific container with python > 3.6. 

This patch is live and working (: 