### PR TITLE
Core setup of sn10 server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ known_hosts:
 	grep --quiet '^worker-0.bronze.build.galaxyproject.eu' ~/.ssh/known_hosts || echo "worker-0.bronze.build.galaxyproject.eu ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKE2VMZbiOf4NHTVyNj9FyCu2P71YF/RHHO97lrsPC46" >> ~/.ssh/known_hosts
 	grep --quiet '^beacon.bi.privat' ~/.ssh/known_hosts || echo "beacon.bi.privat ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJLhLsIO61hj8Kk6VQWTq5JU+PRm5/so1k44yZQTwvVO" >> ~/.ssh/known_hosts
 	grep --quiet '^upload.bi.privat' ~/.ssh/known_hosts || echo "upload.bi.privat ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHMz9KPAC6tZwxoBE0tcqDVA29mPtE3K+so9MYGsNkNU" >> ~/.ssh/known_hosts
+	grep --quiet '^sn10.bi.privat' ~/.ssh/known_hosts || echo "sn10.bi.privat ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC49py5wws/7FhAfRDRS8byDMbSaqxNj3ddigSoXJM/y" >> ~/.ssh/known_hosts
 	grep --quiet '^sn10.galaxyproject.eu' ~/.ssh/known_hosts || echo "sn10.galaxyproject.eu ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC49py5wws/7FhAfRDRS8byDMbSaqxNj3ddigSoXJM/y" >> ~/.ssh/known_hosts
 	grep --quiet '^central-manager.bi.privat' ~/.ssh/known_hosts || echo "central-manager.bi.privat ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMoOla00b8+03VlVu9TOHJbij41jFILenJ2zWHsZE8fh" >> ~/.ssh/known_hosts
 	grep --quiet '^sn12.galaxyproject.eu' ~/.ssh/known_hosts || echo "sn12.galaxyproject.eu ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMoOla00b8+03VlVu9TOHJbij41jFILenJ2zWHsZE8fh" >> ~/.ssh/known_hosts

--- a/group_vars/sn10/autofs.yml
+++ b/group_vars/sn10/autofs.yml
@@ -1,0 +1,5 @@
+autofs_mount_points:
+  - data
+  - misc
+
+nfs_kernel_tuning: true

--- a/group_vars/sn10/vars.yml
+++ b/group_vars/sn10/vars.yml
@@ -1,0 +1,1 @@
+hostname: "{{ inventory_hostname }}"

--- a/hosts
+++ b/hosts
@@ -108,7 +108,7 @@ tpv-broker.bi.privat
 sn09.galaxyproject.eu
 
 [sn10]
-sn10.galaxyproject.eu ansible_ssh_user=root
+sn10.bi.privat ansible_ssh_user=root
 
 [sn11]
 sn11.galaxyproject.eu ansible_ssh_user=root

--- a/sn10.yml
+++ b/sn10.yml
@@ -1,0 +1,15 @@
+- name: Set up sn10 server
+  hosts: sn10
+  become: true
+  vars_files:
+    - mounts/dest/all.yml
+    - mounts/mountpoints.yml
+  roles:
+    - role: usegalaxy_eu.handy.os_setup
+      vars:
+        enable_hostname: true
+    - usegalaxy-eu.dynmotd
+    - usegalaxy-eu.autoupdates
+    - influxdata.chrony
+
+    - usegalaxy-eu.autofs


### PR DESCRIPTION
Run `usegalaxy_eu.handy.os_setup` (with only `enable_hostname` set to `true`), `usegalaxy-eu.dynmotd`, `usegalaxy-eu.autoupdates`, `influxdata.chrony` and (notably) `usegalaxy-eu.autofs`.

Motivated by the need for a [test deployment of the UCSC Genome Browser](https://github.com/usegalaxy-eu/issues/issues/952), being the most important bit the setup of the NFS shares.

**EDIT:** I created a [Jenkins project](https://build.galaxyproject.eu/job/usegalaxy-eu/job/playbooks/job/sn10/) too.