### PR TITLE
Temporarily add Tailscale node IPv4 to Celery cluster config

### DIFF
--- a/celery.yml
+++ b/celery.yml
@@ -2,6 +2,7 @@
 - name: Celery cluster
   vars:
     celerycluster_ansible_group: celerycluster
+    tailscale_node_ipv4: "100.111.134.66"
   hosts: "{{ celerycluster_ansible_group }}"
   gather_facts: true
   become: true


### PR DESCRIPTION
addition/fix to https://github.com/usegalaxy-eu/infrastructure-playbook/pull/2040