### PR TITLE
Comment out chunk_upload_size in gxconfig.yml

### DIFF
--- a/group_vars/gxconfig.yml
+++ b/group_vars/gxconfig.yml
@@ -1386,7 +1386,7 @@ base_app_main: &BASE_APP_MAIN
   # Galaxy can upload user files in chunks without using nginx. Enable
   # the chunk uploader by specifying a chunk size larger than 0. The
   # chunk size is specified in bytes (default: 10MB).
-  chunk_upload_size: 0
+  #chunk_upload_size: 104857600
 
   # Have Galaxy manage dynamic proxy component for routing requests to
   # other services based on Galaxy's session cookie.  It will attempt to


### PR DESCRIPTION
Comment out the chunk_upload_size setting in gxconfig.yml use the default value