### PR TITLE
Use Pickle as task serializer for Celery

### DIFF
--- a/group_vars/gxconfig.yml
+++ b/group_vars/gxconfig.yml
@@ -2707,6 +2707,9 @@ base_app_main: &BASE_APP_MAIN
       galaxy.fetch_data: disabled
       # galaxy.fetch_data: galaxy.external
       galaxy.set_job_metadata: galaxy.external
+    task_serializer: pickle
+    accept_content: ["pickle", "json"]
+    result_serializer: "pickle"
 
   # If set to a non-0 value, upper limit on number of tasks that can be
   # executed per user per second.


### PR DESCRIPTION
I am not sure if this is necessary, but I observed the error below while monitoring the Celery cluster. The worker stopped processing jobs for a while but continued later.

```shell
Jul 01 11:36:44 celery-1.bi.privat watchmedo[4621]: [2026-07-01 11:36:44,162: DEBUG/MainProcess] Closed channel #1
Jul 01 11:36:44 celery-1.bi.privat watchmedo[4621]: [2026-07-01 11:36:44,164: ERROR/MainProcess] Control command error: EncodeError(TypeError('Object of type ComputeDatasetHashTaskRequest is not JSON serializabl>
Jul 01 11:36:44 celery-1.bi.privat watchmedo[4621]: Traceback (most recent call last):
Jul 01 11:36:44 celery-1.bi.privat watchmedo[4621]:   File "/opt/galaxy/venv/lib/python3.11/site-packages/kombu/serialization.py", line 41, in _reraise_errors
Jul 01 11:36:44 celery-1.bi.privat watchmedo[4621]:     yield
Jul 01 11:36:44 celery-1.bi.privat watchmedo[4621]:   File "/opt/galaxy/venv/lib/python3.11/site-packages/kombu/serialization.py", line 220, in dumps
Jul 01 11:36:44 celery-1.bi.privat watchmedo[4621]:     payload = encoder(data)
Jul 01 11:36:44 celery-1.bi.privat watchmedo[4621]:               ^^^^^^^^^^^^^
Jul 01 11:36:44 celery-1.bi.privat watchmedo[4621]:   File "/opt/galaxy/venv/lib/python3.11/site-packages/kombu/utils/json.py", line 63, in dumps
Jul 01 11:36:44 celery-1.bi.privat watchmedo[4621]:     return _dumps(s, cls=cls, **dict(default_kwargs, **kwargs))
Jul 01 11:36:44 celery-1.bi.privat watchmedo[4621]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Jul 01 11:36:44 celery-1.bi.privat watchmedo[4621]:   File "/usr/local/tools/_conda/envs/__python@3.11.5/lib/python3.11/json/__init__.py", line 238, in dumps
Jul 01 11:36:44 celery-1.bi.privat watchmedo[4621]:     **kw).encode(obj)
Jul 01 11:36:44 celery-1.bi.privat watchmedo[4621]:           ^^^^^^^^^^^
Jul 01 11:36:44 celery-1.bi.privat watchmedo[4621]:   File "/usr/local/tools/_conda/envs/__python@3.11.5/lib/python3.11/json/encoder.py", line 200, in encode
Jul 01 11:36:44 celery-1.bi.privat watchmedo[4621]:     chunks = self.iterencode(o, _one_shot=True)
Jul 01 11:36:44 celery-1.bi.privat watchmedo[4621]:              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Jul 01 11:36:44 celery-1.bi.privat watchmedo[4621]:   File "/usr/local/tools/_conda/envs/__python@3.11.5/lib/python3.11/json/encoder.py", line 258, in iterencode
Jul 01 11:36:44 celery-1.bi.privat watchmedo[4621]:     return _iterencode(o, 0)
Jul 01 11:36:44 celery-1.bi.privat watchmedo[4621]:            ^^^^^^^^^^^^^^^^^
Jul 01 11:36:44 celery-1.bi.privat watchmedo[4621]:   File "/opt/galaxy/venv/lib/python3.11/site-packages/kombu/utils/json.py", line 47, in default
Jul 01 11:36:44 celery-1.bi.privat watchmedo[4621]:     return super().default(o)
Jul 01 11:36:44 celery-1.bi.privat watchmedo[4621]:            ^^^^^^^^^^^^^^^^^^
Jul 01 11:36:44 celery-1.bi.privat watchmedo[4621]:   File "/usr/local/tools/_conda/envs/__python@3.11.5/lib/python3.11/json/encoder.py", line 180, in default
Jul 01 11:36:44 celery-1.bi.privat watchmedo[4621]:     raise TypeError(f'Object of type {o.__class__.__name__} '
Jul 01 11:36:44 celery-1.bi.privat watchmedo[4621]: TypeError: Object of type ComputeDatasetHashTaskRequest is not JSON serializable
Jul 01 11:36:44 celery-1.bi.privat watchmedo[4621]: During handling of the above exception, another exception occurred:
Jul 01 11:36:44 celery-1.bi.privat watchmedo[4621]: Traceback (most recent call last):
Jul 01 11:36:44 celery-1.bi.privat watchmedo[4621]:   File "/opt/galaxy/venv/lib/python3.11/site-packages/celery/worker/pidbox.py", line 44, in on_message
Jul 01 11:36:44 celery-1.bi.privat watchmedo[4621]:     self.node.handle_message(body, message)
Jul 01 11:36:44 celery-1.bi.privat watchmedo[4621]:   File "/opt/galaxy/venv/lib/python3.11/site-packages/kombu/pidbox.py", line 143, in handle_message
Jul 01 11:36:44 celery-1.bi.privat watchmedo[4621]:     return self.dispatch(**body)
Jul 01 11:36:44 celery-1.bi.privat watchmedo[4621]:            ^^^^^^^^^^^^^^^^^^^^^
Jul 01 11:36:44 celery-1.bi.privat watchmedo[4621]:   File "/opt/galaxy/venv/lib/python3.11/site-packages/kombu/pidbox.py", line 110, in dispatch
Jul 01 11:36:44 celery-1.bi.privat watchmedo[4621]:     self.reply({self.hostname: reply},
Jul 01 11:36:44 celery-1.bi.privat watchmedo[4621]:   File "/opt/galaxy/venv/lib/python3.11/site-packages/kombu/pidbox.py", line 147, in reply
Jul 01 11:36:44 celery-1.bi.privat watchmedo[4621]:     self.mailbox._publish_reply(data, exchange, routing_key, ticket,
Jul 01 11:36:44 celery-1.bi.privat watchmedo[4621]:   File "/opt/galaxy/venv/lib/python3.11/site-packages/kombu/pidbox.py", line 287, in _publish_reply
Jul 01 11:36:44 celery-1.bi.privat watchmedo[4621]:     producer.publish(
Jul 01 11:36:44 celery-1.bi.privat watchmedo[4621]:   File "/opt/galaxy/venv/lib/python3.11/site-packages/kombu/messaging.py", line 178, in publish
Jul 01 11:36:44 celery-1.bi.privat watchmedo[4621]:     body, content_type, content_encoding = self._prepare(
Jul 01 11:36:44 celery-1.bi.privat watchmedo[4621]:                                            ^^^^^^^^^^^^^^
Jul 01 11:36:44 celery-1.bi.privat watchmedo[4621]:   File "/opt/galaxy/venv/lib/python3.11/site-packages/kombu/messaging.py", line 280, in _prepare
Jul 01 11:36:44 celery-1.bi.privat watchmedo[4621]:     body) = dumps(body, serializer=serializer)
Jul 01 11:36:44 celery-1.bi.privat watchmedo[4621]:             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Jul 01 11:36:44 celery-1.bi.privat watchmedo[4621]:   File "/opt/galaxy/venv/lib/python3.11/site-packages/kombu/serialization.py", line 219, in dumps
Jul 01 11:36:44 celery-1.bi.privat watchmedo[4621]:     with _reraise_errors(EncodeError):
Jul 01 11:36:44 celery-1.bi.privat watchmedo[4621]:   File "/usr/local/tools/_conda/envs/__python@3.11.5/lib/python3.11/contextlib.py", line 155, in __exit__
Jul 01 11:36:44 celery-1.bi.privat watchmedo[4621]:     self.gen.throw(typ, value, traceback)
Jul 01 11:36:44 celery-1.bi.privat watchmedo[4621]:   File "/opt/galaxy/venv/lib/python3.11/site-packages/kombu/serialization.py", line 45, in _reraise_errors
Jul 01 11:36:44 celery-1.bi.privat watchmedo[4621]:     reraise(wrapper, wrapper(exc), sys.exc_info()[2])
Jul 01 11:36:44 celery-1.bi.privat watchmedo[4621]:   File "/opt/galaxy/venv/lib/python3.11/site-packages/kombu/exceptions.py", line 34, in reraise
Jul 01 11:36:44 celery-1.bi.privat watchmedo[4621]:     raise value.with_traceback(tb)
Jul 01 11:36:44 celery-1.bi.privat watchmedo[4621]:   File "/opt/galaxy/venv/lib/python3.11/site-packages/kombu/serialization.py", line 41, in _reraise_errors
Jul 01 11:36:44 celery-1.bi.privat watchmedo[4621]:     yield
Jul 01 11:36:44 celery-1.bi.privat watchmedo[4621]:   File "/opt/galaxy/venv/lib/python3.11/site-packages/kombu/serialization.py", line 220, in dumps
Jul 01 11:36:44 celery-1.bi.privat watchmedo[4621]:     payload = encoder(data)
Jul 01 11:36:44 celery-1.bi.privat watchmedo[4621]:               ^^^^^^^^^^^^^
Jul 01 11:36:44 celery-1.bi.privat watchmedo[4621]:   File "/opt/galaxy/venv/lib/python3.11/site-packages/kombu/utils/json.py", line 63, in dumps
Jul 01 11:36:44 celery-1.bi.privat watchmedo[4621]:     return _dumps(s, cls=cls, **dict(default_kwargs, **kwargs))
Jul 01 11:36:44 celery-1.bi.privat watchmedo[4621]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Jul 01 11:36:44 celery-1.bi.privat watchmedo[4621]:   File "/usr/local/tools/_conda/envs/__python@3.11.5/lib/python3.11/json/__init__.py", line 238, in dumps
Jul 01 11:36:44 celery-1.bi.privat watchmedo[4621]:     **kw).encode(obj)
Jul 01 11:36:44 celery-1.bi.privat watchmedo[4621]:           ^^^^^^^^^^^
Jul 01 11:36:44 celery-1.bi.privat watchmedo[4621]:   File "/usr/local/tools/_conda/envs/__python@3.11.5/lib/python3.11/json/encoder.py", line 200, in encode
Jul 01 11:36:44 celery-1.bi.privat watchmedo[4621]:     chunks = self.iterencode(o, _one_shot=True)
Jul 01 11:36:44 celery-1.bi.privat watchmedo[4621]:              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Jul 01 11:36:44 celery-1.bi.privat watchmedo[4621]:   File "/usr/local/tools/_conda/envs/__python@3.11.5/lib/python3.11/json/encoder.py", line 258, in iterencode
Jul 01 11:36:44 celery-1.bi.privat watchmedo[4621]:     return _iterencode(o, 0)
Jul 01 11:36:44 celery-1.bi.privat watchmedo[4621]:            ^^^^^^^^^^^^^^^^^
Jul 01 11:36:44 celery-1.bi.privat watchmedo[4621]:   File "/opt/galaxy/venv/lib/python3.11/site-packages/kombu/utils/json.py", line 47, in default
Jul 01 11:36:44 celery-1.bi.privat watchmedo[4621]:     return super().default(o)
Jul 01 11:36:44 celery-1.bi.privat watchmedo[4621]:            ^^^^^^^^^^^^^^^^^^
Jul 01 11:36:44 celery-1.bi.privat watchmedo[4621]:   File "/usr/local/tools/_conda/envs/__python@3.11.5/lib/python3.11/json/encoder.py", line 180, in default
Jul 01 11:36:44 celery-1.bi.privat watchmedo[4621]:     raise TypeError(f'Object of type {o.__class__.__name__} '
Jul 01 11:36:44 celery-1.bi.privat watchmedo[4621]: kombu.exceptions.EncodeError: Object of type ComputeDatasetHashTaskRequest is not JSON serializable
Jul 01 11:36:44 celery-1.bi.privat watchmedo[4621]: [2026-07-01 11:36:44,227: DEBUG/MainProcess] Closed channel #2
Jul 01 11:36:44 celery-1.bi.privat watchmedo[4621]: [2026-07-01 11:36:44,227: DEBUG/MainProcess] using channel_id: 2
Jul 01 11:36:44 celery-1.bi.privat watchmedo[4621]: [2026-07-01 11:36:44,229: DEBUG/MainProcess] Channel open
Jul 01 11:36:49 celery-1.bi.privat watchmedo[4621]: [2026-07-01 11:36:49,485: DEBUG/MainProcess] heartbeat_tick : for connection ddc859472e1d450a8ec2a9319b50c3d7
Jul 01 11:36:49 celery-1.bi.privat watchmedo[4621]: [2026-07-01 11:36:49,485: DEBUG/MainProcess] heartbeat_tick : Prev sent/recv: 387262/1187162, now - 387268/1187513, monotonic - 7117.624643791, last_heartbeat_>
Jul 01 11:37:09 celery-1.bi.privat watchmedo[4621]: [2026-07-01 11:37:09,486: DEBUG/MainProcess] heartbeat_tick : for connection ddc859472e1d450a8ec2a9319b50c3d7
Jul 01 11:37:09 celery-1.bi.privat watchmedo[4621]: [2026-07-01 11:37:09,486: DEBUG/MainProcess] heartbeat_tick : Prev sent/recv: 387268/1187513, now - 387268/1187855, monotonic - 7137.625575522, last_heartbeat_>
Jul 01 11:37:09 celery-1.bi.privat watchmedo[4621]: [2026-07-01 11:37:09,486: DEBUG/MainProcess] heartbeat_tick: sending heartbeat for connection ddc859472e1d450a8ec2a9319b50c3d7
```