### PR TITLE
add gpu for flexynesis when using GNN

### DIFF
--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -804,8 +804,9 @@ tools:
         if: |
           params = job.get_param_values(app)
           params.get('training_type', {}).get('model_class', {}).get('model_class') == 'GNN'
-        cores: 4
+        cores: 20
         mem: 100
+        gpus: 1
 
   toolshed.g2.bx.psu.edu/repos/genouest/helixer/helixer/.*:
     params:


### PR DESCRIPTION
GNN should run on GPU, not CPU, as discussed [here](https://github.com/BIMSBbioinfo/flexynesis/issues/145)