### PR TITLE
Use `influxdb.bi.privat` as inventory hostname for InfluxDB host

### DIFF
--- a/hosts
+++ b/hosts
@@ -13,7 +13,7 @@ worker-0.bronze.build.galaxyproject.eu
 beacon.bi.privat ansible_ssh_user=root
 
 [influxdb]
-influxdb.galaxyproject.eu ansible_host=influxdb.bi.privat
+influxdb.bi.privat
 
 [mq]
 mq02.galaxyproject.eu


### PR DESCRIPTION
Use together with https://github.com/usegalaxy-eu/ansible-influxdb-container/pull/10. ~~Can be merged immediately because the playbook is already broken anyways.~~ No, let's better wait for the new release and add a commit to use the upgraded role.
