### PR TITLE
Automatically restart `gunicorn` workers periodically

### DIFF
--- a/group_vars/sn09/sn09.yml
+++ b/group_vars/sn09/sn09.yml
@@ -238,6 +238,9 @@ galaxy_systemd_memory_limit: 35
 galaxy_systemd_memory_limit_handler: 40
 galaxy_systemd_memory_limit_workflow: 15
 
+galaxy_systemd_gunicorn_max_requests: 25920000  # 24h assuming 300 Requests per second
+galaxy_systemd_gunicorn_max_requests_jitter: 3240000  # 3h assuming 300 Requests per second
+
 # gie_proxy
 gie_proxy_dir: '{{ galaxy_root }}/gie-proxy/proxy'
 gie_proxy_git_version: v0.1.0


### PR DESCRIPTION
Configure `galaxy_systemd_gunicorn_max_requests` and `galaxy_systemd_gunicorn_max_requests_jitter` to restart `gunicorn` workers automatically every 25920000 requests (24h assuming 300 requests per second) with a jitter of 3240000 requests (3h assuming 300 requests per second).

Note that `systemd` does the job of restarting each `galaxy-gunicorn` systemd unit (there are as many units as `galaxy_systemd_gunicorns`) if the memory limit is reached. This setting restart individual workers (each unit is spawning `galaxy_systemd_gunicorn_workers` workers within it).

If there is a slow memory leak, this setting should keep it under control. I do not expect it to be useful if the memory leak is large and sudden though.

The motivation behind this commit is the fact that since [334fb0046878cc631e60fbc5a471888fac256a73](https://github.com/usegalaxy-eu/infrastructure-playbook/pull/2084) gunicorn workers are no longer restarted daily.