### PR TITLE
Bump usegalaxy_eu.galaxy_systemd version and enable SSE monitor

### DIFF
--- a/group_vars/sn09/sn09.yml
+++ b/group_vars/sn09/sn09.yml
@@ -234,6 +234,8 @@ galaxy_systemd_gunicorn_env: '{{ apollo_env }} GALAXY_DROPBOX_APP_CLIENT_ID={{ d
 galaxy_systemd_handler_env: '{{ galaxy_systemd_gunicorn_env }}'
 galaxy_systemd_workflow_scheduler_env: '{{ galaxy_systemd_gunicorn_env }}'
 
+galaxy_systemd_sse_monitor: true
+
 galaxy_systemd_memory_limit: 35
 galaxy_systemd_memory_limit_handler: 40
 galaxy_systemd_memory_limit_workflow: 15

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -100,7 +100,7 @@ roles:
     src: https://github.com/usegalaxy-eu/ansible-certbot
     version: 0.1.5
   - name: usegalaxy_eu.galaxy_systemd
-    version: 2.2.0
+    version: 2.3.0
   - name: usegalaxy-eu.dynmotd
     src: https://github.com/usegalaxy-eu/ansible-dynmotd
     version: 0.1.0


### PR DESCRIPTION
Server-Sent Events (SSE) for real-time updates work better in production with a standalone monitor process (see [docs](https://docs.galaxyproject.org/en/latest/admin/sse_updates.html#standalone-monitor-recommended-for-production)).

Bump the usegalaxy_eu.galaxy_systemd role version to a version that includes a systemd unit for the SSE monitor and set `galaxy_systemd_sse_monitor: true` to deploy it.

⚠️ Requires https://github.com/usegalaxy-eu/ansible-galaxy-systemd/pull/19 (and a new release assumed to be tagged `2.3.0`), closes https://github.com/usegalaxy-eu/issues/issues/1001.