### PR TITLE
Allow the BI RNA server access to Condor

### DIFF
--- a/group_vars/htcondor/vars.yml
+++ b/group_vars/htcondor/vars.yml
@@ -14,7 +14,7 @@ htcondor_role_submit: false
 htcondor_password: "{{ vault_htcondor_password }}"
 
 # Settings specific to the `condor_config.local.j2` configuration file.
-htcondor_allow_write: "10.4.68.0/24"
+htcondor_allow_write: "10.4.68.0/24,132.230.153.0/28"
 htcondor_allow_negotiator: "{{ ansible_default_ipv4.address | default(ansible_all_ipv4_addresses[0]) }},$(CONDOR_HOST),$(ALLOW_WRITE)"
 htcondor_allow_administrator: "$(ALLOW_NEGOTIATOR)"
 htcondor_system_periodic_hold: "{{ 30 * 24 * 60 * 60 }}"


### PR DESCRIPTION
The BI RNA server needs access to Condor to be able to submit jobs; this PR adds the servers subnet to the `ALLOW_WRITE` macro. (Note that `/28` is intentional, we don't want to allow the entire 132.230.153.0 network.)