### PR TITLE
Ensure apollo restarts and add mountpoints

### DIFF
--- a/apollo.yml
+++ b/apollo.yml
@@ -49,7 +49,7 @@
     - hxr.gx-cookie-proxy
 
     - hxr.apollo
-  post_install:
+  post_tasks:
     - name: Restart Tomcat service if Apollo is not accessible
       block:
         - name: Check if Apollo is accessible

--- a/apollo.yml
+++ b/apollo.yml
@@ -50,9 +50,18 @@
 
     - hxr.apollo
   post_install:
-    - name: Ensure to restart tomcat service
-      # serves as workaround for Apollo not coming back up after a reboot
-      ansible.builtin.service:
-        name: tomcat
-        state: restarted
-        enabled: true
+    - name: Restart Tomcat service if Apollo is not accessible
+      block:
+        - name: Check if Apollo is accessible
+          ansible.builtin.uri:
+            url: "http://127.0.0.1:8080"
+            method: GET
+            return_content: no
+          register: apollo_status
+
+        - name: Restart Tomcat service
+          ansible.builtin.service:
+            name: tomcat
+            state: restarted
+            enabled: true
+          when: apollo_status.status >= 400

--- a/apollo.yml
+++ b/apollo.yml
@@ -43,9 +43,16 @@
     - influxdata.chrony
 
     - galaxyproject.nginx
-    - hxr.autofs
+    - usegalaxy-eu.autofs
 
     - devops.tomcat7
     - hxr.gx-cookie-proxy
 
     - hxr.apollo
+  post_install:
+    - name: Ensure to restart tomcat service
+      # serves as workaround for Apollo not coming back up after a reboot
+      ansible.builtin.service:
+        name: tomcat
+        state: restarted
+        enabled: true

--- a/apollo.yml
+++ b/apollo.yml
@@ -54,7 +54,7 @@
       block:
         - name: Check if Apollo is accessible
           ansible.builtin.uri:
-            url: "http://127.0.0.1:8080"
+            url: "http://127.0.0.1:8080/apollo/annotator/index"
             method: GET
             return_content: no
           register: apollo_status

--- a/group_vars/apollo.yml
+++ b/group_vars/apollo.yml
@@ -6,8 +6,9 @@ hxr_custom_user:
   comment: "Apache Tomcat"
   shell: /sbin/nologin
 
-usegalaxy_eu_autofs_mounts:
+autofs_mount_points:
   - data
+nfs_kernel_tuning: true
 
 # NGINX
 nginx_enable_default_server: false


### PR DESCRIPTION
Switch from the ancient `hxr.autofs` role to `usegalaxy-eu.autofs`, which is the role that is currently in use to manage the mounts.

Restart Tomcat service after the playbook runs. Works around an issue with Apollo not coming back up after a reboot (this workaround would make it come back after the playbook runs).

Closes https://github.com/usegalaxy-eu/issues/issues/991.