### PR TITLE
Use qwen-3.5-397b-llmlb for custom tool agent, enable quality critic agent

### DIFF
--- a/group_vars/gxconfig.yml
+++ b/group_vars/gxconfig.yml
@@ -2764,7 +2764,16 @@ base_app_main: &BASE_APP_MAIN
   # ``structured_output_override: true|false`` beats the model
   # capability table -- see ``agent_model_capabilities_file`` for the
   # table's location and contents.
-  #inference_services: null
+  inference_services:
+    default:
+      model: "gpt-oss-120b-llmlb"
+      api_base_url: "{{ galaxy_infrastructure_llm_url }}"
+      api_key: "{{ galaxy_infrastructure_llm_api_key }}"
+    custom_tool:
+      model: "qwen-3.5-397b-llmlb"
+      api_base_url: "{{ galaxy_infrastructure_llm_url }}"
+      api_key: "{{ galaxy_infrastructure_llm_api_key }}"
+      quality_critic_enabled: true
 
   # YAML file with capability hints for agent inference models. Maps
   # fnmatch-style globs against model names to features such as


### PR DESCRIPTION
from within galaxy's test dir, set up evals/models.yaml and run
```
PYTHONPATH=../lib python -m evals.run_evals --datasets custom_tool --judge-model qwen-3.5-397b-llmlb --models qwen-3.5-397b-llmlb,gpt-oss-120b-llmlb
```

# Galaxy agent evals -- 2026-06-19

_Generated 2026-06-19T10:51:43 from `47104e4dfac`._

## custom_tool

| metric | qwen-3.5-397b-llmlb | gpt-oss-120b-llmlb |
| --- | --- | --- |
| ToolProduced | 4/5 | 0/5 |
| LLMJudge | 3/5 | 0/5 |
| FirstAttemptOk | 4/5 | 0/5 |
| ToolYamlContains | 3/5 | 0/5 |
| median latency (s) | 18.46 | 16.70 |
| total tokens (in/out) | 36723/4034 | 0/0 |
| est. cost ($) | 0.0000 | 0.0000 |

### Per-case detail

| case | qwen-3.5-397b-llmlb | gpt-oss-120b-llmlb |
| --- | --- | --- |
| boxplot_welch_ttest | OK (judge 0.00) | WRONG ({'ok': False, 'attempts': 2, 'tool_yaml': '', 'content': 'Th) |
| head_n_lines | WRONG ({'ok': False, 'attempts': None, 'tool_yaml': '', 'content': ) | WRONG ({'ok': False, 'attempts': 2, 'tool_yaml': '', 'content': 'Th) |
| multi_file_concatenate | OK (judge 1.00) | WRONG ({'ok': False, 'attempts': 2, 'tool_yaml': '', 'content': 'Th) |
| grep_filter_with_mode | OK (judge 1.00) | WRONG ({'ok': False, 'attempts': 2, 'tool_yaml': '', 'content': 'Th) |
| split_to_collection | OK (judge 1.00) | WRONG ({'ok': False, 'attempts': 2, 'tool_yaml': '', 'content': 'Th) |
