### PR TITLE
add support to tags

### DIFF
--- a/templates/galaxy/config/job_conf.yml
+++ b/templates/galaxy/config/job_conf.yml
@@ -6,15 +6,26 @@ galaxy_jobconf:
   plugin_workers: 8
   handlers:
     count: "{{ galaxy_systemd_handlers }}"
-    assign_with: db-skip-locked
+    assign: db-skip-locked
     max_grab: 16
     ready_window_size: 32
+    handler_definitions:
+      0:
+        tags:
+          - htcondor-apiv2
+        plugins:
+          - htcondor_apiv2
+    default_process:
+      exclude_plugins:
+        - htcondor_apiv2
   plugins:
     #- id: drmaa
     #load: galaxy.jobs.runners.drmaa:DRMAAJobRunner
     #workers: 3
     - id: condor
       load: galaxy.jobs.runners.condor:CondorJobRunner
+    - id: htcondor_apiv2
+      load: galaxy.jobs.runners.htcondor:HTCondorJobRunner
     - id: local
       load: galaxy.jobs.runners.local:LocalJobRunner
     - id: pulsar_embedded

--- a/templates/galaxy/config/job_conf.yml.j2
+++ b/templates/galaxy/config/job_conf.yml.j2
@@ -31,9 +31,9 @@ runners:
 # Job handler configuration
 #
 handling:
-{% if galaxy_jobconf.handlers.assign_with is defined %}
-  assign_with:
-    - {{ galaxy_jobconf.handlers.assign_with }}
+{% if galaxy_jobconf.handlers.assign is defined %}
+  assign:
+    - {{ galaxy_jobconf.handlers.assign }}
 {% endif %}
 {% if galaxy_jobconf.handlers.default is defined %}
   default: {{ galaxy_jobconf.handlers.default }}
@@ -46,8 +46,28 @@ handling:
 {% endif %}
 {% if galaxy_systemd_handlers is defined and galaxy_systemd_handlers > 0 %}
   processes:
+{% set handler_definitions = galaxy_jobconf.handlers.handler_definitions | default({}) %}
+{% set default_handler_definition = galaxy_jobconf.handlers.default_process | default({}) %}
 {% for n in range(galaxy_systemd_handlers) %}
+{% set handler_definition = handler_definitions.get(n, default_handler_definition) %}
     {{ galaxy_systemd_handler_prefix }}_{{ n }}:
+{% if handler_definition.tags is defined %}
+      tags:
+{% for tag in handler_definition.tags %}
+        - {{ tag }}
+{% endfor %}
+{% endif %}
+{% if handler_definition.plugins is defined %}
+      plugins:
+{% for plugin in handler_definition.plugins %}
+        - {{ plugin }}
+{% endfor %}
+{% elif handler_definition.exclude_plugins is defined %}
+      plugins:
+{% for plugin in galaxy_jobconf.plugins | sort(attribute='id') if plugin.id not in handler_definition.exclude_plugins %}
+        - {{ plugin.id }}
+{% endfor %}
+{% endif %}
 {% endfor %}
 {% elif galaxy_systemd_handlers is defined and galaxy_systemd_handlers == 0 %}
   processes:
@@ -113,6 +133,9 @@ tools:
   - id: {{ tool['id'] }}
 {% if 'destination' in tool %}
     environment: {{ tool['destination'] }}
+{% endif %}
+{% if 'handler' in tool %}
+    handler: {{ tool['handler'] }}
 {% endif %}
 {% if 'resources' in tool %}
     resources: {{ tool['resources'] }}


### PR DESCRIPTION
This pull request updates the Galaxy job configuration templates to provide more flexible and explicit handler and plugin assignment, especially for HTCondor support. The changes introduce new fields for handler definitions, improve handler assignment logic, and add support for specifying handlers per tool.

Handler and plugin assignment improvements:
* Changed the handler assignment field from `assign_with` to `assign` in both `job_conf.yml` and `job_conf.yml.j2` to match the sample conf file
* Added support for per-handler definitions via a new `handler_definitions` section, allowing tags and plugins to be set for individual handlers, and introduced a `default_process` for fallback configuration. 
* Enhanced the Jinja2 template logic to dynamically assign tags and plugins to handlers based on these new definitions, including support for plugin exclusion.

HTCondor support:
* Added the `htcondor_apiv2` plugin and its handler tag to the configuration, and ensured it can be excluded from the default process if needed.

Per-tool handler assignment:
* Enabled specifying a `handler` for individual tools in the job configuration template, allowing more granular control over job routing.

ref: https://github.com/usegalaxy-eu/infrastructure-playbook/issues/1926