### PR TITLE
Set `influxdb_hostname` to `{{ hostname }}` for InfluxDB node

### DIFF
--- a/group_vars/influxdb.yml
+++ b/group_vars/influxdb.yml
@@ -1,10 +1,14 @@
 ---
+hostname: influxdb.galaxyproject.eu
+
 swap_file_size_mb: '5120'
 swap_file_path: /data/swapfile
 
 docker_users:
   - centos
+
 # influxdb
+influxdb_hostname: "{{ hostname }}"
 influxdb_https_enabled: "true"
 
 influxdb_users:

--- a/influxdb.yml
+++ b/influxdb.yml
@@ -2,8 +2,6 @@
 - hosts: influxdb
   name: InfluxDB
   become: true
-  vars:
-    hostname: influxdb.galaxyproject.eu
   vars_files:
     - "secret_group_vars/all.yml"
     - secret_group_vars/aws.yml # AWS creds


### PR DESCRIPTION
Since version 2.0.0, the InfluxDB role `usegalaxy_eu.influxdbserver` uses the variable `influxdb_hostname` to configure InfluxDB via HTTPS requests.

This change, combined with having set `influxdb.bi.privat` as inventory hostname for the InfluxDB host (see #2075) breaks the InfluxDB playbook, because there are no SSL certs available for `influxdb.bi.privat`.

Setting `influxdb_hostname: "{{ hostname }}"` reverts it to influxdb.galaxyproject.eu, which has an SSL certificate and hopefully fixes the playbook.