### PR TITLE
Resilient `rustus` systemd unit restart policy

### DIFF
--- a/upload.yml
+++ b/upload.yml
@@ -8,7 +8,43 @@
     - secret_group_vars/sentry.yml
     - mounts/mountpoints.yml
     - mounts/dest/all.yml
+  handlers:
+    - name: Reload systemd
+      ansible.builtin.systemd:
+        daemon_reload: true
   pre_tasks:
+    - name: Deploy `rustus` systemd unit override(s)
+      # increase the resilience of automatic restarts of `rustus` service to
+      # work around the error `rustus-main_uploads.service: Failed at step
+      # CHDIR spawning /usr/local/bin/rustus: No such file or directory` that
+      # occurs only for a short period of time after a reboot
+      block:
+        - name: Ensure systemd override directory exists
+          ansible.builtin.file:
+            dest: "/etc/systemd/system/rustus-{{ item.name }}.service.d/"
+            state: directory
+            owner: root
+            group: root
+            mode: "0644"
+          loop: "{{ rustus_instances }}"
+
+        - name: Deploy systemd override file
+          ansible.builtin.copy:
+            dest: "/etc/systemd/system/rustus-{{ item.name }}.service.d/override.conf"
+            content: |
+              [Unit]
+              # infinite restart attempts
+              StartLimitIntervalSec=0
+              
+              [Service]
+              Restart=always
+              RestartSec=10s
+              TimeoutStartSec=20s
+            owner: root
+            group: root
+            mode: "0644"
+          loop: "{{ rustus_instances }}"
+          notify: Reload systemd
     - ansible.posix.firewalld:
         zone: public
         port: 1080-1081/tcp


### PR DESCRIPTION
Override all `rustus` systemd units so that the service is automatically restarted every ten seconds without a limit on the number of restart attempts.

Addresses https://github.com/usegalaxy-eu/issues/issues/991.

**EDIT:** this is a quick and dirty fix, but at least we would have a fix in-place for Monday.