### PR TITLE
Bump usegalaxy_eu.fs_maintenance role to version 0.1.0

### DIFF
--- a/requirements.yaml
+++ b/requirements.yaml
@@ -123,7 +123,7 @@ roles:
     src: https://github.com/usegalaxy-eu/ansible-autofs
     version: 1.3.0
   - name: usegalaxy_eu.fs_maintenance
-    version: 0.0.9
+    version: 0.1.0
     src: https://github.com/usegalaxy-eu/ansible-fs-maintenance
   - name: usegalaxy_eu.rustus
     version: 0.3.0


### PR DESCRIPTION
Required by https://github.com/usegalaxy-eu/infrastructure-playbook/pull/2163.