### PR TITLE
Adds Stats routing to traefik

### DIFF
--- a/files/traefik/rules/grafana-router.yml
+++ b/files/traefik/rules/grafana-router.yml
@@ -1,0 +1,11 @@
+http:
+  routers:
+    grafana-rtr:
+      rule: "Host(`stats.galaxyproject.eu`)"
+      service: grafana
+      entryPoints:
+        - websecure
+      tls:
+        certResolver: "route53"
+        domains:
+          - main: "stats.galaxyproject.eu"

--- a/files/traefik/rules/grafana-service.yml
+++ b/files/traefik/rules/grafana-service.yml
@@ -1,0 +1,7 @@
+http:
+  services:
+    grafana:
+      loadBalancer:
+        passHostHeader: true
+        servers:
+          - url: "http://stats.bi.privat:3000"

--- a/grafana.yml
+++ b/grafana.yml
@@ -36,34 +36,27 @@
     - role: usegalaxy_eu.handy.os_setup
       become: true
       vars:
-        hostname: "{{ grafana_domain }}"
+        hostname: "{{ grafana_ini.server.domain }}"
         enable_hostname: true
         enable_powertools: true # geerlingguy.repo-epel role doesn't enable PowerTools repository
     - influxdata.chrony # Keep our time in sync.
 
     ## Monitoring
     - dj-wasabi.telegraf
-    - role: hxr.monitor-ssl
-      become: true
     - role: hxr.monitor-email
       become: true
 
-    ## Grafana
-    - role: galaxyproject.nginx
-      become: true
-      vars:
-        hostname: "{{ grafana_domain }}"
     - grafana
     - role: pgs
       become: true
 
   post_tasks:
-    - name: Open nginx ports
+    - name: Open Grafana port
       become: true
       ansible.posix.firewalld:
+        zone: internal
         port: "{{ item }}"
         permanent: true
         state: enabled
       with_items:
-        - 80/tcp
-        - 443/tcp
+        - 3000/tcp

--- a/group_vars/grafana/vars.yml
+++ b/group_vars/grafana/vars.yml
@@ -8,33 +8,8 @@ certbot_virtualenv_package_name: python3-virtualenv
 certbot_post_renewal: |
     systemctl restart nginx || true
 
-# NGINX
-nginx_enable_default_server: false
-nginx_servers:
-  - redirect-ssl
-nginx_ssl_servers:
-  - grafana-ssl
-
-nginx_conf_http:
-  gzip: "on"
-  gzip_vary: "on"
-  gzip_min_length: 256
-  gzip_proxied: any
-  gzip_comp_level: 6
-  gzip_http_version: "1.1"
-  gzip_types: text/plain text/css text/xml text/javascript application/javascript application/x-javascript application/xml image/png image/jpg
-  gzip_disable: '"MSIE [1-6]\."'
-  client_max_body_size: 1g
-
-nginx_remove_default_vhost: true
-
-# Nginx Letsencrypt bindings
-nginx_ssl_role: usegalaxy-eu.certbot
-nginx_conf_ssl_certificate: /etc/ssl/certs/fullchain.pem
-nginx_conf_ssl_certificate_key: /etc/ssl/user/privkey-nginx.pem
-
 # Autoupdates
-au_hostname: "{{ grafana_domain }}"
+au_hostname: "{{ grafana_ini.server.domain }}"
 
 # Grafana
 grafana_version: "13.1.1"
@@ -45,75 +20,58 @@ grafana_version: "13.1.1"
 grafana_yum_repo: "https://rpm.grafana.com"
 grafana_yum_key: "https://rpm.grafana.com/gpg.key"
 
-grafana_address: "127.0.0.1"
-grafana_domain: stats.galaxyproject.eu
-grafana_url: "https://{{ grafana_domain }}"
+grafana_ini:
+  server:
+    http_addr: "0.0.0.0"
+    domain: stats.galaxyproject.eu
+    root_url: "https://stats.galaxyproject.eu"
 
-grafana_users:
-  default_theme: "light"
+  users:
+    default_theme: light
 
-grafana_security:
-  admin_user: admin
-  admin_password: "{{ vault_grafana_auth_admin_password }}"
-  allow_embedding: "true"
-  cookie_secure: "true"
-grafana_security_secret_key: "{{ vault_grafana_security_secret_key }}"
+  security:
+    admin_user: admin
+    admin_password: "{{ vault_grafana_auth_admin_password }}"
+    secret_key: "{{ vault_grafana_security_secret_key }}"
+    allow_embedding: true
+    cookie_secure: true
 
-grafana_database:
-  type: postgres
-  host: sn11.galaxyproject.eu:5432
-  name: "{{ vault_grafana_database_name }}"
-  user: "{{ vault_grafana_database_user }}"
-  password: "{{ vault_grafana_database_password }}"
+  database:
+    type: postgres
+    host: sn11.galaxyproject.eu:5432
+    name: "{{ vault_grafana_database_name }}"
+    user: "{{ vault_grafana_database_user }}"
+    password: "{{ vault_grafana_database_password }}"
 
-grafana_auth:
-  anonymous:
-    enabled: "true"
-    org_name: "UseGalaxy.eu"
-    org_role: "Viewer"
+  auth:
+    anonymous:
+      enabled: true
+      org_name: UseGalaxy.eu
+      org_role: Viewer
+    github:
+      enabled: true
+      allow_sign_up: true
+      client_id: "{{ vault_grafana_auth__github_client_id }}"
+      client_secret: "{{ vault_grafana_auth__github_client_secret }}"
+      scopes: user:email,read:org
+      auth_url: https://github.com/login/oauth/authorize
+      token_url: https://github.com/login/oauth/access_token
+      api_url: https://api.github.com/user
+      allowed_organisations: usegalaxy.eu galaxyproject
 
-  github:
-    enabled: "true"
-    allow_sign_up: "true"
-    client_id: "{{ vault_grafana_auth__github_client_id }}"
-    client_secret: "{{ vault_grafana_auth__github_client_secret }}"
-    scopes: "user:email,read:org"
-    auth_url: "https://github.com/login/oauth/authorize"
-    token_url: "https://github.com/login/oauth/access_token"
-    api_url: "https://api.github.com/user"
-    allowed_organisations: "usegalaxy.eu galaxyproject"
-grafana_auth_admin_password: "{{ vault_grafana_auth_admin_password }}"
+  external_image_storage:
+    provider: local
 
-grafana_image_storage:
-  provider: local
+  panels:
+    disable_sanitize_html: true
 
-grafana_panels:
-  disable_sanitize_html: "true"
+  unified_alerting:
+    enabled: true
+    execute_alerts: true
 
-# This setting is not yet used by the role `grafana.grafana.grafana`. It will
-# be when PR [1] is merged.
-#
-# References:
-# - [1] https://github.com/grafana/grafana-ansible-collection/pull/215
-grafana_unified_alerting:
-  enabled: "true"
-  execute_alerts: "true"
-
-# Legacy alerting was removed in Grafana 11 [1]. However, the Ansible role
-# `grafana.grafana.grafana` still populates the [alerting] section [2] unless
-# `grafana_alerting` is empty. The setting can be removed from this file as
-# soon as PR [3] is merged.
-#
-# References:
-# - [1] https://grafana.com/blog/2024/04/04/legacy-alerting-removal-what-you-need-to-know-about-upgrading-to-grafana-alerting/
-# - [2] https://github.com/grafana/grafana-ansible-collection/blob/2e7fd0591d8ad1700186174213b8142047525b88/roles/grafana/templates/grafana.ini.j2#L116-L127
-# - [3] https://github.com/grafana/grafana-ansible-collection/pull/215
-grafana_alerting: {}
-
-grafana_plugins:
-  - grafana-worldmap-panel
-  - grafana-piechart-panel
-  - natel-discrete-panel
+# Grafana 13 does not support the legacy Angular plugins previously listed
+# here. Their dashboards must use supported visualizations instead.
+grafana_plugins: []
 
 grafana_dashboards_dir: "files/grafana"
 

--- a/hosts
+++ b/hosts
@@ -1,6 +1,6 @@
 # Cloud
 [grafana]
-stats.galaxyproject.eu
+stats.bi.privat
 
 [build:children]
 sn12

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -19,7 +19,7 @@ collections:
     # Therefore, they have to be included in this file. @domgz opened an issue on the repository of the Grafana Ansible collection
     # https://github.com/grafana/grafana-ansible-collection/issues/222
     # notifying the developers of this issue.
-    version: 5.3.0
+    version: 6.1.0
   # - name: community.general  # required by `grafana.grafana` (already specified above)
   #   source: https://github.com/ansible-collections/community.general.git
   #   version: 9.0.1

--- a/roles/pgs/tasks/main.yml
+++ b/roles/pgs/tasks/main.yml
@@ -13,7 +13,7 @@
   git:
     repo: 'https://github.com/martenson/public-galaxy-servers/'
     dest: "{{ pgs_repo_dir }}"
-    version: master
+    version: main
     force: yes
 
 - name: "Fix perms here"


### PR DESCRIPTION
Sense we are migrating stats to KVM, grafana will no longer need to be routed trough nginx. We can route it directly in traefik and manege the ssl certs there. 