### PR TITLE
make galaxyproject role independent

### DIFF
--- a/group_vars/sn09/sn09.yml
+++ b/group_vars/sn09/sn09.yml
@@ -316,7 +316,9 @@ galaxy_user:
   home: /opt/galaxy
   uid: 999
   shell: /bin/bash
-
+galaxy_webhook_dir: "{{ galaxy_mutable_data_dir }}/webhooks"
+galaxy_tour_dir: "{{ galaxy_mutable_data_dir }}/tours"
+tpv_mutable_dir: "{{ galaxy_mutable_data_dir }}/total_perspective_vortex"
 # Galaxy configuration files will be written with these permissions (mode argument to Ansible copy/template module)
 galaxy_config_perms: 0644
 

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -65,7 +65,7 @@ roles:
     version: 0.14.2
   - name: galaxyproject.galaxy
     src: https://github.com/galaxyproject/ansible-galaxy
-    version: cd835d778891539934c3da3b90d9b2ed4914c86f
+    version: ede09c4db04f37cbd51b9de060e70db58d6a2681
   - name: galaxyproject.cvmfs
     src: https://github.com/usegalaxy-eu/ansible-cvmfs
     version: master


### PR DESCRIPTION
If we ever need to just run ansible-galaxy role without depending in other roles we need to define this variables