### PR TITLE
Revert "Disable Celery rate limits per-user"

### DIFF
--- a/group_vars/gxconfig.yml
+++ b/group_vars/gxconfig.yml
@@ -2704,7 +2704,7 @@ base_app_main: &BASE_APP_MAIN
 
   # If set to a non-0 value, upper limit on number of tasks that can be
   # executed per user per second.
-  #celery_user_rate_limit: 0.0
+  celery_user_rate_limit: 0.5 # 1 task every 2 seconds
 
   # Maximum number of Celery tasks that can execute concurrently for a
   # single user. If set to 0 (default), no concurrency limit is
@@ -2712,7 +2712,7 @@ base_app_main: &BASE_APP_MAIN
   # retried until a slot becomes available. A periodic cleanup task
   # reclaims slots from crashed workers by inspecting active tasks on
   # all workers.
-  #celery_user_concurrency_limit: 0
+  celery_user_concurrency_limit: 5
 
   # When both `celery_user_rate_limit` and `celery_user_concurrency_limit` 
   # are set, rate limiting runs first (to schedule the timeslot) and concurrency 


### PR DESCRIPTION
Reverts usegalaxy-eu/infrastructure-playbook#2131
Part of https://github.com/usegalaxy-eu/issues/issues/1003