### PR TITLE
Bump usegalaxy_eu.influxdbserver version to 2.0.0

### DIFF
--- a/requirements.yaml
+++ b/requirements.yaml
@@ -129,7 +129,7 @@ roles:
   - name: usegalaxy_eu.rabbitmqserver
     version: 1.5.0
   - name: usegalaxy_eu.influxdbserver
-    version: 1.2.0
+    version: 2.0.0
   - name: usegalaxy_eu.flower
     version: 2.1.1
   - name: usegalaxy_eu.walle


### PR DESCRIPTION
Meant to address ongoing issues with the InfluxDB playbook.