### PR TITLE
update flexynesis rule

### DIFF
--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -802,8 +802,12 @@ tools:
     rules:
       - id: flexynesis_gnn_high_mem
         if: |
-          params = job.get_param_values(app)
-          params.get('training_type', {}).get('model_class', {}).get('model_class') == 'GNN'
+          retval = False
+          options = job.get_param_values(app)
+          training_type = options.get('training_type', {})
+          if isinstance(training_type, dict):
+            retval = training_type.get('model_class', {}).get('model_class') == 'GNN'
+          retval
         cores: 20
         mem: 100
         gpus: 1

--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -805,7 +805,7 @@ tools:
           retval = False
           options = job.get_param_values(app)
           training_type = options.get('training_type', {})
-          if isinstance(training_type, dict):
+          if training_type and isinstance(training_type, dict):
             retval = training_type.get('model_class', {}).get('model_class') == 'GNN'
           retval
         cores: 20


### PR DESCRIPTION
After setting the rule for flexynesis, it got failed for `unsupervised` and `crossmodal` types. The problem was that when `training_type` is `unsupervised` or `crossmodal`, params.get('training_type', {}) returns a string ("unsupervised"), not a dict.
Calling .get('model_class', {}) on a string raises AttributeError: 'str' object has no attribute 'get'.

I tried to use an if statement like the one for baker tool so this only triggers if training_type is a dict.