### PR TITLE
Write traefik non-access logs to stdout (Docker)

### DIFF
--- a/group_vars/traefik.yml
+++ b/group_vars/traefik.yml
@@ -100,12 +100,9 @@ traefik_containers:
       - --certificatesresolvers.route53.acme.caserver=https://acme-v02.api.letsencrypt.org/directory
       - "--certificatesresolvers.route53.acme.email={{ traefik_letsencrypt_mail }}"
       # Enable Logging
-      - "--log=true"
-      - "--log.format=json"
-      - --log.filePath={{ traefik_log_dir }}/traefik.log
       - "--log.level=INFO" # DEBUG, PANIC, FATAL, ERROR, WARN, INFO
-      - --accesslog=true
-      - --accesslog.filepath={{ traefik_log_dir }}/access.log
+      - "--accesslog=true"
+      - "--accesslog.filepath={{ traefik_log_dir }}/access.log"
     labels:
       "traefik.enable": "true"
       "traefik.http.routers.traefik.rule": "Host(`traefik.{{ tailscale_domain }}`)"


### PR DESCRIPTION
This is because logs are missing and live log observation does not work
removed the `--logs="true"` label, because there is nothing mentioning it in the v3.0 documentation
https://doc.traefik.io/traefik/v3.0/observability/logs/