### PR TITLE
Disable Celery rate limits per-user

### DIFF
--- a/group_vars/gxconfig.yml
+++ b/group_vars/gxconfig.yml
@@ -2702,7 +2702,7 @@ base_app_main: &BASE_APP_MAIN
 
   # If set to a non-0 value, upper limit on number of tasks that can be
   # executed per user per second.
-  celery_user_rate_limit: 0.5 # 1 task every 2 seconds
+  #celery_user_rate_limit: 0.0
 
   # Maximum number of Celery tasks that can execute concurrently for a
   # single user. If set to 0 (default), no concurrency limit is
@@ -2710,7 +2710,7 @@ base_app_main: &BASE_APP_MAIN
   # retried until a slot becomes available. A periodic cleanup task
   # reclaims slots from crashed workers by inspecting active tasks on
   # all workers.
-  celery_user_concurrency_limit: 5
+  #celery_user_concurrency_limit: 0
 
   # When both `celery_user_rate_limit` and `celery_user_concurrency_limit` 
   # are set, rate limiting runs first (to schedule the timeslot) and concurrency 


### PR DESCRIPTION
Rate-limits seem to be working as intended.

The motivation for this change is strictly scoped to monitoring purposes. Since the Galaxy 26.1 upgrade and the per-user Celery task rate limits came into effect, it has been observed that the queue of internal Galaxy tasks accumulates a lot of pending tasks during long periods. But some analysis makes us believe that it is normal and that it is the effect of the rate limiter. The accumulated tasks should belong strictly to rate-limited users.

Disabling the rate limits is meant as a way to observe if the behavior of the queue is normal without the rate limits and to get some statistics for a future issue where improvements to the monitoring system will be proposed.

After that's done, **the rate-limits can be re-enabled**.