### PR TITLE
Add service that makes NFS mount /netboot a requirement

### DIFF
--- a/dnbd3.yml
+++ b/dnbd3.yml
@@ -35,6 +35,34 @@
         target: '{{ dnbd3_base_path }}/http(/.*)?'
         setype: httpd_sys_rw_content_t
         state: present
+    - name: Make autofs RequiredBy tftp, httpd, dnbd3
+      ansible.builtin.copy:
+        content: |
+          [Unit]
+          Description=Make sure services that depend on autofs only start once it is up
+          Requires=autofs.service
+          After=autofs.service
+          Before=tftp.service
+          Before=dnbd3-server.service
+          Before=httpd.service
+          StartLimitInterval=200
+          StartLimitBurst=5
+          [Service]
+          Restart=always
+          RestartSec=15
+          Type=oneshot
+          ExecStart=/bin/ls "{{ dnbd3_base_path }}"
+          [Install]
+          RequiredBy=tftp.service
+          RequiredBy=dnbd3-server.service
+          RequiredBy=httpd.service
+        dest: /etc/systemd/system/require-autofs.service
+    - name: Enable the service
+      ansible.builtin.systemd_service:
+        daemon_reload: true
+        state: started
+        enabled: true
+        name: require-autofs.service
 
   roles:
     - usegalaxy-eu.dynmotd

--- a/dnbd3.yml
+++ b/dnbd3.yml
@@ -42,10 +42,8 @@
           Description=Make sure services that depend on autofs only start once it is up
           Requires=autofs.service
           After=autofs.service
-          Before=tftp.service
-          Before=dnbd3-server.service
-          Before=httpd.service
-          StartLimitInterval=200
+          Before=tftp.service dnbd3-server.service httpd.service
+          StartLimitIntervalSec=200
           StartLimitBurst=5
           [Service]
           Restart=always
@@ -53,9 +51,7 @@
           Type=oneshot
           ExecStart=/bin/ls "{{ dnbd3_base_path }}"
           [Install]
-          RequiredBy=tftp.service
-          RequiredBy=dnbd3-server.service
-          RequiredBy=httpd.service
+          RequiredBy=tftp.service dnbd3-server.service httpd.service
         dest: /etc/systemd/system/require-autofs.service
     - name: Enable the service
       ansible.builtin.systemd_service:


### PR DESCRIPTION
This should solve the issue that these NFS dependent services (dnbd3, httpd, tftp) fail to start after a reboot.
Part of: 
- https://github.com/usegalaxy-eu/issues/issues/990
