### PR TITLE
Fix Systemd Mount Files for KVM Autostart

### DIFF
--- a/dnbd3_libvirt_jenkins.yml
+++ b/dnbd3_libvirt_jenkins.yml
@@ -118,16 +118,13 @@
         content: |
           [Unit]
           Description=Mount NFS Share for Libvirt
-          Requires=network-online.target
-          After=network-online.target
-          Before=virtstoraged.service
           
           [Mount]
           What=/dev/mapper/vg_images-images
           Where=/images
           
           [Install]
-          RequiredBy=virtstoraged.service
+          RequiredBy=libvirtd.service
         dest: /etc/systemd/system/images.mount
     - name: Create mountpoint for Libvirt
       ansible.builtin.copy:
@@ -136,7 +133,6 @@
           Description=Mount NFS Share for Libvirt
           Requires=network-online.target
           After=network-online.target
-          Before=virtstoraged.service
           
           [Mount]
           What=ufr-dyn.isi1.public.ads.uni-freiburg.de:/ifs/isi1/ufr/bronze/nfs/denbi/dnb01/vms
@@ -145,7 +141,7 @@
           Options=hard,rw,nosuid,nconnect=2,nodev,vers=3
           
           [Install]
-          RequiredBy=virtstoraged.service
+          WantedBy=remote-fs.target
         dest: /etc/systemd/system/data.mount
   post_tasks:
     - name: Enable the service

--- a/dnbd3_libvirt_jenkins.yml
+++ b/dnbd3_libvirt_jenkins.yml
@@ -124,7 +124,7 @@
           Where=/images
           
           [Install]
-          RequiredBy=libvirtd.service
+          RequiredBy=libvirtd.socket
         dest: /etc/systemd/system/images.mount
     - name: Create mountpoint for Libvirt
       ansible.builtin.copy:


### PR DESCRIPTION
See https://github.com/usegalaxy-eu/issues/issues/991 This was not working, because it is not virtstoraged, but virqemud which manages the VMs. The underlying service is libvirtd, so this should be referenced.
For the NFS mount this would result in a cyclic dependency so adding it to remote-fs.target is the solution that works. See https://www.reddit.com/r/systemd/comments/pk6igk/start_service_after_all_mount_units_had_run/

---

Closes https://github.com/usegalaxy-eu/issues/issues/991.