### PR TITLE
Add glm-5.2-llmlb to uni-freiburg

### DIFF
--- a/files/galaxy/config/llm/genai_models.loc
+++ b/files/galaxy/config/llm/genai_models.loc
@@ -23,6 +23,7 @@ qwen-3.6-27b-llmlb-freiburg	qwen-3.6-27b-llmlb	Advanced reasoning and multimodal
 qwen3.5-9b-llmlb-freiburg	qwen3.5-9b-llmlb	Efficient 9B native vision-language model for everyday tasks with fast inference (Qwen3.5-9B) [uni-freiburg]	multimodal	uni-freiburg	Alibaba Cloud
 mistral-small-4-llmlb-freiburg	mistral-small-4-llmlb	Latest Mistral Small generation with multimodal support and strong instruction following (Mistral-Small-4) [uni-freiburg]	multimodal	uni-freiburg	Mistral AI
 gemma-4-31b-llmlb-freiburg	gemma-4-31b-llmlb	High-performance 31B multimodal model for complex reasoning and image understanding (Gemma-4-31B-IT) [uni-freiburg]	multimodal	uni-freiburg	Google DeepMind
+glm-5.2-llmlb-freiburg	glm-5.2-llmlb	Flagship Mixture-of-Experts model by Zhipu AI optimized for coding, agentic workflows, and long-horizon tasks (GLM-5.2) [uni-freiburg]	text	uni-freiburg	Zhipu AI
 gpt-oss-120b-e-infra.cz	gpt-oss-120b	Most capable for complex tasks, deep reasoning, and detailed outputs (GPT-OSS-120B) [e-INFRA CZ]	text	e-infra.cz	OpenAI
 deepseek-v3.2-e-infra.cz	deepseek-v3.2	High-performance model with advanced reasoning capabilities (DeepSeek-V3.2) [e-INFRA CZ]	text	e-infra.cz	DeepSeek
 deepseek-v3.2-thinking-e-infra.cz	deepseek-v3.2-thinking	DeepSeek V3.2 with enhanced thinking and reasoning process (DeepSeek-V3.2-Thinking) [e-INFRA CZ]	text	e-infra.cz	DeepSeek


### PR DESCRIPTION
This PR adds the new glm-5.2-llmlb model entry to the uni-freiburg provider in genai_models.loc. Testing confirmed it works as a text model.