### PR TITLE
Bump Grafana 11.4.0→13.1.1

### DIFF
--- a/group_vars/grafana/vars.yml
+++ b/group_vars/grafana/vars.yml
@@ -37,7 +37,7 @@ nginx_conf_ssl_certificate_key: /etc/ssl/user/privkey-nginx.pem
 au_hostname: "{{ grafana_domain }}"
 
 # Grafana
-grafana_version: "11.4.0"
+grafana_version: "13.1.1"
 
 # patch from https://github.com/grafana/grafana-ansible-collection/pull/414;
 # once merged upstream, update the collection version in requirements.yml and


### PR DESCRIPTION
This is necessary because we acidentally updated it during https://github.com/usegalaxy-eu/issues/issues/1020 when we did a `dnf update` on all servers.
After a downgrade automatically done by ansible, the pyroscope plugin is not loading anymore leading to broken dashboards. This is presumably due to a background npm update or changes in the database, however something that can not be undone by dnf/rpm downgrades.
The lesson from this is to deploy services with docker, or exclude packages manually.