### PR TITLE
Revert "Disable SSE monitor"

### DIFF
--- a/group_vars/sn09/sn09.yml
+++ b/group_vars/sn09/sn09.yml
@@ -234,7 +234,7 @@ galaxy_systemd_gunicorn_env: '{{ apollo_env }} GALAXY_DROPBOX_APP_CLIENT_ID={{ d
 galaxy_systemd_handler_env: '{{ galaxy_systemd_gunicorn_env }}'
 galaxy_systemd_workflow_scheduler_env: '{{ galaxy_systemd_gunicorn_env }}'
 
-galaxy_systemd_sse_monitor: false
+galaxy_systemd_sse_monitor: true
 
 galaxy_systemd_memory_limit: 35
 galaxy_systemd_memory_limit_handler: 40


### PR DESCRIPTION
https://github.com/galaxyproject/galaxy/pull/22958 has been merged and it is available in our fork. I think we can give https://github.com/usegalaxy-eu/issues/issues/1001 a second try.

Reverts usegalaxy-eu/infrastructure-playbook#2133.