### PR TITLE
UFZ pulsar: disable singularity caching

### DIFF
--- a/files/galaxy/tpv/destinations.yml.j2
+++ b/files/galaxy/tpv/destinations.yml.j2
@@ -443,12 +443,12 @@ destinations:
     max_accepted_gpus: 0
     env:
       LC_ALL: C
-      SINGULARITY_CACHEDIR: "/data/galaxy_server/pulsar_singularity_tmp/"
-      SINGULARITY_TMPDIR: "/data/galaxy_server/pulsar_singularity_cachedir/"
     params:
       jobs_directory: /work/songalax/pulsar-eu/staging
       persistence_directory: /work/songalax/pulsar-eu/persisted_data
       tool_dependency_dir: /data/galaxy_server/pulsar/deps
+      # TODO: remove once CVMFS is available / containers are synced in another way
+      singularity_run_extra_arguments: --disable-cache
       submit_user: $__user_email__
       submit_native_specification: "--qos=galaxy -p galaxy -t 24:00:00 --cpus-per-task={int(cores)} --mem-per-cpu={int(mem/cores)}"
     scheduling:


### PR DESCRIPTION
Finally found the time to check if `SINGULARITY_CACHEDIR` works in multi user setups: it does not (singularity requires really specific file and directory permissions: in particular no access for others).

So I would disable caching until we have CVMFS in place (otherwise we would need to deal with the user caches).