### PR TITLE
Remove broken LLM models from genai_models.loc

### DIFF
--- a/files/galaxy/config/llm/genai_models.loc
+++ b/files/galaxy/config/llm/genai_models.loc
@@ -14,8 +14,6 @@
 #free_tag: Optional tag that can be freely used by admins to specify additional filter options
 #
 gpt-oss-120b-llmlb-freiburg	gpt-oss-120b-llmlb	Most capable for complex tasks, deep reasoning, and detailed outputs (GPT-OSS-120B) [uni-freiburg]	text	uni-freiburg	OpenAI
-mistral-3.2-24b-llmlb-freiburg	mistral-3.2-24b-llmlb	Balanced accuracy and speed, good for drafting documents and structured outputs (Mistral-Small-3.2-24B-Instruct-2506-FP8) [uni-freiburg]	multimodal	uni-freiburg	Mistral AI
-gpt-oss-20b-llmlb-freiburg	gpt-oss-20b-llmlb	Smooth for straightforward Q&A or text generation, efficient on small servers (GPT-OSS-20B) [uni-freiburg]	text	uni-freiburg	OpenAI
 gemma-3-12b-llmlb-freiburg	gemma-3-12b-llmlb	Handles text + images, great for describing photos, diagrams, or screenshots (Gemma-3-12B-IT) [uni-freiburg]	multimodal	uni-freiburg	Google DeepMind
 numarkdown-8b-thinking-llmlb-freiburg	numarkdown-8b-thinking-llmlb	Advanced OCR and document understanding, excels at extracting structured data from scanned images (NuMarkdown-8B-Thinking) [uni-freiburg]	image	uni-freiburg	NuMind
 gemma-3-27b-llmlb-freiburg	gemma-3-27b-llmlb	High-performance multimodal model for complex reasoning and image understanding (Gemma-3-27B-IT) [uni-freiburg]	multimodal	uni-freiburg	Google DeepMind
@@ -27,10 +25,7 @@ mistral-small-4-llmlb-freiburg	mistral-small-4-llmlb	Latest Mistral Small genera
 gemma-4-31b-llmlb-freiburg	gemma-4-31b-llmlb	High-performance 31B multimodal model for complex reasoning and image understanding (Gemma-4-31B-IT) [uni-freiburg]	multimodal	uni-freiburg	Google DeepMind
 gpt-oss-120b-e-infra.cz	gpt-oss-120b	Most capable for complex tasks, deep reasoning, and detailed outputs (GPT-OSS-120B) [e-INFRA CZ]	text	e-infra.cz	OpenAI
 deepseek-v3.2-e-infra.cz	deepseek-v3.2	High-performance model with advanced reasoning capabilities (DeepSeek-V3.2) [e-INFRA CZ]	text	e-infra.cz	DeepSeek
-deepseek-r1-e-infra.cz	deepseek-r1	Advanced reasoning model with chain-of-thought capabilities (DeepSeek-R1) [e-INFRA CZ]	text	e-infra.cz	DeepSeek
 deepseek-v3.2-thinking-e-infra.cz	deepseek-v3.2-thinking	DeepSeek V3.2 with enhanced thinking and reasoning process (DeepSeek-V3.2-Thinking) [e-INFRA CZ]	text	e-infra.cz	DeepSeek
-mistral-large-e-infra.cz	mistral-large	Large-scale model for complex tasks and long-context understanding (Mistral-Large) [e-INFRA CZ]	multimodal	e-infra.cz	Mistral AI
-glm-4.7-e-infra.cz	glm-4.7	Latest generation model with enhanced reasoning and knowledge (GLM-4.7) [e-INFRA CZ]	multimodal	e-infra.cz	Zhipu AI
 llama-4-scout-17b-16e-instruct-e-infra.cz	llama-4-scout-17b-16e-instruct	Efficient instruct-tuned model for general tasks (Llama-4-Scout-17B) [e-INFRA CZ]	multimodal	e-infra.cz	Meta AI
 qwen3-coder-30b-e-infra.cz	qwen3-coder-30b	Specialized code generation model with 30B parameters (Qwen3-Coder-30B) [e-INFRA CZ]	multimodal	e-infra.cz	Alibaba Cloud
 qwen3-coder-e-infra.cz	qwen3-coder	Efficient code generation model for programming tasks (Qwen3-Coder) [e-INFRA CZ]	multimodal	e-infra.cz	Alibaba Cloud


### PR DESCRIPTION
This PR removes five LLM model entries from `files/galaxy/config/llm/genai_models.loc` that were found to be non-functional during LiteLLM endpoint testing.

Removed models:
- `mistral-3.2-24b-llmlb-freiburg`
- `gpt-oss-20b-llmlb-freiburg`
- `deepseek-r1-e-infra.cz`
- `mistral-large-e-infra.cz`
- `glm-4.7-e-infra.cz`

These models failed when queried through the configured OpenAI-compatible `/v1/chat/completions` endpoints. Removing them prevents users from selecting broken models in Galaxy.