### PR TITLE
Disable SSE monitor

### DIFF
--- a/group_vars/sn09/sn09.yml
+++ b/group_vars/sn09/sn09.yml
@@ -234,7 +234,7 @@ galaxy_systemd_gunicorn_env: '{{ apollo_env }} GALAXY_DROPBOX_APP_CLIENT_ID={{ d
 galaxy_systemd_handler_env: '{{ galaxy_systemd_gunicorn_env }}'
 galaxy_systemd_workflow_scheduler_env: '{{ galaxy_systemd_gunicorn_env }}'
 
-galaxy_systemd_sse_monitor: true
+galaxy_systemd_sse_monitor: false
 
 galaxy_systemd_memory_limit: 35
 galaxy_systemd_memory_limit_handler: 40


### PR DESCRIPTION
Messages pile up in a RabbitMQ queue called `control.sse_monitor.sn09.galaxyproject.eu.XXXXXXX@sn09.galaxyproject.eu` (where XXXXXXX is an integer) and are never consumed.

Related: https://github.com/usegalaxy-eu/infrastructure-playbook/pull/2130, https://github.com/usegalaxy-eu/issues/issues/1001.