### PR TITLE
Update genai_models.loc: aliases + pinned models, remove dead e-INFRA entries

### DIFF
--- a/files/galaxy/config/llm/genai_models.loc
+++ b/files/galaxy/config/llm/genai_models.loc
@@ -24,9 +24,30 @@ qwen3.5-9b-llmlb-freiburg	qwen3.5-9b-llmlb	Efficient 9B native vision-language m
 mistral-small-4-llmlb-freiburg	mistral-small-4-llmlb	Latest Mistral Small generation with multimodal support and strong instruction following (Mistral-Small-4) [uni-freiburg]	multimodal	uni-freiburg	Mistral AI
 gemma-4-31b-llmlb-freiburg	gemma-4-31b-llmlb	High-performance 31B multimodal model for complex reasoning and image understanding (Gemma-4-31B-IT) [uni-freiburg]	multimodal	uni-freiburg	Google DeepMind
 glm-5.2-llmlb-freiburg	glm-5.2-llmlb	Flagship Mixture-of-Experts model by Zhipu AI optimized for coding, agentic workflows, and long-horizon tasks (GLM-5.2) [uni-freiburg]	text	uni-freiburg	Zhipu AI
+gemma-4-12b-llmlb-freiburg	gemma-4-12b-llmlb	12B multimodal, balanced speed and capability (Gemma-4-12B) [uni-freiburg]	multimodal	uni-freiburg	Google DeepMind
+kimi-k2.7-code-llmlb-freiburg	kimi-k2.7-code-llmlb	Kimi K2.7 specialized for coding [uni-freiburg]	text	uni-freiburg	Moonshot AI
 gpt-oss-120b-e-infra.cz	gpt-oss-120b	Most capable for complex tasks, deep reasoning, and detailed outputs (GPT-OSS-120B) [e-INFRA CZ]	text	e-infra.cz	OpenAI
-deepseek-v3.2-e-infra.cz	deepseek-v3.2	High-performance model with advanced reasoning capabilities (DeepSeek-V3.2) [e-INFRA CZ]	text	e-infra.cz	DeepSeek
-deepseek-v3.2-thinking-e-infra.cz	deepseek-v3.2-thinking	DeepSeek V3.2 with enhanced thinking and reasoning process (DeepSeek-V3.2-Thinking) [e-INFRA CZ]	text	e-infra.cz	DeepSeek
-llama-4-scout-17b-16e-instruct-e-infra.cz	llama-4-scout-17b-16e-instruct	Efficient instruct-tuned model for general tasks (Llama-4-Scout-17B) [e-INFRA CZ]	multimodal	e-infra.cz	Meta AI
-qwen3-coder-30b-e-infra.cz	qwen3-coder-30b	Specialized code generation model with 30B parameters (Qwen3-Coder-30B) [e-INFRA CZ]	multimodal	e-infra.cz	Alibaba Cloud
-qwen3-coder-e-infra.cz	qwen3-coder	Efficient code generation model for programming tasks (Qwen3-Coder) [e-INFRA CZ]	multimodal	e-infra.cz	Alibaba Cloud
+deepseek-v4-pro-e-infra.cz	deepseek-v4-pro	DeepSeek V4 Pro - 1.6T MoE, 1M context [e-INFRA CZ]	text	e-infra.cz	DeepSeek
+deepseek-v4-pro-thinking-e-infra.cz	deepseek-v4-pro-thinking	DeepSeek V4 Pro with reasoning enabled [e-INFRA CZ]	text	e-infra.cz	DeepSeek
+qwen3.5-122b-e-infra.cz	qwen3.5-122b	Qwen3.5 122B MoE, multimodal [e-INFRA CZ]	multimodal	e-infra.cz	Alibaba Cloud
+qwen3.5-int4-e-infra.cz	qwen3.5-int4	Qwen3.5 397B (int4 AWQ), multimodal [e-INFRA CZ]	multimodal	e-infra.cz	Alibaba Cloud
+qwen3.5-e-infra.cz	qwen3.5	Qwen3.5 model family, multimodal [e-INFRA CZ]	multimodal	e-infra.cz	Alibaba Cloud
+gemma4-e-infra.cz	gemma4	Gemma 4 model family, multimodal [e-INFRA CZ]	multimodal	e-infra.cz	Google DeepMind
+mistral-medium-3.5-e-infra.cz	mistral-medium-3.5	Mistral Medium 3.5, 128B multimodal [e-INFRA CZ]	multimodal	e-infra.cz	Mistral AI
+kimi-k2.7-e-infra.cz	kimi-k2.7	Kimi K2.7, coding and multimodal, 256k context [e-INFRA CZ]	multimodal	e-infra.cz	Moonshot AI
+glm-5.2-e-infra.cz	glm-5.2	GLM 5.2 - 756B MoE, coding and agentic workflows [e-INFRA CZ]	multimodal	e-infra.cz	Zhipu AI
+command-a-e-infra.cz	command-a	Cohere Command-A [e-INFRA CZ]	multimodal	e-infra.cz	Cohere
+
+# --- Aliases: stable role/task routing names ---
+deepseek-e-infra.cz	deepseek	DeepSeek - latest, math and coding [e-INFRA CZ]	text	e-infra.cz	DeepSeek
+deepseek-thinking-e-infra.cz	deepseek-thinking	DeepSeek with step-by-step reasoning on [e-INFRA CZ]	text	e-infra.cz	DeepSeek
+thinker-e-infra.cz	thinker	Reasoning model for complex problems [e-INFRA CZ]	text	e-infra.cz	e-infra.cz
+mini-e-infra.cz	mini	Compact fast default model [e-INFRA CZ]	multimodal	e-infra.cz	e-infra.cz
+coder-e-infra.cz	coder	Coding-focused model [e-INFRA CZ]	multimodal	e-infra.cz	e-infra.cz
+agentic-e-infra.cz	agentic	Agentic/coding model [e-INFRA CZ]	multimodal	e-infra.cz	e-infra.cz
+kimi-e-infra.cz	kimi	Kimi, strong coding performance [e-INFRA CZ]	multimodal	e-infra.cz	Moonshot AI
+glm-e-infra.cz	glm	GLM, large context [e-INFRA CZ]	multimodal	e-infra.cz	Zhipu AI
+ufr-coding-fast-freiburg	ufr/coding-fast	Fast coding/text model [uni-freiburg]	multimodal	uni-freiburg	uni-freiburg
+ufr-coding-complex-freiburg	ufr/coding-complex	Higher-capability coding/text model [uni-freiburg]	text	uni-freiburg	uni-freiburg
+ufr-vision-fast-freiburg	ufr/vision-fast	Fast vision/multimodal model [uni-freiburg]	multimodal	uni-freiburg	uni-freiburg
+ufr-vision-complex-freiburg	ufr/vision-complex	Higher-capability vision/multimodal model [uni-freiburg]	multimodal	uni-freiburg	uni-freiburg


### PR DESCRIPTION
Updates `files/galaxy/config/llm/genai_models.loc` for the LLM Hub tool, keeping the dropdown usable as e-INFRA CZ rotates models (see CESNET/usegalaxy#340).

## What changed

**Added 12 aliases** — stable role/task routing names the LiteLLM proxy resolves server-side, so the dropdown survives concrete-model rotation:
- e-INFRA CZ: `deepseek`, `deepseek-thinking`, `thinker`, `mini`, `coder`, `agentic`, `kimi`, `glm`
- uni-freiburg: `ufr/coding-fast`, `ufr/coding-complex`, `ufr/vision-fast`, `ufr/vision-complex` (exposed as `ufr-*-freiburg` since the `value` column can't contain `/`)

**Added 12 pinned concrete model ids** — for reproducibility-sensitive work where the exact model matters:
- e-INFRA CZ: `deepseek-v4-pro`, `deepseek-v4-pro-thinking`, `qwen3.5-122b`, `qwen3.5-int4`, `qwen3.5`, `gemma4`, `mistral-medium-3.5`, `kimi-k2.7`, `glm-5.2`, `command-a`
- uni-freiburg: `gemma-4-12b-llmlb`, `kimi-k2.7-code-llmlb`

**Removed 5 e-INFRA entries** whose models no longer exist on the proxy (each returns HTTP 400 `Invalid model name`):
- `deepseek-v3.2`, `deepseek-v3.2-thinking`, `llama-4-scout-17b-16e-instruct`, `qwen3-coder-30b`, `qwen3-coder`

## Design notes
- **Reproducibility:** existing entry `value` identifiers (column 0, stored in Galaxy dataset/job metadata) are preserved so old datasets and workflows keep resolving. Only dead models were removed.
- **Naming convention:** new entries follow the existing `-e-infra.cz` / `-freiburg` `value` suffix; the `model_id` column holds the real id sent to the proxy.
- **No tool changes:** this is a `.loc`-only update — the aliases are just `model_id` values the proxy resolves, so no changes to `llm_hub.xml`/`llm_hub.py`.
- **free_tag column:** generic role aliases (`thinker`, `mini`, `coder`, `agentic`) carry the provider as their tag (since the alias name isn't a vendor); vendor-named aliases keep the vendor — consistent with the existing `ufr-*` entries.
- **Descriptions** carry no volatile text (no `(currently X)` resolution note, no `pinned`/`alias` labels) so they don't go stale; the alias->model mapping is maintained upstream by CERIT-SC at https://docs.cerit.io/en/docs/ai-as-a-service/chat-ai#model-aliases.

## Verification
All 36 resulting entries were probed live against their proxies via `/v1/chat/completions` (text request for all, text+image for the 27 multimodal entries) on 2026-07-14 — every entry returns 200. Routing headers confirmed `kimi-k2.7-code-llmlb` resolves to its own backend (not, e.g., GLM-5.2).