### PR TITLE
fix: redirect galaxyproject.eu /terms and /privacy to the GDPR site

### DIFF
--- a/templates/nginx/galaxyproject.j2
+++ b/templates/nginx/galaxyproject.j2
@@ -65,6 +65,23 @@ server {
 		return 301 https://galaxyproject.org/wall/;
 	}
 
+	# Terms of Service / Privacy Policy live on the separate GDPR site
+	# (usegalaxy-eu/gdpr, served at usegalaxy-eu.github.io/gdpr/), which was not
+	# part of the website migration. /gdpr resolves by accident today -- the
+	# catch-all at the bottom forwards it to the legacy host, where the GDPR site
+	# really is -- but /terms and /privacy do not: they were never pages, only
+	# nginx aliases on usegalaxy.eu (galaxy-main.j2 `location /terms`, and the
+	# traefik gdpr-router rule). Off galaxyproject.eu they fall through to the
+	# catch-all and 404 on the legacy host. Galaxy's own terms_url points at
+	# usegalaxy.eu/terms, so the alias is live and linked; give the same paths a
+	# home here.
+	location ~* "^/terms(?:\.html|/)?$" {
+		return 301 https://usegalaxy-eu.github.io/gdpr/;
+	}
+	location ~* "^/privacy(?:\.html|/)?$" {
+		return 301 https://usegalaxy-eu.github.io/gdpr/privacy-policy.html;
+	}
+
 	# ---------------------------------------------------------------------------
 	# Legacy galaxyproject.eu -> galaxyproject.org (hub) 301 redirect table.
 	# Generated from the galaxy-eu-migration-audit manifest (schema v3).


### PR DESCRIPTION
`https://galaxyproject.eu/terms` currently 404s, and so does `https://galaxyproject.eu/privacy`.

Neither was ever a page on the legacy site. They exist only as proxy aliases on `usegalaxy.eu` — `galaxy-main.j2` (`location /terms`) and the traefik `gdpr-router` rule — pointing at the separate GDPR site (`usegalaxy-eu/gdpr`, served at https://usegalaxy-eu.github.io/gdpr/), which was not part of the website migration.

On `galaxyproject.eu`, they match no rule and fall through to the catch-all at the bottom of `galaxyproject.j2`, which forwards to the legacy host, where no such path exists. `/gdpr` keeps working through that same catch-all because the GDPR site really is there, so only the two alias paths need their own blocks.

This matters beyond the two URLs being linked from the wild: Galaxy's `terms_url` is `https://usegalaxy.eu/terms`, which redirects here.

### Change

Two regex `location` blocks in the `galaxyproject.eu` server block, placed with the other core-page redirects, above the migration table:

- `/terms`, `/terms/`, `/terms.html` → `https://usegalaxy-eu.github.io/gdpr/` (same landing page `usegalaxy.eu/terms` reaches today)
- `/privacy`, `/privacy/`, `/privacy.html` → `https://usegalaxy-eu.github.io/gdpr/privacy-policy.html`

### Verification

Config extracted into a standalone nginx instance (`nginx -t` clean), served locally, every form checked:

| Request | 301 target |
| --- | --- |
| `/terms`, `/terms/`, `/terms.html`, `/TERMS` | `https://usegalaxy-eu.github.io/gdpr/` |
| `/privacy`, `/privacy/`, `/privacy.html` | `https://usegalaxy-eu.github.io/gdpr/privacy-policy.html` |
| `/gdpr`, `/gdpr/tos.html` | unchanged, still handled by the catch-all |

Both targets return 200 today.
