### PR TITLE
Disable user remapping on influx, 999 is free

### DIFF
--- a/influxdb.yml
+++ b/influxdb.yml
@@ -56,7 +56,7 @@
       vars:
         enable_hostname: true
         enable_powertools: true        # geerlingguy.repo-epel role doesn't enable PowerTools repository
-        enable_remap_user: true
+        # enable_remap_user: true
         enable_create_user: true
     - geerlingguy.repo-epel     # Install EPEL repository
     - usegalaxy-eu.autoupdates  # keep all of our packages up to date

--- a/influxdb.yml
+++ b/influxdb.yml
@@ -55,11 +55,6 @@
     - role: usegalaxy_eu.handy.os_setup
       vars:
         enable_hostname: true
-        enable_powertools: true        # geerlingguy.repo-epel role doesn't enable PowerTools repository
-        # enable_remap_user: true
-        enable_create_user: true
-    - geerlingguy.repo-epel     # Install EPEL repository
-    - usegalaxy-eu.autoupdates  # keep all of our packages up to date
     - influxdata.chrony         # Keep our time in sync.
     - usegalaxy-eu.dynmotd
     - hxr.monitor-email


### PR DESCRIPTION
Sorry for the multiple PRs
We should fix the handy-os role later.