### PR TITLE
add port to apollo nginx redirect

### DIFF
--- a/templates/nginx/galaxy-main.j2
+++ b/templates/nginx/galaxy-main.j2
@@ -266,7 +266,7 @@ server {
     {{ gapars_nginx_config }}
 
     location /apollo/ {
-        proxy_pass http://apollo.bi.privat/apollo/;
+        proxy_pass http://apollo.bi.privat:8080/apollo/;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection $connection_upgrade;


### PR DESCRIPTION
For `/apollo/` path specifically we can directly communicate with tomcat. I don't know why the nginx is not redirecting to tomcat the apollo path but for permapol and api it does.

Like this is working https://usegalaxy.eu/apollo/