### PR TITLE
Add Kraken OCR tool configuration with environment variable TORCHINDUCTOR_CACHE_DIR set to "$_GALAXY_JOB_TMP_DIR"

### DIFF
--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -901,3 +901,6 @@ tools:
       SINGULARITYENV_LITELLM_CONFIG_FILE: '/data/db/models/config/litellm_config.yml'
       LITELLM_CONFIG_FILE: '/data/db/models/config/litellm_config.yml'
 
+  toolshed.g2.bx.psu.edu/tools/bgruening/kraken_ocr/kraken_ocr/.*:
+    env:
+      _GALAXY_JOB_TMP_DIR: '/tmp'

--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -903,4 +903,4 @@ tools:
 
   toolshed.g2.bx.psu.edu/tools/bgruening/kraken_ocr/kraken_ocr/.*:
     env:
-      _GALAXY_JOB_TMP_DIR: '/tmp'
+      TORCHINDUCTOR_CACHE_DIR: "$_GALAXY_JOB_TMP_DIR"


### PR DESCRIPTION
All tools within the kraken_ocr suite are running on useGalaxyEU in the following error:

> │ 15 │ cache_dir = os.environ.get("TORCHINDUCTOR_CACHE_DIR") │
> │ 16 │ if cache_dir is None: │
> │ 17 │ │ os.environ["TORCHINDUCTOR_CACHE_DIR"] = cache_dir = default_cac │
> │ ❱ 18 │ os.makedirs(cache_dir, exist_ok=True) │
> │ 19 │ return cache_dir │
> │ 20 │
> │ 21 │
> │ │
> │ /usr/local/lib/python3.10/os.py:225 in makedirs │
> │ │
> │ 222 │ │ if tail == cdir: # xxx/newdir/. exists if xxx/newdi │
> │ 223 │ │ │ return │
> │ 224 │ try: │
> │ ❱ 225 │ │ mkdir(name, mode) │
> │ 226 │ except OSError: │
> │ 227 │ │ # Cannot rely on checking for EEXIST, since the operating sys │
> │ 228 │ │ # could give priority to other errors like EACCES or EROFS │
> 
> ╰──────────────────────────────────────────────────────────────────────────────╯
> FileNotFoundError: [Errno 2] No such file or directory: ''

Going through the traceback we (@anuprulez and I) assume that  _GALAXY_JOB_TMP_DIR = ""
because the TORCHINDUCTOR_CACHE_DIR is set as follows:
`<environment_variable name="TORCHINDUCTOR_CACHE_DIR">\$_GALAXY_JOB_TMP_DIR</environment_variable>`

So setting GALAXY_JOB_TMP_DIR explicit to /tmp hopefully resolves this