### PR TITLE
Adapt file sources configuration to Galaxy 26.1 `fsspec`-based file sources

### DIFF
--- a/templates/galaxy/config/file_sources_conf.yml.j2
+++ b/templates/galaxy/config/file_sources_conf.yml.j2
@@ -4,10 +4,8 @@
   label: ERGA Nextcloud
   doc: ERGA Pilot storage provided by BSC
   writable: true
-  url: 'https://ergapilot.bsc.es'
+  base_url: 'https://ergapilot.bsc.es'
   root: '/remote.php/webdav'
-  use_temp_files: true
-  temp_path: {{ generic_tmp_dir }}
   login: "{{ erga_nextcloud_login }}"
   password: "{{ erga_nextcloud_password }}"
   requires_groups: erga
@@ -102,7 +100,6 @@
   passwd: "{{ covid_crg_ftp_staging_passwd }}"
   timeout: 10
   path: "/home/FTPvandenbeek/userspace/staging/"
-  config_path: ""
   port: 2222
 
 - type: s3fs


### PR DESCRIPTION
WebDAV file sources no longer need `use_temp_files` nor `temp_path` because the new `fsspec` implementation is based on the `webdav4` library, which doesn't store the whole files in memory before writing them like the old implementation did.

In addition, the `fsspec`-based implementation of the SSH file source won't take the `config_path` argument anymore.