### PR TITLE
Remove `critical` Tailscale tag from Traefik node

### DIFF
--- a/group_vars/traefik.yml
+++ b/group_vars/traefik.yml
@@ -43,8 +43,6 @@ lp_logrotate_confd:
         endscript
       }
 
-tailscale_tags: "{{ tailscale_tags_default + ['critical'] }}"
-
 traefik_copy_rules: true
 
 traefik_domain: "{{ hostname }}"


### PR DESCRIPTION
Tag `galaxy` scoped to the global OAuth key introduced in 6fb89fd plays the same role as `critical` now, i.e. all infrastructure nodes use the `galaxy` tag, it is linked to the OAuth key.

The access control rule on the Tailscale admin panel has been already switched from `critical` to `galaxy`.