### PR TITLE
Increase Celery user rate limit to 50 tasks per user

### DIFF
--- a/group_vars/gxconfig.yml
+++ b/group_vars/gxconfig.yml
@@ -2710,7 +2710,7 @@ base_app_main: &BASE_APP_MAIN
 
   # If set to a non-0 value, upper limit on number of tasks that can be
   # executed per user per second.
-  celery_user_rate_limit: 0.5 # 1 task every 2 seconds
+  celery_user_rate_limit: 50
 
   # Maximum number of Celery tasks that can execute concurrently for a
   # single user. If set to 0 (default), no concurrency limit is


### PR DESCRIPTION
We have a large Celery cluster that is known to be able to churn through over 1000 tasks per second, but tasks for some users are waiting until September. I think it is reasonable to allow the cluster to work rather than having it idle and have users waiting until September.