### PR TITLE
Update galaxy_themes_welcome_url_prefix value

### DIFF
--- a/group_vars/sn09/sn09.yml
+++ b/group_vars/sn09/sn09.yml
@@ -375,7 +375,7 @@ galaxy_config: '{{ galaxy_config_hash }}'
 # Galaxy Subdomains
 galaxy_themes_ansible_file_path: '{{ playbook_dir }}/files/galaxy/subdomains'
 galaxy_themes_default_welcome: https://galaxyproject.org/bare/eu/usegalaxy/main/
-galaxy_themes_welcome_url_prefix: https://usegalaxy-eu.github.io/index-
+galaxy_themes_welcome_url_prefix: https://galaxyproject.org/bare/eu/usegalaxy/
 
 galaxy_config_file_src_dir: files/galaxy
 galaxy_config_files:


### PR DESCRIPTION
Reverts usegalaxy-eu/infrastructure-playbook#2100. Closes https://github.com/usegalaxy-eu/issues/issues/943.

@bgruening [wrote](https://github.com/usegalaxy-eu/infrastructure-playbook/pull/2099#issue-4490208326):
> @itisAliRH is currently migrating the subdomain websites to the Hub.
>
> This means we need to serve the domains from the Hub and not from our old website.
>
> I hope this will work, if not maybe that one is to blame: https://github.com/galaxyproject/ansible-galaxy/blob/cd835d778891539934c3da3b90d9b2ed4914c86f/tasks/static_subdomain_dirs.yml#L27

@itisAliRH [wrote](https://github.com/usegalaxy-eu/infrastructure-playbook/pull/2099#issuecomment-4506803649):

> Not all pages have been migrated to the hub yet and they currently might display a 404 error. This will be completed once the issue on https://github.com/usegalaxy-eu/issues/issues/943 is closed.

⚠️ This PR is not ready to be merged unless it becomes clear from https://github.com/usegalaxy-eu/issues/issues/943 or from an approval from @itisAliRH.