### PR TITLE
⚠️ HTCondor 25 Central Manager upgrade

### DIFF
--- a/group_vars/htcondor-manager.yml
+++ b/group_vars/htcondor-manager.yml
@@ -1,3 +1,5 @@
 # Configure the HTCondor central manager node.
 ---
 htcondor_role_manager: true
+htcondor_version: 25.0
+htcondor_channel: 25.0

--- a/group_vars/htcondor/vars.yml
+++ b/group_vars/htcondor/vars.yml
@@ -4,8 +4,8 @@ htcondor_server: "build.galaxyproject.eu"
 htcondor_domain: bi.uni-freiburg.de
 htcondor_server_port: 9628
 htcondor_shared_port: 9628
-htcondor_version: 23.0
-htcondor_channel: 23.0
+htcondor_version: 25.0
+htcondor_channel: 25.0
 htcondor_firewall_condor: false
 htcondor_firewall_nfs: false
 htcondor_role_execute: false
@@ -14,7 +14,7 @@ htcondor_role_submit: false
 htcondor_password: "{{ vault_htcondor_password }}"
 
 # Settings specific to the `condor_config.local.j2` configuration file.
-htcondor_allow_write: "10.5.67.0/24,10.5.68.0/24,132.230.223.0/24,132.230.153.0/28,10.4.68.0/24"
+htcondor_allow_write: "10.4.67.0/24"
 htcondor_allow_negotiator: "{{ ansible_default_ipv4.address | default(ansible_all_ipv4_addresses[0]) }},$(CONDOR_HOST),$(ALLOW_WRITE)"
 htcondor_allow_administrator: "$(ALLOW_NEGOTIATOR)"
 htcondor_system_periodic_hold: "{{ 30 * 24 * 60 * 60 }}"

--- a/group_vars/htcondor/vars.yml
+++ b/group_vars/htcondor/vars.yml
@@ -14,7 +14,7 @@ htcondor_role_submit: false
 htcondor_password: "{{ vault_htcondor_password }}"
 
 # Settings specific to the `condor_config.local.j2` configuration file.
-htcondor_allow_write: "10.4.67.0/24"
+htcondor_allow_write: "10.4.68.0/24"
 htcondor_allow_negotiator: "{{ ansible_default_ipv4.address | default(ansible_all_ipv4_addresses[0]) }},$(CONDOR_HOST),$(ALLOW_WRITE)"
 htcondor_allow_administrator: "$(ALLOW_NEGOTIATOR)"
 htcondor_system_periodic_hold: "{{ 30 * 24 * 60 * 60 }}"

--- a/group_vars/htcondor/vars.yml
+++ b/group_vars/htcondor/vars.yml
@@ -4,8 +4,8 @@ htcondor_server: "build.galaxyproject.eu"
 htcondor_domain: bi.uni-freiburg.de
 htcondor_server_port: 9628
 htcondor_shared_port: 9628
-htcondor_version: 25.0
-htcondor_channel: 25.0
+htcondor_version: 23.0
+htcondor_channel: 23.0
 htcondor_firewall_condor: false
 htcondor_firewall_nfs: false
 htcondor_role_execute: false

--- a/hosts
+++ b/hosts
@@ -69,7 +69,7 @@ htcondor-manager
 htcondor-submit
 
 [htcondor-manager]
-sn12.galaxyproject.eu ansible_ssh_user=root
+central-manager.bi.privat ansible_ssh_user=root
 
 [htcondor-manager:vars]
 ansible_group_priority=4

--- a/hosts
+++ b/hosts
@@ -69,7 +69,7 @@ htcondor-manager
 htcondor-submit
 
 [htcondor-manager]
-build.galaxyproject.eu ansible_ssh_user=root
+sn12.galaxyproject.eu ansible_ssh_user=root
 
 [htcondor-manager:vars]
 ansible_group_priority=4

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -112,7 +112,7 @@ roles:
     version: 1.0.1
   - name: grycap.htcondor
     src: https://github.com/usegalaxy-eu/ansible-htcondor-grycap
-    version: d9a4aab0052dfb31d48c986d39a7f5e3692abba4
+    version: 33ea3aafd9c5d33a1063534e0604631696c052f9
   - name: usegalaxy-eu.update-hosts
     src: https://github.com/usegalaxy-eu/ansible-update-hosts
     version: 0.4.0


### PR DESCRIPTION
We can use the ci to install/upgrade htcondor 25. I'm not 100% sure that the role will handle the upgrade flawlessly - thats why we are backing up. What can happen is that we need to remove the old condor repo from yum and then run the playbook.  