### PR TITLE
add log rotation for cleanup scripts in maintenance

### DIFF
--- a/group_vars/maintenance.yml
+++ b/group_vars/maintenance.yml
@@ -427,6 +427,16 @@ lp_logrotate_confd:
         notifempty
         compress
       }
+  - path: galaxy
+    conf: |
+      /var/log/galaxy/ {
+        compress
+      	copytruncate
+      	daily
+      	notifempty
+      	missingok
+      	rotate 1
+      }
 
 # WallE
 walle_verbose: false

--- a/group_vars/maintenance.yml
+++ b/group_vars/maintenance.yml
@@ -435,7 +435,7 @@ lp_logrotate_confd:
       	daily
       	notifempty
       	missingok
-      	rotate 1
+      	rotate 14
       }
 
 # WallE


### PR DESCRIPTION
I noticed the logs are not behing rotated in maintenance. Right now we have ~500Mb of logs on `/var/log/galaxy ` that we want probably to rotate. 

Part of: https://github.com/usegalaxy-eu/issues/issues/995