### PR TITLE
Fix `msconvert` "/tmp/.wine-0 is not owned by you"

### DIFF
--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -355,9 +355,9 @@ tools:
       docker_run_extra_arguments: " --gpus all -e NVIDIA_VISIBLE_DEVICES=all -e NVIDIA_DRIVER_CAPABILITIES=graphics,compute "
 
   toolshed.g2.bx.psu.edu/repos/galaxyp/msconvert/msconvert/.*:
-    ## seems to be still needed 2025/12
+    ## seems to be still needed 2026/06
     params:
-      docker_run_extra_arguments: --user 999
+      docker_run_extra_arguments: --user 999 -v /bin/false:/usr/bin/sudo:ro
 
   toolshed.g2.bx.psu.edu/repos/goeckslab/vitessce_spatial/vitessce_spatial/.*:
     params:


### PR DESCRIPTION
This solution [was tested in May](https://usegalaxy.eu/datasets/26c75dcccb616ac8fc1c559facc51d66/details), but it never got merged. I am opening this PR because we just got a [new bug report on this issue](ttps://usegalaxy.eu/datasets/26c75dcccb616ac8c72e405adf27105c/details).

The reasoning is as follows. The CLI command for this tool is:

```bash
cp '/data/dnb**/galaxy_db/files/*/*/*/dataset_********-****-****-****-************.dat' 'Sample*.raw' \
  && CAN_SUDO=$(sudo -n -l > /dev/null 2> /dev/null || echo $?) \
  && echo "CAN SUDO $CAN_SUDO" \
  && if [ -z "$CAN_SUDO" ]; then
       uid=`id -u` && gid=`id -g` && WINE="wine_anyuser"
     else
       WINE="wine" && export WINEPREFIX=$(mktemp -d) && (cp -a /wineprefix64/* $WINEPREFIX 2> /dev/null || true)
     fi \
  && $WINE msconvert 'Sample*.raw' \
       --outdir outputs \
       --mzML \
       --simAsSpectra \
       --ignoreUnknownInstrumentError \
       --runIndexSet 0 \
       --stripLocationFromSourceFiles \
       --filter "peakPicking vendor msLevel=1-" \
       --filter "demultiplex massError=10.0PPM nnlsMaxIter=50 nnlsEps=1e-10 noWeighting=false demuxBlockExtra=0.0 variableFill=false noSumNormalize=false optimization=overlap_only interpolateRT=true minWindowSize=0.2" \
       --64 \
       --zlib \
       --outfile 'Sample*' \
  && if [ -z "$CAN_SUDO" ]; then
       sudo chown -R $uid:$gid './'
     fi \
  && mv 'outputs/Sample*.mzML' '/data/jwd**/main/***/***/***/*********/outputs/dataset_********-****-****-****-************.dat'
```

Thus, ensuring `$CAN_SUDO` is false works around the issue.