### PR TITLE
Comment out TPV references to destinations that divide GPUs across jobs

### DIFF
--- a/files/galaxy/tpv/destinations.yml.j2
+++ b/files/galaxy/tpv/destinations.yml.j2
@@ -153,13 +153,13 @@ destinations:
               else:
                   entity.params['submit_requirements'] = gpu_conditions
 
-  embedded_pulsar_docker_gpu_pxe_div4:
-    inherits: embedded_pulsar_docker_gpu_pxe
-    context:
-      galaxy_group: 'GalaxyGroup == "pxe-gpu-div4"'
-    scheduling:
-      require:
-        - pxe-gpu-div4
+  # embedded_pulsar_docker_gpu_pxe_div4:
+  #   inherits: embedded_pulsar_docker_gpu_pxe
+  #   context:
+  #     galaxy_group: 'GalaxyGroup == "pxe-gpu-div4"'
+  #   scheduling:
+  #     require:
+  #       - pxe-gpu-div4
 
 
 
@@ -596,17 +596,17 @@ destinations:
 
 
   # This means a GPU can be shared by max 4 jobs at the same time
-  condor_container_gpu_divide4:
-    inherits: condor_container_gpu
-    max_accepted_gpus: 1
-    params:
-      singularity_enabled: false  # sharing GPUs has not been tested with Singularity
-      requirements: 'GalaxyGroup == "pxe-gpu-div4"'
-    scheduling:
-      require:
-        - gpu-divided
-      reject:
-        - singularity  # sharing GPUs has not been tested with Singularity
+  # condor_container_gpu_divide4:
+  #   inherits: condor_container_gpu
+  #   max_accepted_gpus: 1
+  #   params:
+  #     singularity_enabled: false  # sharing GPUs has not been tested with Singularity
+  #     requirements: 'GalaxyGroup == "pxe-gpu-div4"'
+  #   scheduling:
+  #     require:
+  #       - gpu-divided
+  #     reject:
+  #       - singularity  # sharing GPUs has not been tested with Singularity
 
   condor_singularity_with_conda:
     inherits: basic_singularity_destination

--- a/files/galaxy/tpv/interactive_tools.yml
+++ b/files/galaxy/tpv/interactive_tools.yml
@@ -90,9 +90,9 @@ tools:
     mem: 8
     env:
       XLA_FLAGS: "--xla_gpu_cuda_data_dir=/op/conda/"
-    scheduling:
-      require:
-        - pxe-gpu-div4
+    # scheduling:
+    #   require:
+    #     - pxe-gpu-div4
 
   #interactive_tool_jupyter_notebook:
   #  rules:

--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -443,9 +443,9 @@ tools:
       docker_run_extra_arguments: ' --gpus all '
     env:
       GPU_AVAILABLE: 1
-    scheduling:
-      require:
-        - gpu-divided
+    # scheduling:
+    #   require:
+    #     - gpu-divided
 
   toolshed.g2.bx.psu.edu/repos/bgruening/whisper/whisper/.*:
     cores: 1
@@ -464,9 +464,9 @@ tools:
       WHISPERX_MODEL_DIR: "/data/db/models/whisperx/whisperx_models/"
       WHISPERX_DEVICE: "cuda"
       WHISPERX_COMPUTE_TYPE: "float16"
-    scheduling:
-      require:
-        - gpu-divided
+    # scheduling:
+    #   require:
+    #     - gpu-divided
 
   toolshed.g2.bx.psu.edu/repos/iuc/biapy/biapy/.*:
     inherits: _basic_docker_tool


### PR DESCRIPTION
At the moment, the v100 is our only host supporting this feature, but it is running interactive tools via `GalaxyGroup = "interactive"`. Crucially, it no longer belongs to the "pxe-gpu-div4" group, so any tools that at the moment need to run on such a host will fail to run.