### PR TITLE
[URGENT] Use private DNS for upload node

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ known_hosts:
 	grep --quiet '^worker-0.gold.build.galaxyproject.eu' ~/.ssh/known_hosts || echo "worker-0.gold.build.galaxyproject.eu ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAjC0YY4V6gDjvIyFb1qyszQn+Jr2GtLImSJO5BVoeHq" >> ~/.ssh/known_hosts
 	grep --quiet '^worker-0.bronze.build.galaxyproject.eu' ~/.ssh/known_hosts || echo "worker-0.bronze.build.galaxyproject.eu ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKE2VMZbiOf4NHTVyNj9FyCu2P71YF/RHHO97lrsPC46" >> ~/.ssh/known_hosts
 	grep --quiet '^beacon.bi.privat' ~/.ssh/known_hosts || echo "beacon.bi.privat ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJLhLsIO61hj8Kk6VQWTq5JU+PRm5/so1k44yZQTwvVO" >> ~/.ssh/known_hosts
-	grep --quiet '^upload.galaxyproject.eu' ~/.ssh/known_hosts || echo "upload.galaxyproject.eu ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHMz9KPAC6tZwxoBE0tcqDVA29mPtE3K+so9MYGsNkNU" >> ~/.ssh/known_hosts
+	grep --quiet '^upload.bi.privat' ~/.ssh/known_hosts || echo "upload.bi.privat ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHMz9KPAC6tZwxoBE0tcqDVA29mPtE3K+so9MYGsNkNU" >> ~/.ssh/known_hosts
 	grep --quiet '^sn10.galaxyproject.eu' ~/.ssh/known_hosts || echo "sn10.galaxyproject.eu ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC49py5wws/7FhAfRDRS8byDMbSaqxNj3ddigSoXJM/y" >> ~/.ssh/known_hosts
 	grep --quiet '^central-manager.bi.privat' ~/.ssh/known_hosts || echo "central-manager.bi.privat ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMoOla00b8+03VlVu9TOHJbij41jFILenJ2zWHsZE8fh" >> ~/.ssh/known_hosts
 	grep --quiet '^sn12.galaxyproject.eu' ~/.ssh/known_hosts || echo "sn12.galaxyproject.eu ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMoOla00b8+03VlVu9TOHJbij41jFILenJ2zWHsZE8fh" >> ~/.ssh/known_hosts

--- a/hosts
+++ b/hosts
@@ -22,7 +22,7 @@ mq.bi.privat
 incoming.galaxyproject.eu
 
 [upload]
-upload.galaxyproject.eu
+upload.bi.privat
 
 [proxy]
 proxy.galaxyproject.eu

--- a/templates/nginx/galaxy-main.j2
+++ b/templates/nginx/galaxy-main.j2
@@ -173,7 +173,7 @@ server {
         proxy_set_header         Upgrade $http_upgrade;
         proxy_set_header         Connection "upgrade";
         client_max_body_size     0;
-        proxy_pass http://upload.galaxyproject.eu:1081/api/upload/resumable_upload;
+        proxy_pass http://upload.bi.privat:1081/api/upload/resumable_upload;
     }
 
     location /phinch {


### PR DESCRIPTION
`upload.galaxyproject.eu` is no longer operational. Switch to `upload.bi.privat`.

**Why urgent?** There is an NGINX `proxy_pass` directive pointing to a domain that does not exist. I think we are just lucky the TCP connection is still open and therefore uploads work.