### PR TITLE
Move work dirs for 's3_scratch_netapp01' to 'jwd06'

### DIFF
--- a/templates/galaxy/config/object_store_conf.yml.j2
+++ b/templates/galaxy/config/object_store_conf.yml.j2
@@ -374,9 +374,9 @@ backends:
       cache_updated_data: true
     extra_dirs:
       - type: job_work
-        path: "{{ jwd.jwd07.path }}/main"
+        path: "{{ jwd.jwd06.path }}/main"
       - type: temp
-        path: "{{ jwd.jwd07.path }}/tmp"
+        path: "{{ jwd.jwd06.path }}/tmp"
 
 
   # Private object stores, or as we call it unshareable storage


### PR DESCRIPTION
This PR is proposed to alleviate the problem described [here](https://github.com/usegalaxy-eu/issues/issues/1009): The zpool on `zfs07` is already the by far most heavily used as it hosts `cache07` and it appears advisable to move the additional load (and, more importantly, block usage) resulting from the current setting to some other zpool. `jwd06` is currently the least used of the JWDs. While the zpool on `zfs08` currently has an even lower block usage than that of `zfs06` this is mainly due to ~50 TiB of obsolete cached data in `cache06`, data that could safely be removed.

The remaining question is if we should maybe also reduce the weight of `files38` which also uses `jwd06`. Maybe is should be more like this?
- `files36` (uses `jwd08`): `weight=2`
- `files37` (uses `jwd07`): `weight=1`
- `files38` (uses `jwd06`): `weight=1`

Closes https://github.com/usegalaxy-eu/issues/issues/1009.