### PR TITLE
Move DNF Automatic role `usegalaxy-eu.autoupdates` to all.yml

### DIFF
--- a/all.yml
+++ b/all.yml
@@ -4,3 +4,10 @@
   gather_facts: false
   roles:
     - role: usegalaxy_eu.ssh_manager
+
+- name: Manage repositories and packages
+  hosts: all
+  become: true
+  roles:
+    - role: usegalaxy-eu.autoupdates
+      when: ansible_facts['os_family'] == "RedHat"

--- a/beacon.yml
+++ b/beacon.yml
@@ -17,7 +17,6 @@
         enable_powertools: true        # geerlingguy.repo-epel role doesn't enable PowerTools repository
         #enable_remap_user: true
         enable_create_user: true
-    - usegalaxy-eu.autoupdates  # keep all of our packages up to date
     - influxdata.chrony
     - dj-wasabi.telegraf
     - usegalaxy-eu.dynmotd # nicer MOTD/welcome message

--- a/cvmfs.yml
+++ b/cvmfs.yml
@@ -39,7 +39,6 @@
         enable_grub: true
         enable_kernel_5: true
     - geerlingguy.repo-epel     # Install EPEL repository
-    - usegalaxy-eu.autoupdates  # keep all of our packages up to date
     - influxdata.chrony         # Keep our time in sync.
     - usegalaxy-eu.dynmotd
     # Filesystems

--- a/dnbd3_libvirt_jenkins.yml
+++ b/dnbd3_libvirt_jenkins.yml
@@ -55,7 +55,6 @@
         name: require-autofs.service
   roles:
     - usegalaxy-eu.dynmotd
-    - usegalaxy-eu.autoupdates # keep all of our packages up to date
     - influxdata.chrony # Keep our time in sync.
     - dj-wasabi.telegraf
     - usegalaxy-eu.autofs
@@ -168,7 +167,6 @@
     - hxr.admin-tools
     - influxdata.chrony
     - hxr.monitor-email
-    - usegalaxy-eu.autoupdates
     - usegalaxy-eu.autofs
     - ssh-host-sign
     - dj-wasabi.telegraf
@@ -206,7 +204,6 @@
     - geerlingguy.repo-epel
     - influxdata.chrony
     - hxr.monitor-email
-    - usegalaxy-eu.autoupdates
     - hxr.aws-cli # Setup the AWS client that will be needed for route53 authentication of certbot. MUST come before nginx role
     - galaxyproject.nginx
     - ssh-host-sign

--- a/grafana.yml
+++ b/grafana.yml
@@ -39,10 +39,6 @@
         hostname: "{{ grafana_domain }}"
         enable_hostname: true
         enable_powertools: true # geerlingguy.repo-epel role doesn't enable PowerTools repository
-    - role: usegalaxy-eu.autoupdates # keep all of our packages up to date
-      become: true
-      vars:
-        hostname: "{{ grafana_domain }}"
     - influxdata.chrony # Keep our time in sync.
 
     ## Monitoring

--- a/group_vars/grafana/vars.yml
+++ b/group_vars/grafana/vars.yml
@@ -33,6 +33,9 @@ nginx_ssl_role: usegalaxy-eu.certbot
 nginx_conf_ssl_certificate: /etc/ssl/certs/fullchain.pem
 nginx_conf_ssl_certificate_key: /etc/ssl/user/privkey-nginx.pem
 
+# Autoupdates
+au_hostname: "{{ grafana_domain }}"
+
 # Grafana
 grafana_version: "11.4.0"
 

--- a/group_vars/proxy.yml
+++ b/group_vars/proxy.yml
@@ -8,6 +8,3 @@ nginx_conf_http:
 nginx_remove_default_vhost: true
 
 certbot_well_known_root: /srv/nginx/_well-known_root
-
-# Autoupdates
-au_apply_updates: true

--- a/incoming.yml
+++ b/incoming.yml
@@ -56,7 +56,6 @@
         enable_remap_user: true
         enable_install_software: true  # Some extra admin tools (*top, vim, etc)
     - geerlingguy.repo-epel     # Install EPEL repository
-    - usegalaxy-eu.autoupdates  # keep all of our packages up to date
     - influxdata.chrony         # Keep our time in sync.
     - usegalaxy-eu.dynmotd
     ## Filesystems

--- a/maintenance.yml
+++ b/maintenance.yml
@@ -139,7 +139,6 @@
     - usegalaxy-eu.vgcn-monitoring
     - usegalaxy_eu.handy.os_setup
     - geerlingguy.repo-epel
-    - usegalaxy-eu.autoupdates
     - influxdata.chrony
     - usegalaxy-eu.autofs
     - hxr.monitor-cluster

--- a/mq.yml
+++ b/mq.yml
@@ -54,7 +54,6 @@
         enable_remap_user: true
         enable_create_user: true
     - geerlingguy.repo-epel     # Install EPEL repository
-    - usegalaxy-eu.autoupdates  # keep all of our packages up to date
     - influxdata.chrony         # Keep our time in sync.
     # Applications
     - geerlingguy.docker

--- a/plausible.yml
+++ b/plausible.yml
@@ -15,7 +15,6 @@
     - geerlingguy.repo-epel
     - hxr.admin-tools
     - influxdata.chrony
-    - usegalaxy-eu.autoupdates
     # - galaxyproject.nginx
     # missing iptables, pip3 install docker
     - geerlingguy.docker

--- a/proxy.yml
+++ b/proxy.yml
@@ -21,7 +21,6 @@
         enable_powertools: true        # geerlingguy.repo-epel role doesn't enable PowerTools repository
         enable_grub: true
     - geerlingguy.repo-epel     # Install EPEL repository
-    - usegalaxy-eu.autoupdates  # keep all of our packages up to date
     - influxdata.chrony         # Keep our time in sync.
     - usegalaxy-eu.dynmotd
     # Applications

--- a/sn09.yml
+++ b/sn09.yml
@@ -292,7 +292,6 @@
         enable_pam_limits: true # Prevent out of control processes
         enable_install_software: true # Some extra admin tools (*top, vim, etc)
     - geerlingguy.repo-epel # Install EPEL repository
-    - usegalaxy-eu.autoupdates # keep all of our packages up to date
     - influxdata.chrony # Keep our time in sync.
 
     ## Filesystems

--- a/sn10.yml
+++ b/sn10.yml
@@ -9,7 +9,6 @@
       vars:
         enable_hostname: true
     - usegalaxy-eu.dynmotd
-    - usegalaxy-eu.autoupdates
     - influxdata.chrony
 
     - usegalaxy-eu.autofs

--- a/sn11.yml
+++ b/sn11.yml
@@ -34,7 +34,6 @@
     - usegalaxy-eu.dynmotd
     - influxdata.chrony
     - hxr.monitor-email
-    - usegalaxy-eu.autoupdates # keep all of our packages up to date
     - usegalaxy-eu.autofs
     - ssh-host-sign
     - usegalaxy-eu.ansible-postgresql

--- a/traefik-proxy.yml
+++ b/traefik-proxy.yml
@@ -48,7 +48,6 @@
 
   roles:
     - geerlingguy.repo-epel # Install EPEL repository
-    - usegalaxy-eu.autoupdates # keep all of our packages up to date
     - influxdata.chrony # Keep our time in sync.
     - dj-wasabi.telegraf
     - usegalaxy-eu.logrotate # Rotate logs


### PR DESCRIPTION
Run the DNF Automatic role `usegalaxy-eu.autoupdates` in the all.yml playbook rather than on each individual playbook, as this configuration is generally desirable and present on most playbooks.

Restrict the application to RHEL-based distributions though, as there are servers that run other operating systems.