### PR TITLE
Let Traefik use OAuth authentication for Tailscale

### DIFF
--- a/group_vars/all/tailscale.yml
+++ b/group_vars/all/tailscale.yml
@@ -1,6 +1,13 @@
+tailscale_tags_default:
+  # assigned to all hosts that connect to the Tailscale network if you want to assign
+  # extra tags to a host, append them to the default tags:
+  # `tailscale_tags: "{{ tailscale_tags_default + ['my_tag'] }}"`
+  - galaxy
+
 tailscale_args: "--accept-dns=false"
 tailscale_authkey: "{{ vault_tailscale_authkey }}"
 tailscale_oauth_ephemeral: true
 tailscale_oauth_preauthorized: true
-tailscale_tags:
-  - galaxy
+tailscale_tags: "{{ tailscale_tags_default }}"
+
+tailscale_domain: springhare-dinosaur.ts.net

--- a/group_vars/traefik.yml
+++ b/group_vars/traefik.yml
@@ -43,14 +43,11 @@ lp_logrotate_confd:
         endscript
       }
 
-tailscale_tags:
-  - "critical"
+tailscale_tags: "{{ tailscale_tags_default + ['critical'] }}"
 
 traefik_copy_rules: true
 
 traefik_domain: "{{ hostname }}"
-tailscale_domain: springhare-dinosaur.ts.net
-tailscale_authkey: "{{ tailscale_auth_key_usegalaxy_eu }}"
 
 traefik_networks:
   traefik:


### PR DESCRIPTION
Fixes the following error while running the playbook.

```
TASK [artis3n.tailscale : Tailscale Auth Key Required] *************************
fatal: [traefik.galaxyproject.eu]: FAILED! => {"msg": "The conditional check 'not tailscale_authkey' failed. The error was: error while evaluating conditional (not tailscale_authkey): {{ tailscale_auth_key_usegalaxy_eu }}: 'tailscale_auth_key_usegalaxy_eu' is undefined. 'tailscale_auth_key_usegalaxy_eu' is undefined. {{ tailscale_auth_key_usegalaxy_eu }}: 'tailscale_auth_key_usegalaxy_eu' is undefined. 'tailscale_auth_key_usegalaxy_eu' is undefined\n\nThe error appears to be in '/scratch/workspace/usegalaxy-eu/playbooks/traefik/roles/artis3n.tailscale/tasks/main.yml': line 10, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Tailscale Auth Key Required\n  ^ here\n"}
```