### PR TITLE
Increase amount of tasks run before recycling Celery workers to 250k

### DIFF
--- a/group_vars/celerycluster.yml
+++ b/group_vars/celerycluster.yml
@@ -40,7 +40,7 @@ autofs_mount_points:
 # SystemD
 galaxy_systemd_mode: ""
 galaxy_systemd_celery: true
-galaxy_systemd_celery_internal_max_tasks: 10000
+galaxy_systemd_celery_internal_max_tasks: 250000
 galaxy_systemd_celery_beat_schedule_path: "/opt/galaxy/celery/celery-beat-schedule"
 galaxy_systemd_watchdog: true
 galaxy_systemd_celery_env: "GALAXY_DROPBOX_APP_CLIENT_ID={{ dropbox_app_client_id }} GALAXY_DROPBOX_APP_CLIENT_SECRET={{ dropbox_app_client_secret }} GALAXY_GOOGLE_DRIVE_APP_CLIENT_ID={{ google_drive_oauth_client_id }} GALAXY_GOOGLE_DRIVE_APP_CLIENT_SECRET={{ google_drive_oauth_client_secret }}"


### PR DESCRIPTION
Yesterday, I restarted the Celery workers. Today in the morning they were still restarting. `py-spy` revealed that they were still loading data tables.

Today, we have stopped all Celery workers. After that, we have started just one systemd unit. This unit has successfully started after ~10min. `strace` output and the systemd unit logs reveals much faster loading of the data tables. That means that starting all Celery workers simultaneously clogs NFS to a standstill.

However, after processing 10k tasks, the worker processes within the Celery systemd unit have been restarted, because they have hit the limit set by `--max-tasks-per-child 10000`. There is a backlog of 3.4 million tasks, therefore restarting the workers every 10k tasks is not cost-effective.

Increase the value of `--max-tasks-per-child` to 250k to reduce the number of expensive worker restarts.