### PR TITLE
Revert "rm default cleanup of 60 days"

### DIFF
--- a/group_vars/maintenance.yml
+++ b/group_vars/maintenance.yml
@@ -162,6 +162,16 @@ fsm_cron_tasks:
     dow: "*"
     job: "docker system prune -f --all> /dev/null"
     user: "{{ fsm_galaxy_user.username }}"
+  gxadmin:
+    enable: true
+    name: "Gxadmin Galaxy clean up"
+    minute: 0
+    hour: "*/6"
+    dom: "*"
+    month: "*"
+    dow: "*"
+    job: "/usr/bin/gxadmin galaxy cleanup 60"
+    user: "{{ fsm_galaxy_user.username }}"
 fsm_htcondor_enable: true
 
 # Role: dj-wasabi.telegraf

--- a/group_vars/sn09/sn09.yml
+++ b/group_vars/sn09/sn09.yml
@@ -70,6 +70,16 @@ fsm_cron_tasks:
     dow: '*'
     job: '. {{ galaxy_root }}/.bashrc && docker system prune -f --all> /dev/null'
     user: '{{ fsm_galaxy_user.username }}'
+  gxadmin:
+    enable: false
+    name: 'Gxadmin Galaxy clean up'
+    minute: 0
+    hour: 0
+    dom: '*/2'
+    month: '*'
+    dow: '*'
+    job: '{{ custom_telegraf_env }} /usr/bin/gxadmin galaxy cleanup 60'
+    user: '{{ fsm_galaxy_user.username }}'
 
 # Telegraf
 telegraf_agent_hostname: '{{ hostname }}'


### PR DESCRIPTION
Reverts usegalaxy-eu/infrastructure-playbook#1981

We need to rethink this. We need this cleanup, but maybe then for each object-store separately. 

The underlying scripts like `/opt/galaxy/server/scripts/cleanup_datasets/cleanup_datasets.py --config /opt/galaxy/config/galaxy.yml -1 -r -d 60` needs to be executed, otherwise orphaned histories and users are never deleted, which in turn means the associated datasets are never deleted/purged etc ...

This PR should not be merged as it is, its more a todo task.
