### PR TITLE
Install python3-docker with pip

### DIFF
--- a/influxdb.yml
+++ b/influxdb.yml
@@ -37,7 +37,8 @@
       ansible.builtin.pip:
         name: docker
         version: 7.1.0
-        break_system_packages: true
+        # needed for ansible-core >= 2.17
+        # break_system_packages: true
   handlers:
     - name: Reload Firewalld
       listen: copied_service

--- a/influxdb.yml
+++ b/influxdb.yml
@@ -11,7 +11,7 @@
     - name: Install Dependencies
       become: true
       ansible.builtin.package:
-        name: ['python3-virtualenv', 'python3-docker']
+        name: ['python3-virtualenv']
     - name: Configure SELinux
       ansible.posix.seboolean:
         name: "{{ item }}"
@@ -33,6 +33,11 @@
         owner: root
         group: root
       notify: copied_service
+    - name: Install docker with pip
+      ansible.builtin.pip:
+        name: docker
+        version: 7.1.0
+        break_system_packages: true
   handlers:
     - name: Reload Firewalld
       listen: copied_service


### PR DESCRIPTION
There is no EPEL package at the moment, so I move this to pip install even though "break_system_packages" is not nice to read, but with a pinned version it should be safe.