### PR TITLE
Route ForestMamba to L40S GPUs

### DIFF
--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -329,6 +329,11 @@ tools:
     cores: 10
     mem: 20
 
+  toolshed.g2.bx.psu.edu/repos/bgruening/3dtrees_forestmamba/3dtrees_forestmamba/.*:
+    gpus: 1
+    context:
+      include_gpu_models: ["NVIDIA L40S"]
+
   toolshed.g2.bx.psu.edu/repos/bgruening/3dtrees_standardization/3dtrees_standardization/.*:
     cores: 10
     mem: 4


### PR DESCRIPTION
## What changed

- Add a TPV entry for `bgruening/3dtrees_forestmamba`.
- Request one GPU for ForestMamba jobs.
- Restrict matching GPU models to `NVIDIA L40S`, excluding Tesla T4 by omission.

## Why

ForestMamba should run on L40S GPU nodes rather than Tesla T4 nodes.

## Validation

- Parsed `files/galaxy/tpv/tools.yml` with Python/PyYAML.
