### PR TITLE
lower celery mem limit

### DIFF
--- a/group_vars/celerycluster.yml
+++ b/group_vars/celerycluster.yml
@@ -48,12 +48,12 @@ galaxy_systemd_celery_internal_pool: threads
 galaxy_systemd_celery_internal_max_tasks: 250000
 galaxy_systemd_celery_internal_workers: 1
 galaxy_systemd_celery_internal_concurrency: 8
-galaxy_systemd_memory_limit_celery_internal: "{{ galaxy_systemd_celery_internal_concurrency * 6 }}"
+galaxy_systemd_memory_limit_celery_internal: 10
 galaxy_systemd_celery_external_pool: threads
 galaxy_systemd_celery_external_max_tasks: 250000
 galaxy_systemd_celery_external_workers: 1
 galaxy_systemd_celery_external_concurrency: 2
-galaxy_systemd_memory_limit_celery_external: "{{ galaxy_systemd_celery_external_concurrency * 6 }}"
+galaxy_systemd_memory_limit_celery_external: 10
 
 # Flower
 flower_bind_address: "{{ tailscale_node_ipv4 }}"

--- a/hosts
+++ b/hosts
@@ -49,11 +49,12 @@ plausible.bi.privat
 celery-1.bi.privat
 celery-2.bi.privat
 celery-3.bi.privat
-celery-4.bi.privat
 celery-cloud-0.galaxyproject.eu ansible_ssh_user=rocky
 celery-cloud-1.galaxyproject.eu ansible_ssh_user=rocky
 celery-cloud-2.galaxyproject.eu ansible_ssh_user=rocky
 celery-cloud-3.galaxyproject.eu ansible_ssh_user=rocky
+celery-cloud-4.galaxyproject.eu ansible_ssh_user=rocky
+celery-cloud-5.galaxyproject.eu ansible_ssh_user=rocky
 
 # Baremetal
 [galaxyservers]

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -100,7 +100,7 @@ roles:
     src: https://github.com/usegalaxy-eu/ansible-certbot
     version: 0.1.5
   - name: usegalaxy_eu.galaxy_systemd
-    version: 2.3.0
+    version: 2.4.0
   - name: usegalaxy-eu.dynmotd
     src: https://github.com/usegalaxy-eu/ansible-dynmotd
     version: 0.1.0


### PR DESCRIPTION
With recent fixes, our celery restarts pick memory is be less than 1G. I think having some slack in case we need to process milions of tasks again at the time is okay IMO. 

needs: https://github.com/usegalaxy-eu/ansible-galaxy-systemd/pull/20

closes https://github.com/usegalaxy-eu/issues/issues/1010