### PR TITLE
Restrict SSL cert sharing between InfluxDB host and container

### DIFF
--- a/group_vars/influxdb.yml
+++ b/group_vars/influxdb.yml
@@ -22,8 +22,8 @@ influxdb_data_dir: /data/monitoring/influxdb_data
 influxdb_container_standalone_setup_details:
   volumes:
     - "{{ influxdb_data_dir }}:/var/lib/influxdb"
-    - "/etc/pki/tls/certs:/etc/ssl/certs/"
-    - "/etc/ssl/user:/etc/ssl/user"
+    - "/etc/pki/tls/certs:/etc/ssl/user/influxdb/public/"
+    - "/etc/ssl/user:/etc/ssl/user/influxdb/private/"
   ports:
     - 8086:8086
   env:
@@ -31,8 +31,8 @@ influxdb_container_standalone_setup_details:
       'INFLUXDB_HTTP_AUTH_ENABLED': "true",
       'INFLUXDB_HTTP_ENABLED': "true",
       'INFLUXDB_HTTP_HTTPS_ENABLED': "{{ influxdb_https_enabled }}",
-      'INFLUXDB_HTTP_HTTPS_CERTIFICATE': "/etc/ssl/certs/fullchain.pem",
-      'INFLUXDB_HTTP_HTTPS_PRIVATE_KEY': "/etc/ssl/user/privkey-influxdb.pem",
+      'INFLUXDB_HTTP_HTTPS_CERTIFICATE': "/etc/ssl/user/influxdb/public/fullchain.pem",
+      'INFLUXDB_HTTP_HTTPS_PRIVATE_KEY': "/etc/ssl/user/influxdb/private/privkey-influxdb.pem",
       'INFLUXDB_HTTP_LOG_ENABLED': "false",
       'INFLUXDB_DATA_INDEX_VERSION': "tsi1",
       'INFLUXDB_DATA_CACHE_MAX_MEMORY_SYZE': '1048576000',


### PR DESCRIPTION
Share just the Let's Encrypt cert obtained by Certbot (rather than whole cert directories).

This change should hopefully fix the following problem.

```shell
...
10:24:36 TASK [usegalaxy_eu.influxdbserver : Check need to create admin] ****************
10:24:37 fatal: [influxdb.bi.privat]: FAILED! => {"changed": true, "rc": 1, "stderr": "Failed to connect to https://influxdb.galaxyproject.eu:8086: Get https://influxdb.galaxyproject.eu:8086/ping: x509: certificate signed by unknown authority\nPlease check your connection settings and ensure 'influxd' is running.", "stderr_lines": ["Failed to connect to https://influxdb.galaxyproject.eu:8086: Get https://influxdb.galaxyproject.eu:8086/ping: x509: certificate signed by unknown authority", "Please check your connection settings and ensure 'influxd' is running."], "stdout": "", "stdout_lines": []}
...
```