### PR TITLE
Make redirections to .org match with or without trailing slash and make them case-insensitive

### DIFF
--- a/templates/nginx/galaxyproject.j2
+++ b/templates/nginx/galaxyproject.j2
@@ -8,25 +8,28 @@ server {
 	location = / {
 		return 301 https://galaxyproject.org/eu/;
 	}
-	location = /freiburg/ {
+	location ~* ^/eu/? {
+		return 301 https://galaxyproject.org/eu/;
+	}
+	location ~* ^/freiburg/? {
 		return 301 https://galaxyproject.org/freiburg/;
 	}
-	location = /erasmusmc/ {
+	location ~* ^/erasmusmc/? {
 		return 301 https://galaxyproject.org/erasmusmc/;
 	}
-	location = /belgium/ {
+	location ~* ^/belgium/? {
 		return 301 https://galaxyproject.org/belgium/;
 	}
-	location = /pasteur/ {
+	location ~* ^/pasteur/? {
 		return 301 https://galaxyproject.org/pasteur/;
 	}
-	location = /genouest/ {
+	location ~* ^/genouest/? {
 		return 301 https://galaxyproject.org/genouest/;
 	}
-	location = /elixir-it/ {
+	location ~* ^/elixir-it/? {
 		return 301 https://galaxyproject.org/elixir-it/;
 	}
-	location = /ifb/ {
+	location ~* ^/ifb/? {
 		return 301 https://galaxyproject.org/ifb/;
 	}
 

--- a/templates/nginx/galaxyproject.j2
+++ b/templates/nginx/galaxyproject.j2
@@ -8,28 +8,28 @@ server {
 	location = / {
 		return 301 https://galaxyproject.org/eu/;
 	}
-	location ~* ^/eu/? {
+	location ~* ^/eu/?$ {
 		return 301 https://galaxyproject.org/eu/;
 	}
-	location ~* ^/freiburg/? {
+	location ~* ^/freiburg/?$ {
 		return 301 https://galaxyproject.org/freiburg/;
 	}
-	location ~* ^/erasmusmc/? {
+	location ~* ^/erasmusmc/?$ {
 		return 301 https://galaxyproject.org/erasmusmc/;
 	}
-	location ~* ^/belgium/? {
+	location ~* ^/belgium/?$ {
 		return 301 https://galaxyproject.org/belgium/;
 	}
-	location ~* ^/pasteur/? {
+	location ~* ^/pasteur/?$ {
 		return 301 https://galaxyproject.org/pasteur/;
 	}
-	location ~* ^/genouest/? {
+	location ~* ^/genouest/?$ {
 		return 301 https://galaxyproject.org/genouest/;
 	}
-	location ~* ^/elixir-it/? {
+	location ~* ^/elixir-it/?$ {
 		return 301 https://galaxyproject.org/elixir-it/;
 	}
-	location ~* ^/ifb/? {
+	location ~* ^/ifb/?$ {
 		return 301 https://galaxyproject.org/ifb/;
 	}
 


### PR DESCRIPTION
The main problem with the current match expressions for redirecting to .org seems to be that they do not match if the first path component is not terminated by a slash. The regexp matching introduced by this PR should fix this behaviour. In addition, an extra match clause to catch "galaxyproject.eu/eu" has been added. All the newly introduced regexp matches are case insensitive, so "EU", "Belgium" etc are also included.

**CAVEAT EMPTOR:** *These expressions have been constructed according to the nginx manual but are **completely untested***