### PR TITLE
Disable SSE updates

### DIFF
--- a/group_vars/gxconfig.yml
+++ b/group_vars/gxconfig.yml
@@ -2921,7 +2921,7 @@ base_app_main: &BASE_APP_MAIN
   # remains the source of updates for all three. See the admin guide
   # "Server-Sent Events for real-time updates" for the full
   # architecture, monitoring guidance and proxy configuration.
-  enable_sse_updates: true
+  enable_sse_updates: false
 
   # The interval in seconds between history audit table polls when using
   # the polling fallback (SQLite or when PostgreSQL LISTEN/NOTIFY is


### PR DESCRIPTION
At the moment SSE updates are failing for the set of tools that don't need the handler to execute. The development team was not able to reproduce the bug.

Let's thus disable SSE updates for now.