### PR TITLE
Accept HTTP errors when checking if Apollo is accessible

### DIFF
--- a/apollo.yml
+++ b/apollo.yml
@@ -58,6 +58,7 @@
             method: GET
             return_content: no
           register: apollo_status
+          ignore_errors: true
 
         - name: Restart Tomcat service
           ansible.builtin.service:


### PR DESCRIPTION
Obviously needed, because "Restart Tomcat service" should run precisely when there are errors.

Follow-up for https://github.com/usegalaxy-eu/infrastructure-playbook/pull/2218 and https://github.com/usegalaxy-eu/infrastructure-playbook/pull/2219.