### PR TITLE
Update Freiburg genai models config: clarify columns and remove GLM-5.1

### DIFF
--- a/files/galaxy/config/llm/genai_models.loc
+++ b/files/galaxy/config/llm/genai_models.loc
@@ -4,13 +4,14 @@
 #
 #The entries are as follows:
 #
-#<model_id>	<display_name>	<domain>	<provider>	<free_tag>
+#<value>	<model_id>	<name>	<domain>	<provider>	<free_tag>
 #
-#domain (defined by the Galaxy community, e.g. text / multimodal)
-#provider (the entity providing the api)
-#free_tag (could be freely used by an admin to specify more filter options)
-#For example:
-#
+#value: Unique identifier for the dropdown selection
+#model_id: The actual model identifier to send to the LiteLLM API
+#name: Display name shown to users in the Galaxy interface
+#domain: Model type - text, image, or multimodal
+#provider: Server identifier matching a key in the servers section of your YAML config
+#free_tag: Optional tag that can be freely used by admins to specify additional filter options
 #
 gpt-oss-120b-llmlb-freiburg	gpt-oss-120b-llmlb	Most capable for complex tasks, deep reasoning, and detailed outputs (GPT-OSS-120B) [uni-freiburg]	text	uni-freiburg	OpenAI
 mistral-3.2-24b-llmlb-freiburg	mistral-3.2-24b-llmlb	Balanced accuracy and speed, good for drafting documents and structured outputs (Mistral-Small-3.2-24B-Instruct-2506-FP8) [uni-freiburg]	multimodal	uni-freiburg	Mistral AI
@@ -18,7 +19,6 @@ gpt-oss-20b-llmlb-freiburg	gpt-oss-20b-llmlb	Smooth for straightforward Q&A or t
 gemma-3-12b-llmlb-freiburg	gemma-3-12b-llmlb	Handles text + images, great for describing photos, diagrams, or screenshots (Gemma-3-12B-IT) [uni-freiburg]	multimodal	uni-freiburg	Google DeepMind
 numarkdown-8b-thinking-llmlb-freiburg	numarkdown-8b-thinking-llmlb	Advanced OCR and document understanding, excels at extracting structured data from scanned images (NuMarkdown-8B-Thinking) [uni-freiburg]	image	uni-freiburg	NuMind
 gemma-3-27b-llmlb-freiburg	gemma-3-27b-llmlb	High-performance multimodal model for complex reasoning and image understanding (Gemma-3-27B-IT) [uni-freiburg]	multimodal	uni-freiburg	Google DeepMind
-glm-5.1-llmlb-freiburg	glm-5.1-llmlb	Latest GLM 5.1 generation model with enhanced reasoning and knowledge (GLM-5.1) [uni-freiburg]	text	uni-freiburg	Zhipu AI
 nuextract3-llmlb-freiburg	nuextract3-llmlb	NuExtract3 is a unified 4B vision-language reasoning model for document understanding (NuExtract3) [uni-freiburg]	image	uni-freiburg	NuMind
 qwen-3.5-397b-llmlb-freiburg	qwen-3.5-397b-llmlb	Flagship 397B mixture-of-experts model for the most demanding reasoning, long-context, and visual tasks (Qwen3.5-397B) [uni-freiburg]	multimodal	uni-freiburg	Alibaba Cloud
 qwen-3.6-27b-llmlb-freiburg	qwen-3.6-27b-llmlb	Advanced reasoning and multimodal understanding with efficient 27B architecture (Qwen3.6-27B) [uni-freiburg]	multimodal	uni-freiburg	Alibaba Cloud


### PR DESCRIPTION
This PR updates the Freiburg genai models configuration. Specifically, it clarifies the description of the columns in the header comments and removes the outdated GLM 5.1 model entry.