### PR TITLE
Swap contents of `model_id` and `display_name` columns on genai_models.loc

### DIFF
--- a/files/galaxy/config/llm/genai_models.loc
+++ b/files/galaxy/config/llm/genai_models.loc
@@ -12,25 +12,25 @@
 #For example:
 #
 #
-gpt-oss-120b-llmlb-freiburg	gpt-oss-120b-llmlb	Most capable for complex tasks, deep reasoning, and detailed outputs (GPT-OSS-120B) [uni-freiburg]	text	uni-freiburg	OpenAI
-mistral-3.2-24b-llmlb-freiburg	mistral-3.2-24b-llmlb	Balanced accuracy and speed, good for drafting documents and structured outputs (Mistral-Small-3.2-24B-Instruct-2506-FP8) [uni-freiburg]	multimodal	uni-freiburg	Mistral AI
-gpt-oss-20b-llmlb-freiburg	gpt-oss-20b-llmlb	Smooth for straightforward Q&A or text generation, efficient on small servers (GPT-OSS-20B) [uni-freiburg]	text	uni-freiburg	OpenAI
-gemma-3-12b-llmlb-freiburg	gemma-3-12b-llmlb	Handles text + images, great for describing photos, diagrams, or screenshots (Gemma-3-12B-IT) [uni-freiburg]	multimodal	uni-freiburg	Google DeepMind
-numarkdown-8b-thinking-llmlb-freiburg	numarkdown-8b-thinking-llmlb	Advanced OCR and document understanding, excels at extracting structured data from scanned images (NuMarkdown-8B-Thinking) [uni-freiburg]	image	uni-freiburg	NuMind
-gemma-3-27b-llmlb-freiburg	gemma-3-27b-llmlb	High-performance multimodal model for complex reasoning and image understanding (Gemma-3-27B-IT) [uni-freiburg]	multimodal	uni-freiburg	Google DeepMind
-glm-5.1-llmlb-freiburg	glm-5.1-llmlb	Latest GLM 5.1 generation model with enhanced reasoning and knowledge (GLM-5.1) [uni-freiburg]	text	uni-freiburg	Zhipu AI
-nuextract3-llmlb-freiburg	nuextract3-llmlb	NuExtract3 is a unified 4B vision-language reasoning model for document understanding (NuExtract3) [uni-freiburg]	image	uni-freiburg	NuMind
-qwen-3.5-397b-llmlb-freiburg	qwen-3.5-397b-llmlb	Flagship 397B mixture-of-experts model for the most demanding reasoning, long-context, and visual tasks (Qwen3.5-397B) [uni-freiburg]	multimodal	uni-freiburg	Alibaba Cloud
-qwen-3.6-27b-llmlb-freiburg	qwen-3.6-27b-llmlb	Advanced reasoning and multimodal understanding with efficient 27B architecture (Qwen3.6-27B) [uni-freiburg]	multimodal	uni-freiburg	Alibaba Cloud
-qwen3.5-9b-llmlb-freiburg	qwen3.5-9b-llmlb	Efficient 9B native vision-language model for everyday tasks with fast inference (Qwen3.5-9B) [uni-freiburg]	multimodal	uni-freiburg	Alibaba Cloud
-mistral-small-4-llmlb-freiburg	mistral-small-4-llmlb	Latest Mistral Small generation with multimodal support and strong instruction following (Mistral-Small-4) [uni-freiburg]	multimodal	uni-freiburg	Mistral AI
-gemma-4-31b-llmlb-freiburg	gemma-4-31b-llmlb	High-performance 31B multimodal model for complex reasoning and image understanding (Gemma-4-31B-IT) [uni-freiburg]	multimodal	uni-freiburg	Google DeepMind
-gpt-oss-120b-e-infra.cz	gpt-oss-120b	Most capable for complex tasks, deep reasoning, and detailed outputs (GPT-OSS-120B) [e-INFRA CZ]	text	e-infra.cz	OpenAI
-deepseek-v3.2-e-infra.cz	deepseek-v3.2	High-performance model with advanced reasoning capabilities (DeepSeek-V3.2) [e-INFRA CZ]	text	e-infra.cz	DeepSeek
-deepseek-r1-e-infra.cz	deepseek-r1	Advanced reasoning model with chain-of-thought capabilities (DeepSeek-R1) [e-INFRA CZ]	text	e-infra.cz	DeepSeek
-deepseek-v3.2-thinking-e-infra.cz	deepseek-v3.2-thinking	DeepSeek V3.2 with enhanced thinking and reasoning process (DeepSeek-V3.2-Thinking) [e-INFRA CZ]	text	e-infra.cz	DeepSeek
-mistral-large-e-infra.cz	mistral-large	Large-scale model for complex tasks and long-context understanding (Mistral-Large) [e-INFRA CZ]	multimodal	e-infra.cz	Mistral AI
-glm-4.7-e-infra.cz	glm-4.7	Latest generation model with enhanced reasoning and knowledge (GLM-4.7) [e-INFRA CZ]	multimodal	e-infra.cz	Zhipu AI
-llama-4-scout-17b-16e-instruct-e-infra.cz	llama-4-scout-17b-16e-instruct	Efficient instruct-tuned model for general tasks (Llama-4-Scout-17B) [e-INFRA CZ]	multimodal	e-infra.cz	Meta AI
-qwen3-coder-30b-e-infra.cz	qwen3-coder-30b	Specialized code generation model with 30B parameters (Qwen3-Coder-30B) [e-INFRA CZ]	multimodal	e-infra.cz	Alibaba Cloud
-qwen3-coder-e-infra.cz	qwen3-coder	Efficient code generation model for programming tasks (Qwen3-Coder) [e-INFRA CZ]	multimodal	e-infra.cz	Alibaba Cloud
+gpt-oss-120b-llmlb	gpt-oss-120b-llmlb-freiburg	Most capable for complex tasks, deep reasoning, and detailed outputs (GPT-OSS-120B) [uni-freiburg]	text	uni-freiburg	OpenAI
+mistral-3.2-24b-llmlb	mistral-3.2-24b-llmlb-freiburg	Balanced accuracy and speed, good for drafting documents and structured outputs (Mistral-Small-3.2-24B-Instruct-2506-FP8) [uni-freiburg]	multimodal	uni-freiburg	Mistral AI
+gpt-oss-20b-llmlb	gpt-oss-20b-llmlb-freiburg	Smooth for straightforward Q&A or text generation, efficient on small servers (GPT-OSS-20B) [uni-freiburg]	text	uni-freiburg	OpenAI
+gemma-3-12b-llmlb	gemma-3-12b-llmlb-freiburg	Handles text + images, great for describing photos, diagrams, or screenshots (Gemma-3-12B-IT) [uni-freiburg]	multimodal	uni-freiburg	Google DeepMind
+numarkdown-8b-thinking-llmlb	numarkdown-8b-thinking-llmlb-freiburg	Advanced OCR and document understanding, excels at extracting structured data from scanned images (NuMarkdown-8B-Thinking) [uni-freiburg]	image	uni-freiburg	NuMind
+gemma-3-27b-llmlb	gemma-3-27b-llmlb-freiburg	High-performance multimodal model for complex reasoning and image understanding (Gemma-3-27B-IT) [uni-freiburg]	multimodal	uni-freiburg	Google DeepMind
+glm-5.1-llmlb	glm-5.1-llmlb-freiburg	Latest GLM 5.1 generation model with enhanced reasoning and knowledge (GLM-5.1) [uni-freiburg]	text	uni-freiburg	Zhipu AI
+nuextract3-llmlb	nuextract3-llmlb-freiburg	NuExtract3 is a unified 4B vision-language reasoning model for document understanding (NuExtract3) [uni-freiburg]	image	uni-freiburg	NuMind
+qwen-3.5-397b-llmlb	qwen-3.5-397b-llmlb-freiburg	Flagship 397B mixture-of-experts model for the most demanding reasoning, long-context, and visual tasks (Qwen3.5-397B) [uni-freiburg]	multimodal	uni-freiburg	Alibaba Cloud
+qwen-3.6-27b-llmlb	qwen-3.6-27b-llmlb-freiburg	Advanced reasoning and multimodal understanding with efficient 27B architecture (Qwen3.6-27B) [uni-freiburg]	multimodal	uni-freiburg	Alibaba Cloud
+qwen3.5-9b-llmlb	qwen3.5-9b-llmlb-freiburg	Efficient 9B native vision-language model for everyday tasks with fast inference (Qwen3.5-9B) [uni-freiburg]	multimodal	uni-freiburg	Alibaba Cloud
+mistral-small-4-llmlb	mistral-small-4-llmlb-freiburg	Latest Mistral Small generation with multimodal support and strong instruction following (Mistral-Small-4) [uni-freiburg]	multimodal	uni-freiburgMistral AI
+gemma-4-31b-llmlb	gemma-4-31b-llmlb-freiburg	High-performance 31B multimodal model for complex reasoning and image understanding (Gemma-4-31B-IT) [uni-freiburg]	multimodal	uni-freiburg	Google DeepMind
+gpt-oss-120b	gpt-oss-120b-e-infra.cz	Most capable for complex tasks, deep reasoning, and detailed outputs (GPT-OSS-120B) [e-INFRA CZ]	text	e-infra.cz	OpenAI
+deepseek-v3.2	deepseek-v3.2-e-infra.cz	High-performance model with advanced reasoning capabilities (DeepSeek-V3.2) [e-INFRA CZ]	text	e-infra.cz	DeepSeek
+# deepseek-r1	deepseek-r1-e-infra.cz	Advanced reasoning model with chain-of-thought capabilities (DeepSeek-R1) [e-INFRA CZ]	text	e-infra.cz	DeepSeek
+deepseek-v3.2-thinking	deepseek-v3.2-thinking-e-infra.cz	DeepSeek V3.2 with enhanced thinking and reasoning process (DeepSeek-V3.2-Thinking) [e-INFRA CZ]	text	e-infra.cz	DeepSeek
+mistral-large	mistral-large-e-infra.cz	Large-scale model for complex tasks and long-context understanding (Mistral-Large) [e-INFRA CZ]	multimodal	e-infra.cz	Mistral AI
+glm-4.7	glm-4.7-e-infra.cz	Latest generation model with enhanced reasoning and knowledge (GLM-4.7) [e-INFRA CZ]	multimodal	e-infra.cz	Zhipu AI
+llama-4-scout-17b-16e-instruct	llama-4-scout-17b-16e-instruct-e-infra.cz	Efficient instruct-tuned model for general tasks (Llama-4-Scout-17B) [e-INFRA CZ]	multimodal	e-infra.cz	Meta AI
+qwen3-coder-30b	qwen3-coder-30b-e-infra.cz	Specialized code generation model with 30B parameters (Qwen3-Coder-30B) [e-INFRA CZ]	multimodal	e-infra.cz	Alibaba Cloud
+qwen3-coder	qwen3-coder-e-infra.cz	Efficient code generation model for programming tasks (Qwen3-Coder) [e-INFRA CZ]	multimodal	e-infra.cz	Alibaba Cloud


### PR DESCRIPTION
Intended to fix the following error.

```
openai.AuthenticationError: Error code: 401 - {'error': {'message': "key not allowed to access model. This key can only access models=['gpt-oss-120b-llmlb', ...]. Tried to access glm-5.1-llmlb-freiburg", 'type': 'key_model_access_denied', 'param': 'model', 'code': '401'}}
```

It is most likely caused by the `model_id` and `display_name` columns being swapped.