### PR TITLE
Change beacon uid

### DIFF
--- a/group_vars/beacon/vars.yml
+++ b/group_vars/beacon/vars.yml
@@ -11,8 +11,8 @@ script_dir: /home/beacon/script
 galaxy_api_url: https://usegalaxy.eu
 handy_groups:
   - group_name: beacon
-    group_gid: 999
+    group_gid: 1001
 handy_users:
   - user_name: beacon
-    user_uid: 999
+    user_uid: 1001
     user_group: beacon

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -143,7 +143,8 @@ roles:
   - name: geerlingguy.pip
     version: 2.2.0
   - name: paprikant.beacon
-    src: https://github.com/Paprikant/ansible-role-beacon
+    src: https://github.com/gsaudade99/ansible-role-beacon/
+    version: 2639596e9c0af8084272e60579ccddeb5a411bbf
   - name: paprikant.beacon-importer
     src: https://github.com/Paprikant/ansible-role-beacon_importer
   - name: galaxyproject.miniconda


### PR DESCRIPTION
I run the playbook with the two changes in the roles bellow and it seems to be working in rocky 10:

```
root@beacon:~$ docker ps
CONTAINER ID   IMAGE                        COMMAND                  CREATED             STATUS             PORTS                    NAMES
74fde3be569b   cscfi/beacon-python:v1.9.1   "/bin/sh -c /app/app…"   About an hour ago   Up About an hour   0.0.0.0:80->5050/tcp     beacon-python
a086ef058160   postgres:13                  "docker-entrypoint.s…"   About an hour ago   Up About an hour   0.0.0.0:8080->5432/tcp   beacon-python-db
root@beacon:~$ curl http://beacon.bi.privat
{"id": "privat.bi.beacon", "name": "GA4GH Beacon at usegalaxy.eu", "apiVersion": "1.1.0", "organization": {"id": "usegalaxy.eu", "name": "Galaxy Europe", "description": "European Galaxy community", "address": "Georges-K\u00f6hler-Allee 79, 79110 Freiburg im Breisgau", "welcomeUrl": "https://galaxyproject.org/eu/", "contactUrl": "https://usegalaxy-eu.github.io/freiburg/people.html", "logoUrl": "https://galaxyproject.org/images/galaxy-logos/galaxy_project_logo_square.png", "info": {"orgInfo": "The European Galaxy server UseGalaxy.eu is maintained primarily by the Freiburg Galaxy Team in collaboration with other academic groups across Europe and with the US Galaxy team."}}, "description": "Beacon service hosting datastes from all over the usegalaxy.eu instance", "version": "1.8.0", "welcomeUrl": "https://usegalaxy.eu/beacon/", "alternativeUrl": "", "createDateTime": "2022-11-16T00:00:00Z\n1C", "updateDateTime": "2026-05-08T13:47:22Z", "datasets": [], "sampleAlleleRequests": [{"alternateBases": "G", "referenceBases": "A", "referenceName": "MT", "start": 14036, "assemblyId": "GRCh38", "includeDatasetResponses": "ALL"}, {"variantType": "DUP", "referenceBases": "C", "referenceName": "19", "start": 36909436, "assemblyId": "GRCh38", "datasetIds": ["urn:hg:1000genome"], "includeDatasetResponses": "HIT"}, {"variantType": "INS", "referenceBases": "C", "referenceName": "1", "start": 104431389, "assemblyId": "GRCh38"}], "info": {"achievement": "World's first 1.0 Beacon"}}
```

(The response is the same as the original beacon )

xref: https://github.com/usegalaxy-eu/ansible-role-beacon_importer/pull/3
xref: https://github.com/Paprikant/ansible-role-beacon/pull/4


