### PR TITLE
new vgcn fixed cvmfs

### DIFF
--- a/group_vars/dnbd3primary/vars.yml
+++ b/group_vars/dnbd3primary/vars.yml
@@ -1,7 +1,7 @@
 ---
 # Important! This defines which image the bare metal cluster boots.
 # On the node or in Jenkins you can map the revision id (=Jenkins build number) to a vgcn commit
-vgcn_image_revision_id: 336
+vgcn_image_revision_id: 357
 pxe_tarball_revision_id: 37
 
 dnbd3_is_proxy: false

--- a/templates/dnbd3/config.j2
+++ b/templates/dnbd3/config.j2
@@ -1,6 +1,6 @@
 read_only_partition="/dev/disk/by-label/system"
 SLX_DNBD3_SERVERS='{{ hostvars['dnbd3-primary.galaxyproject.eu']['ansible_default_ipv4']['address'] }} {{ hostvars['sn12.galaxyproject.eu']['ansible_default_ipv4']['address'] }}'
-SLX_DNBD3_IMAGE='rockylinux-10-latest-x86_64-generic-workers-internal.qcow2'
+SLX_DNBD3_IMAGE='rockylinux-10-latest-x86_64-generic+workers-internal.qcow2'
 SLX_DNBD3_RID='{{ vgcn_image_revision_id }}'
 SLX_CONFIG_NAME='config.tgz.r{{ pxe_tarball_revision_id }}'
 SLX_WRITABLE_DEVICE_PERSISTENT='no'


### PR DESCRIPTION
This is the new image with fixed cvmfs uid and guid. The problem was that for some reason, autofs reload on vgcn first run would mess with `/scratch/cvmfs` directory ownership (I couldn't find the reason why tho ...)

The solution was to actually add a task to the playbook that makes sure the cvmfs directory as the right ownership:

https://github.com/usegalaxy-eu/vgcn/commit/893c94168562bec6659b6c2ec055b00f709c3450