### PR TITLE
add tcp passtrough to traefik

### DIFF
--- a/files/traefik/rules/cvmfs-stratum0-router.yml
+++ b/files/traefik/rules/cvmfs-stratum0-router.yml
@@ -1,0 +1,7 @@
+tcp:
+  routers:
+    cvmfs-stratum0-rsync:
+      rule: "HostSNI(`*`)"
+      service: cvmfs-stratum0-rsync
+      entryPoints:
+        - cvmfs-rsync

--- a/files/traefik/rules/cvmfs-stratum0-service.yml
+++ b/files/traefik/rules/cvmfs-stratum0-service.yml
@@ -1,0 +1,6 @@
+tcp:
+  services:
+    cvmfs-stratum0-rsync:
+      loadBalancer:
+        servers:
+          - address: "cvmfs-stratum0.bi.privat:22"

--- a/files/traefik/rules/cvmfs-stratum0-service.yml
+++ b/files/traefik/rules/cvmfs-stratum0-service.yml
@@ -3,4 +3,4 @@ tcp:
     cvmfs-stratum0-rsync:
       loadBalancer:
         servers:
-          - address: "cvmfs-stratum0.bi.privat:22"
+          - address: "10.4.68.179:22"

--- a/group_vars/traefik.yml
+++ b/group_vars/traefik.yml
@@ -75,6 +75,7 @@ traefik_containers:
       - --entryPoints.websecure.address=:443
       - --entryPoints.amqps.address=:5671
       - --entryPoints.influxdb.address=:8086
+      - --entryPoints.cvmfs-rsync.address=:5432
       - --entryPoints.web.http.redirections.entryPoint.to=websecure
       - --entryPoints.web.http.redirections.entryPoint.scheme=https
       - --entryPoints.metrics.address=:8082
@@ -159,6 +160,10 @@ traefik_containers:
         mode: host
       - target_port: 8086
         published_port: 8086
+        protocol: tcp
+        mode: host
+      - target_port: 5432
+        published_port: 5432
         protocol: tcp
         mode: host
 

--- a/group_vars/traefik.yml
+++ b/group_vars/traefik.yml
@@ -75,7 +75,7 @@ traefik_containers:
       - --entryPoints.websecure.address=:443
       - --entryPoints.amqps.address=:5671
       - --entryPoints.influxdb.address=:8086
-      - --entryPoints.cvmfs-rsync.address=:5432
+      - --entryPoints.cvmfs-rsync.address=:9087
       - --entryPoints.web.http.redirections.entryPoint.to=websecure
       - --entryPoints.web.http.redirections.entryPoint.scheme=https
       - --entryPoints.metrics.address=:8082
@@ -162,8 +162,8 @@ traefik_containers:
         published_port: 8086
         protocol: tcp
         mode: host
-      - target_port: 5432
-        published_port: 5432
+      - target_port: 9087
+        published_port: 9087
         protocol: tcp
         mode: host
 

--- a/traefik-proxy.yml
+++ b/traefik-proxy.yml
@@ -28,7 +28,14 @@
         - http
         - https
         - ntp
-        - postgresql
+
+    - name: Configure CVMFS rsync port
+      ansible.posix.firewalld:
+        port: 9087/tcp
+        permanent: true
+        immediate: true
+        zone: public
+        state: enabled
 
     - name: Install python docker
       become: true

--- a/traefik-proxy.yml
+++ b/traefik-proxy.yml
@@ -28,6 +28,7 @@
         - http
         - https
         - ntp
+        - postgresql
 
     - name: Install python docker
       become: true


### PR DESCRIPTION
Part of the stratum 0 migration and upgrade we need to put it behind the traefik and enable tcp passtrough so @natefoo can rsync the stratums. We would need to change the rsync port tho.

The KVM is prepared and right now mounted as read-only. We can switch as soon we test the sync.

To switch, we can stop the old server and make the new one read-write (`cvmfs_server transaction`).

ref: https://github.com/usegalaxy-eu/issues/issues/616