### PR TITLE
TEMP fix ITs (condorv2) and force upload to condorv2

### DIFF
--- a/files/galaxy/tpv/destinations.yml.j2
+++ b/files/galaxy/tpv/destinations.yml.j2
@@ -108,6 +108,7 @@ destinations:
     scheduling:
       accept:
         - tool_type_user_defined
+        - condorv2
       require:
         - docker
         - embedded-pulsar

--- a/files/galaxy/tpv/destinations.yml.j2
+++ b/files/galaxy/tpv/destinations.yml.j2
@@ -108,7 +108,8 @@ destinations:
     scheduling:
       accept:
         - tool_type_user_defined
-        - condorv2
+        - condorv2                  # Temp fix for condorv2 destributed compute
+                                    # If a user have any other location, they won't be able to run ITs
       require:
         - docker
         - embedded-pulsar

--- a/files/galaxy/tpv/destinations.yml.j2
+++ b/files/galaxy/tpv/destinations.yml.j2
@@ -109,7 +109,7 @@ destinations:
       accept:
         - tool_type_user_defined
         - condorv2                  # Temp fix for condorv2 destributed compute
-                                    # If a user have any other location, they won't be able to run ITs
+                                    # If a user has any other distributed compute location, they won't be able to run ITs.
       require:
         - docker
         - embedded-pulsar

--- a/files/galaxy/tpv/tool_defaults.yml.j2
+++ b/files/galaxy/tpv/tool_defaults.yml.j2
@@ -183,6 +183,7 @@ tools:
         scheduling:
           require:
             - internal
+            - condorv2
     rank: |
       final_destinations = helpers.weighted_random_sampling(candidate_destinations)
       final_destinations


### PR DESCRIPTION
Fixes ITs for condorv2 distributed compute - we should rethink of a better way of doing this. Any user with a different distributed compute, won't be able to run ITs.

Force any  expression tools / data_source / require python env to condorv2 - temporary for testing 