### PR TITLE
add vulnerability security disclosure policy

### DIFF
--- a/files/galaxy/config/security.txt
+++ b/files/galaxy/config/security.txt
@@ -1,0 +1,4 @@
+Contact: mailto:galaxy@informatik.uni-freiburg.de
+Expires: 2030-06-19T13:03:00.000Z
+Preferred-Languages: en
+Canonical: https://usegalaxy.eu/.well-known/security.txt

--- a/sn09.yml
+++ b/sn09.yml
@@ -135,6 +135,15 @@
       ansible.builtin.copy:
         content: '{{ firewall_htcondor_shared_port_service }}'
         dest: /etc/firewalld/services/htcondor-shared-port.xml
+
+    - name: Deploy security.txt
+      ansible.builtin.copy:
+        src: files/galaxy/security.txt
+        dest: /etc/nginx/security.txt
+        owner: root
+        group: root
+        mode: '0644'
+
   post_tasks:
     - name: Write Galaxy __galaxy_client_build_version and __galaxy_current_commit_id
       delegate_to: 127.0.0.1

--- a/templates/nginx/galaxy-main.j2
+++ b/templates/nginx/galaxy-main.j2
@@ -254,6 +254,12 @@ server {
             proxy_pass          http://127.0.0.1:{{ gie_proxy_port }};
         }
 
+    location = /.well-known/security.txt {
+        alias /etc/nginx/security.txt;
+        default_type text/plain;
+        add_header Cache-Control "no-store";
+    }
+
     location /.well-known/ {
         proxy_pass          http://127.0.0.1:8118;
         proxy_set_header    Host                $host;


### PR DESCRIPTION
The first step is to add the security disclosure contact information. After that we can discuss some security policies.

Partially resolves https://github.com/usegalaxy-eu/issues/issues/1004.