### PR TITLE
Set domain=embedding for RAG embedding models in huggingface.loc

### DIFF
--- a/files/galaxy/config/llm/huggingface.loc
+++ b/files/galaxy/config/llm/huggingface.loc
@@ -7,7 +7,7 @@
 #<unique_build_id>      <display_name>  <pipeline_tag>  <domain>        <free_tag>      <version>       <folder_base_path>
 #
 #pipeline_tag (see this URL: https://huggingface.co/models?pipeline_tag=text-to-image they call it that way)
-#domain (defined by the Galaxy community, e.g. image / sequence / text)
+#domain (defined by the Galaxy community, e.g. image / sequence / text / tabular / embedding)
 #free_tag (not idea yet, but could be freely used by an admin to specify more filter options)
 #version (if available)
 #Your huggingface.loc file should include the huggingface cached model folder you have stored.
@@ -41,5 +41,5 @@ tabpfn_2_5/tabpfn-v2.5-regressor-v2.5_small-samples	tabpfn-v2.5-regressor-v2.5_s
 tabpfn_2_5/tabpfn-v2.5-regressor-v2.5_variant	tabpfn-v2.5-regressor-v2.5_variant	tabular-regression	tabular	tabpfn	1	/data/db/models/huggingface/tabpfn_2_5/tabpfn-v2.5-regressor-v2.5_variant.ckpt
 
 ## RAG embedding models
-sentence-transformers/all-MiniLM-L6-v2	all-MiniLM-L6-v2	feature-extraction	text	vector-rag	1	/data/db/models/huggingface/embeddings/sentence-transformers/all-MiniLM-L6-v2
-BAAI/bge-small-en	BAAI bge-small-en	feature-extraction	text	vector-rag	1	/data/db/models/huggingface/embeddings/BAAI/bge-small-en
+sentence-transformers/all-MiniLM-L6-v2	all-MiniLM-L6-v2	feature-extraction	embedding	vector-rag	1	/data/db/models/huggingface/embeddings/sentence-transformers/all-MiniLM-L6-v2
+BAAI/bge-small-en	BAAI bge-small-en	feature-extraction	embedding	vector-rag	1	/data/db/models/huggingface/embeddings/BAAI/bge-small-en


### PR DESCRIPTION
Follow-up to bgruening/galaxytools#1920 (RAG Retriever LiteLLM embedding support).

## Background

Review feedback in bgruening/galaxytools#1920 (discussion r3666891106) flagged an inconsistency in the `domain` column between the two data tables the RAG Retriever uses:

- `genai_models.loc` (LiteLLM path): `domain=embedding`
- `huggingface.loc` (preinstalled path): `domain=text` for the RAG embedding rows

## Change

Set `domain` to `embedding` for the two RAG embedding rows in `huggingface.loc` so the column is consistent across both tables. Also added `tabular` and `embedding` to the `domain` column's documented example values in the header comment (`tabular` was already in use by the tabpfn rows but not listed).

## Safety

This is a documentation/consistency change only. The RAG Retriever's preinstalled path selects models via `free_tag=vector-rag` and `version=1` — it does **not** filter on the `domain` column. Selection logic is therefore unaffected, and older installed versions of the tool continue to work unchanged.

The corresponding `huggingface.loc.sample` update is in bgruening/galaxytools#1920.