### PR TITLE
Revert "disable no longer necessary crons for maintenance"

### DIFF
--- a/roles/usegalaxy-eu.fix-stuck-handlers/tasks/main.yml
+++ b/roles/usegalaxy-eu.fix-stuck-handlers/tasks/main.yml
@@ -9,5 +9,4 @@
     hour: "{{ item.hour }}"
     job: "{{ item.job }}"
     user: "{{ item.user }}"
-    disabled: true
   loop: "{{ cron_tasks }}"


### PR DESCRIPTION
Reverts usegalaxy-eu/infrastructure-playbook#2084

We just noticed that one of the handlers was up for 3 days and one tool in the toolbox was installed but the handlers didn't catch the change. I think we might be better with keeping a daily restart of the handler then... I'm not sure if this is the correct approach. For me it seems weird that Galaxy is not aware of new tools and a handler restart is needed 