### PR TITLE
Pilot UCSC Genome Browser deployment

### DIFF
--- a/files/traefik/rules/ucsc-genome-browser-middleware.yml
+++ b/files/traefik/rules/ucsc-genome-browser-middleware.yml
@@ -1,0 +1,4 @@
+http:
+  middlewares:
+    ucsc-genome-browser-compress:
+      compress: {}

--- a/files/traefik/rules/ucsc-genome-browser-router.yml
+++ b/files/traefik/rules/ucsc-genome-browser-router.yml
@@ -1,0 +1,11 @@
+http:
+  routers:
+    ucsc-genome-browser-rtr:
+      rule: "Host(`genome.galaxyproject.eu`)"
+      service: ucsc-genome-browser
+      entryPoints:
+        - ucsc-genome-browser
+      tls:
+        certResolver: "route53"
+        domains:
+          - main: "genome.galaxyproject.eu"

--- a/files/traefik/rules/ucsc-genome-browser-router.yml
+++ b/files/traefik/rules/ucsc-genome-browser-router.yml
@@ -1,11 +1,11 @@
 http:
   routers:
     ucsc-genome-browser-rtr:
-      rule: "Host(`genome.galaxyproject.eu`)"
+      rule: "Host(`genome-browser.galaxyproject.eu`)"
       service: ucsc-genome-browser
       entryPoints:
         - websecure
       tls:
         certResolver: "route53"
         domains:
-          - main: "genome.galaxyproject.eu"
+          - main: "genome-browser.galaxyproject.eu"

--- a/files/traefik/rules/ucsc-genome-browser-router.yml
+++ b/files/traefik/rules/ucsc-genome-browser-router.yml
@@ -5,6 +5,8 @@ http:
       service: ucsc-genome-browser
       entryPoints:
         - websecure
+      middlewares:
+        - ucsc-genome-browser-compress
       tls:
         certResolver: "route53"
         domains:

--- a/files/traefik/rules/ucsc-genome-browser-router.yml
+++ b/files/traefik/rules/ucsc-genome-browser-router.yml
@@ -4,7 +4,7 @@ http:
       rule: "Host(`genome.galaxyproject.eu`)"
       service: ucsc-genome-browser
       entryPoints:
-        - ucsc-genome-browser
+        - websecure
       tls:
         certResolver: "route53"
         domains:

--- a/files/traefik/rules/ucsc-genome-browser-service.yml
+++ b/files/traefik/rules/ucsc-genome-browser-service.yml
@@ -1,0 +1,7 @@
+http:
+  services:
+    ucsc-genome-browser:
+      loadBalancer:
+        serversTransport: ucsc-genome-browser-transport
+        servers:
+          - url: "http://sn10.bi.privat:8030"

--- a/files/traefik/rules/ucsc-genome-browser-service.yml
+++ b/files/traefik/rules/ucsc-genome-browser-service.yml
@@ -2,6 +2,5 @@ http:
   services:
     ucsc-genome-browser:
       loadBalancer:
-        serversTransport: ucsc-genome-browser-transport
         servers:
           - url: "http://sn10.bi.privat:8030"

--- a/files/traefik/rules/ucsc-genome-browser-transport.yml
+++ b/files/traefik/rules/ucsc-genome-browser-transport.yml
@@ -1,0 +1,4 @@
+http:
+  serversTransports:
+    ucsc-genome-browser-transport:
+      serverName: genome.galaxyproject.eu

--- a/files/traefik/rules/ucsc-genome-browser-transport.yml
+++ b/files/traefik/rules/ucsc-genome-browser-transport.yml
@@ -1,4 +1,0 @@
-http:
-  serversTransports:
-    ucsc-genome-browser-transport:
-      serverName: genome.galaxyproject.eu

--- a/group_vars/ucsc_genome_browser.yml
+++ b/group_vars/ucsc_genome_browser.yml
@@ -9,7 +9,9 @@ ucsc_genome_browser_vm_state: present  # use `absent` to remove the VM
 
 ucsc_genome_browser_vm_cpus: 2
 ucsc_genome_browser_vm_memory: 16384
-ucsc_genome_browser_vm_ports: []
+ucsc_genome_browser_vm_ports:
+  - host: 8030
+    guest: 80
 ucsc_genome_browser_vm_shares:
   - host: /data/misc08/gbdb/
     guest: "{{ ucsc_genome_browser_setting_GBDBDIR | default('/gbdb/')}}"

--- a/group_vars/ucsc_genome_browser.yml
+++ b/group_vars/ucsc_genome_browser.yml
@@ -1,0 +1,50 @@
+ucsc_genome_browser_setup_script: https://raw.githubusercontent.com/ucscGenomeBrowser/kent/fdded708bc8405da6d0ff43d42f0092a872a0a97/src/product/installer/browserSetup.sh
+ucsc_genome_browser_setup_script_checksum: sha256:e47cd21c479a53d3157a4cd54f867dc26420d5f825d0b6954257e3ee3054882d
+
+ucsc_genome_browser_assemblies: []
+ucsc_genome_browser_assemblies_env: "OS=linux MACH=x86_64"  # works around a bug in the installation script
+
+ucsc_genome_browser_vm_name: ucsc_genome_browser
+ucsc_genome_browser_vm_state: present  # use `absent` to remove the VM
+
+ucsc_genome_browser_vm_cpus: 2
+ucsc_genome_browser_vm_memory: 16384
+ucsc_genome_browser_vm_ports: []
+ucsc_genome_browser_vm_shares:
+  - host: /data/misc08/gbdb/
+    guest: "{{ ucsc_genome_browser_setting_GBDBDIR | default('/gbdb/')}}"
+    readonly: true
+  #  # TODO: default settings should be retrieved from the installation script
+
+ucsc_genome_browser_vm_vagrant_project_dir: "/opt/ucsc_genome_browser/"
+ucsc_genome_browser_vm_vagrantfile: |
+    Vagrant.configure("2") do |config|
+      config.vm.define "{{ ucsc_genome_browser_vm_name }}"
+
+      config.vm.box = "generic/rocky9"
+
+      config.vm.provider "libvirt" do |libvirt|
+        libvirt.default_prefix = ""
+
+        libvirt.memory = {{ ucsc_genome_browser_vm_memory }}
+        libvirt.cpus = {{ ucsc_genome_browser_vm_cpus }}
+  
+        # required to use `virtiofs` for synced folders
+        libvirt.memorybacking :access, :mode => "shared"
+      end
+
+    {% for port in ucsc_genome_browser_vm_ports %}
+      config.vm.network "forwarded_port", guest: {{ port.guest }}, host: {{ port.host }}
+    {% endfor %}
+
+    {% for share in ucsc_genome_browser_vm_shares %}
+      config.vm.synced_folder "{{ share.host }}", "{{ share.guest }}",
+      type: "virtiofs",
+      readonly: {{ share.readonly | default(false) | lower }},
+    {# ensure no performance loss is caused by virtiofs #}
+      accessmode: "passthrough",
+      cache: "always",
+      queue_size: 1024,
+      mount_options: ["dax=always"]
+    {% endfor %}
+    end

--- a/hosts
+++ b/hosts
@@ -45,6 +45,9 @@ cvmfs-stratum0.galaxyproject.eu
 [plausible]
 plausible.bi.privat
 
+[ucsc_genome_browser]
+ucsc-genome-browser.bi.privat ansible_ssh_user=vagrant ansible_ssh_common_args='-o ProxyCommand="ssh -W %h:%p root@sn10.bi.privat"'
+
 [celerycluster]
 celery-1.bi.privat
 celery-2.bi.privat

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -188,3 +188,6 @@ roles:
   - name: l3d.restic
     version: v0.9.2
     src: https://github.com/roles-ansible/ansible_role_restic
+  - name: usegalaxy_eu.ucsc_genome_browser
+    version: a0ca168cc0bd0bf8ff7b1df97b7a8b4e797f7524
+    src: https://github.com/usegalaxy-eu/ansible-ucsc-genome-browser

--- a/ucsc_genome_browser.yml
+++ b/ucsc_genome_browser.yml
@@ -89,6 +89,9 @@
   tasks:
     - name: Manage UCSC Genome Browser VM
       block:
+        - name: Gather system service facts
+          ansible.builtin.service_facts:
+
         - name: Ensure UCSC Genome Browser Vagrant project directory exists
           ansible.builtin.file:
             path: "{{ ucsc_genome_browser_vm_vagrant_project_dir }}"
@@ -101,6 +104,19 @@
           ansible.builtin.copy:
             dest: "{{ ucsc_genome_browser_vm_vagrant_project_dir }}/Vagrantfile"
             content: "{{ ucsc_genome_browser_vm_vagrantfile }}"
+
+        - name: Open forwarded ports for UCSC Genome Browser VM
+          ansible.posix.firewalld:
+            port: "{{ port }}/tcp"
+            immediate: true
+            permanent: true
+            state: enabled
+          loop: "{{ ucsc_genome_browser_vm_ports | map(attribute='host') | list }}"
+          loop_control:
+            loop_var: port
+          when:
+            - ucsc_genome_browser_vm_state == "present"
+            - "'firewalld.service' in ansible_facts.services"
 
         - name: Start UCSC Genome Browser VM
           when: ucsc_genome_browser_vm_state == "present"
@@ -119,6 +135,20 @@
           ansible.builtin.file:
             path: "{{ ucsc_genome_browser_vm_vagrant_project_dir }}"
             state: absent
+
+        - name: Close forwarded ports for UCSC Genome Browser VM
+          ansible.posix.firewalld:
+            port: "{{ port }}/tcp"
+            immediate: true
+            permanent: true
+            state: disabled
+          loop: "{{ ucsc_genome_browser_vm_ports | map(attribute='host') | list }}"
+          loop_control:
+            loop_var: port
+          when:
+            - ucsc_genome_browser_vm_state == "absent"
+            - "'firewalld.service' in ansible_facts.services"
+
   post_tasks:
     - name: Retrieve IP address for UCSC Genome Browser VM
       when: ucsc_genome_browser_vm_state == "present"

--- a/ucsc_genome_browser.yml
+++ b/ucsc_genome_browser.yml
@@ -1,0 +1,194 @@
+# - name: Import sn10 playbook
+#   # crucially, the misc08 mount must be available before the UCSC Genome
+#   # browser VM is deployed
+  # import_playbook: sn10.yml
+
+- name: Manage UCSC Genome Browser VM
+  # provisional deployment, to be replaced either by a bare-metal or a
+  # Terraform-based virtual machine
+  hosts: sn10
+  become: true
+  vars_files:
+    - group_vars/ucsc_genome_browser.yml
+  pre_tasks:
+    - name: Install Vagrant
+      block:
+        - name: Install yum-utils
+          ansible.builtin.package:
+            name: yum-utils
+            state: present
+
+        - name: Import HashiCorp GPG key
+          ansible.builtin.rpm_key:
+            state: present
+            key: https://rpm.releases.hashicorp.com/gpg
+
+        - name: Add HashiCorp YUM repository
+          ansible.builtin.yum_repository:
+            name: hashicorp
+            description: HashiCorp Stable - $basearch
+            baseurl: "https://rpm.releases.hashicorp.com/RHEL/$releasever/$basearch/stable"
+            enabled: true
+            gpgcheck: true
+            gpgkey: "https://rpm.releases.hashicorp.com/gpg"
+            state: present
+
+        - name: Install `vagrant` package
+          ansible.builtin.dnf:
+            name: vagrant
+            state: present
+            update_cache: true
+
+        - name: Install QEMU and Vagrant libvirt plugin
+          block:
+            - name: Ensure KVM, `libvirt` and QEMU are available
+              ansible.builtin.package:
+                name:
+                  - qemu-kvm
+                  - libvirt
+                state: present
+
+            - name: Enable and start all modular Libvirt sockets
+              ansible.builtin.systemd:
+                name: "{{ item }}"
+                state: started
+                enabled: true
+              with_items:
+                - virtqemud.socket
+                - virtnetworkd.socket
+                - virtstoraged.socket
+                - virtnodedevd.socket
+                - virtnwfilterd.socket
+                - virtsecretd.socket
+                - virtinterfaced.socket
+                # - virtproxyd.socket
+              become: true
+
+            - name: Check if Vagrant libvirt plugin is already installed
+              ansible.builtin.command:
+                cmd: vagrant plugin list
+              register: vagrant_plugins
+              changed_when: false
+
+            - name: Install build dependencies for Vagrant libvirt plugin
+              ansible.builtin.package:
+                name:
+                  - make
+                  - gcc
+                  - libvirt-devel
+                state: present
+                enablerepo: crb
+              when: "'vagrant-libvirt' not in vagrant_plugins.stdout"
+
+            - name: Build Vagrant libvirt plugin
+              ansible.builtin.command:
+                cmd: vagrant plugin install vagrant-libvirt
+              register: vagrant_plugin_install
+              failed_when: vagrant_plugin_install.rc != 0
+              when: "'vagrant-libvirt' not in vagrant_plugins.stdout"
+  tasks:
+    - name: Manage UCSC Genome Browser VM
+      block:
+        - name: Ensure UCSC Genome Browser Vagrant project directory exists
+          ansible.builtin.file:
+            path: "{{ ucsc_genome_browser_vm_vagrant_project_dir }}"
+            state: directory
+            owner: root
+            group: root
+            mode: "0750"
+
+        - name: Deploy Vagrantfile for UCSC Genome Browser VM
+          ansible.builtin.copy:
+            dest: "{{ ucsc_genome_browser_vm_vagrant_project_dir }}/Vagrantfile"
+            content: "{{ ucsc_genome_browser_vm_vagrantfile }}"
+
+        - name: Start UCSC Genome Browser VM
+          when: ucsc_genome_browser_vm_state == "present"
+          ansible.builtin.command:
+            cmd: vagrant up
+            chdir: "{{ ucsc_genome_browser_vm_vagrant_project_dir }}"
+
+        - name: Destroy UCSC Genome Browser VM
+          when: ucsc_genome_browser_vm_state == "absent"
+          ansible.builtin.command:
+            cmd: vagrant destroy -f
+            chdir: "{{ ucsc_genome_browser_vm_vagrant_project_dir }}"
+
+        - name: Clear UCSC Genome Browser Vagrant project directory
+          when: ucsc_genome_browser_vm_state == "absent"
+          ansible.builtin.file:
+            path: "{{ ucsc_genome_browser_vm_vagrant_project_dir }}"
+            state: absent
+  post_tasks:
+    - name: Retrieve IP address for UCSC Genome Browser VM
+      when: ucsc_genome_browser_vm_state == "present"
+      block:
+        - name: Get IP address for UCSC Genome Browser VM
+          ansible.builtin.shell:
+            cmd: vagrant ssh-config | grep HostName | awk '{print $2}'
+            chdir: "{{ ucsc_genome_browser_vm_vagrant_project_dir }}"
+          register: ucsc_genome_browser_vm_ip_address
+          changed_when: false
+
+        - name: Set fact for UCSC Genome Browser VM IP address (on controller)
+          become: false
+          delegate_to: localhost
+          delegate_facts: true
+          ansible.builtin.set_fact:
+            ucsc_genome_browser_vm_ip_address: "{{ ucsc_genome_browser_vm_ip_address.stdout }}"
+
+    - name: Retrieve SSH access key for UCSC Genome Browser VM
+      when: ucsc_genome_browser_vm_state == "present"
+      block:
+        - name: Locate SSH access key for UCSC Genome Browser VM
+          ansible.builtin.shell:
+            cmd: vagrant ssh-config | grep IdentityFile | awk '{print $2}'
+            chdir: "{{ ucsc_genome_browser_vm_vagrant_project_dir }}"
+          register: ucsc_genome_browser_vm_ssh_key_path
+          changed_when: false
+
+        - name: Slurp SSH access key for UCSC Genome Browser VM
+          ansible.builtin.slurp:
+            src: "{{ ucsc_genome_browser_vm_ssh_key_path.stdout }}"
+          register: ucsc_genome_browser_vm_private_key_slurp
+
+        - name: Decode SSH access key for UCSC Genome Browser VM
+          ansible.builtin.set_fact:
+            ucsc_genome_browser_vm_private_key_content: "{{ ucsc_genome_browser_vm_private_key_slurp.content | b64decode }}"
+
+        - name: Create temporary setup directory for UCSC Genome Browser role on controller
+          become: false
+          delegate_to: localhost
+          delegate_facts: true
+          ansible.builtin.tempfile:
+            state: directory
+            prefix: ucsc_genome_browser
+          changed_when: false
+          register: ucsc_genome_browser_tmpdir_controller
+
+        - name: Write SSH access key for UCSC Genome Browser VM to temporary file on controller
+          become: false
+          delegate_to: localhost
+          delegate_facts: true
+          ansible.builtin.copy:
+            content: "{{ ucsc_genome_browser_vm_private_key_content }}"
+            dest: "{{ ucsc_genome_browser_tmpdir_controller.path }}/ucsc_genome_browser_vm_private_key"
+            mode: "0600"
+          no_log: true
+
+        - name: Set UCSC Genome Browser VM SSH key file path (on controller)
+          become: false
+          delegate_to: localhost
+          delegate_facts: true
+          ansible.builtin.set_fact:
+            ucsc_genome_browser_vm_private_key_path: "{{ ucsc_genome_browser_tmpdir_controller.path }}/ucsc_genome_browser_vm_private_key"
+
+- name: Install UCSC Genome Browser
+  hosts: ucsc_genome_browser
+  tags: ucsc_genome_browser
+  vars:
+    ansible_host: "{{ hostvars['localhost']['ucsc_genome_browser_vm_ip_address'] }}"
+    ansible_ssh_private_key_file: "{{ hostvars['localhost']['ucsc_genome_browser_vm_private_key_path'] }}"
+  roles:
+    - name: usegalaxy_eu.ucsc_genome_browser
+      become: true


### PR DESCRIPTION
Deploy the UCSC genome browser on a Vagrant VM running on sn10.

⚠️ Requires https://github.com/usegalaxy-eu/infrastructure-playbook/pull/2179.

Closes https://github.com/usegalaxy-eu/issues/issues/952.

> **TODO:**
> - [ ] Revert 7ea9d5164b76702df471dcda1cb3e25ca7b9f57d, make Apache responsible for the compression (lightens the load on Traefik).

About the TODO: I should start debugging this deployment with UCSC people tomorrow, let's postpone it.