### PR TITLE
Update registered user concurrent jobs limit

### DIFF
--- a/templates/galaxy/config/job_conf.yml
+++ b/templates/galaxy/config/job_conf.yml
@@ -307,7 +307,7 @@ galaxy_jobconf:
     - type: "output_size"
       value: "'300GB'"
     - type: "registered_user_concurrent_jobs"
-      value: "40"
+      value: "20"
     - type: "anonymous_user_concurrent_jobs"
       value: "3"
     - type: "destination_user_concurrent_jobs"


### PR DESCRIPTION
Reduced the concurrent jobs limit for registered users from 40 to 20.