### PR TITLE
Deploy security.txt security disclosure policy file from correct path

### DIFF
--- a/sn09.yml
+++ b/sn09.yml
@@ -138,7 +138,7 @@
 
     - name: Deploy security.txt
       ansible.builtin.copy:
-        src: files/galaxy/security.txt
+        src: files/galaxy/config/security.txt
         dest: /etc/nginx/security.txt
         owner: root
         group: root


### PR DESCRIPTION
The current path [is incorrect](https://build.galaxyproject.eu/job/usegalaxy-eu/job/playbooks/job/sn09/580/console), resulting in the failure of the task "Deploy security.txt".

Follow-up for https://github.com/usegalaxy-eu/infrastructure-playbook/pull/2209, partially resolves https://github.com/usegalaxy-eu/issues/issues/1004.