### PR TITLE
run ITs in v100

### DIFF
--- a/files/galaxy/tpv/tool_defaults.yml.j2
+++ b/files/galaxy/tpv/tool_defaults.yml.j2
@@ -110,12 +110,14 @@ tools:
         cores: 1
         mem: 4
         params:
+          requirements: '(GalaxyGroup == "pxe-gpu-div4")'
           docker_volumes: $defaults
           container_monitor_result: callback
         scheduling:
           require:
             - docker
             - embedded-pulsar
+
       - id: remote_resources
         if: not (dry_run_mode := job_wrapper is None) and (user is not None and not (tool.tool_type in ["expression", "data_source"] or tool.requires_galaxy_python_environment))
         # `job_wrapper is None` occurs when TPV is launched in dry-run mode


### PR DESCRIPTION
It's a quick fix. Other tools still also run in the v100.

Closes https://github.com/usegalaxy-eu/issues/issues/1016.