### PR TITLE
patch root owned files in venv

### DIFF
--- a/roles/hxr.install-to-venv/defaults/main.yml
+++ b/roles/hxr.install-to-venv/defaults/main.yml
@@ -1,0 +1,1 @@
+hxr_user: galaxy

--- a/roles/hxr.install-to-venv/tasks/main.yml
+++ b/roles/hxr.install-to-venv/tasks/main.yml
@@ -1,4 +1,5 @@
 - name: Install all of the necessary dependencies
+  become_user: "{{ galaxy_user }}"
   pip:
     name: "{{ pip_install_dependencies }}"
     virtualenv: "{{ pip_venv_path }}"

--- a/roles/hxr.install-to-venv/tasks/main.yml
+++ b/roles/hxr.install-to-venv/tasks/main.yml
@@ -1,5 +1,5 @@
 - name: Install all of the necessary dependencies
-  become_user: "galaxy"
+  become_user: "{{ hxr_user }}"
   pip:
     name: "{{ pip_install_dependencies }}"
     virtualenv: "{{ pip_venv_path }}"

--- a/roles/hxr.install-to-venv/tasks/main.yml
+++ b/roles/hxr.install-to-venv/tasks/main.yml
@@ -1,5 +1,5 @@
 - name: Install all of the necessary dependencies
-  become_user: "{{ galaxy_user }}"
+  become_user: "{{ galaxy_user.name }}"
   pip:
     name: "{{ pip_install_dependencies }}"
     virtualenv: "{{ pip_venv_path }}"

--- a/roles/hxr.install-to-venv/tasks/main.yml
+++ b/roles/hxr.install-to-venv/tasks/main.yml
@@ -1,5 +1,5 @@
 - name: Install all of the necessary dependencies
-  become_user: "{{ galaxy_user.name }}"
+  become_user: "galaxy"
   pip:
     name: "{{ pip_install_dependencies }}"
     virtualenv: "{{ pip_venv_path }}"


### PR DESCRIPTION
This role is used in sn09 that is by default running as root:

```
become: true
become_user: root
```

When the role is called and pip install whatever packages into venv, the packages will be installed as root, causing the CI fail to sync as user galaxy ....