### PR TITLE
Ensure `firewalld` is installed on Celery cluster

### DIFF
--- a/celery.yml
+++ b/celery.yml
@@ -12,6 +12,11 @@
     - mounts/mountpoints.yml
     - mounts/dest/all.yml
   pre_tasks:
+    - name: Install `firewalld` package
+      ansible.builtin.package:
+        name: firewalld
+        state: present
+
     - name: Select main node for the Celery cluster
       # The main node is the only one that runs Flower and Celery Beat. It is the first host defined in the inventory
       # for Celery Cluster group.

--- a/celery.yml
+++ b/celery.yml
@@ -12,11 +12,6 @@
     - mounts/mountpoints.yml
     - mounts/dest/all.yml
   pre_tasks:
-    - name: Install `firewalld` package
-      ansible.builtin.package:
-        name: firewalld
-        state: present
-
     - name: Select main node for the Celery cluster
       # The main node is the only one that runs Flower and Celery Beat. It is the first host defined in the inventory
       # for Celery Cluster group.

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -162,7 +162,7 @@ roles:
     version: 2.0.0
   - src: https://github.com/usegalaxy-eu/ansible-fw-glxeu-generic
     name: usegalaxy_eu.firewall
-    version: 2.0.0
+    version: 2.1.0
   - name: usegalaxy_eu.dnbd3
     src: https://github.com/usegalaxy-eu/ansible-dnbd3
     version: main


### PR DESCRIPTION
```
fatal: [celery-cloud-3.galaxyproject.eu]: FAILED! => {"changed": false, "msg": "Could not find the requested service firewalld: host"}
```

`dnf install firewalld` also shows it as uninstalled for hosts where the Celery cluster is not active yet.