### PR TITLE
Add service 'condor' to the FW 'internal' zone on host sn12

### DIFF
--- a/host_vars/sn12.galaxyproject.eu/vars.yml
+++ b/host_vars/sn12.galaxyproject.eu/vars.yml
@@ -14,4 +14,5 @@ firewall_ip_prefix_internal:
   - 10.126.0.0/16
 firewall_internal_services:
   - ssh
+  - condor
 firewall_public_services: []


### PR DESCRIPTION
The BI RNA server needs this; [this earlier PR](https://github.com/usegalaxy-eu/infrastructure-playbook/pull/2083) has turned out to be incomplete. Ideally, we would allow SSH to `132.230.153.0/25` and Condor to `132.230.153.0/28` only, but firewalld would require additional direct or rich rules *plus* removing /25 from the `internal` zone to accomplish that. This fix is much easier and does not give away much (Condor still has its internal, token-based access protections).