### PR TITLE
cleanup our object store

### DIFF
--- a/templates/galaxy/config/object_store_conf.yml.j2
+++ b/templates/galaxy/config/object_store_conf.yml.j2
@@ -141,35 +141,35 @@ backends:
       - type: more_stable
     files_dir: "/data/dnb09/galaxy_db/files"
 
-  - id: files24
-    type: disk
-    store_by: uuid
-    device: "dnb09"
-    name: "University of Freiburg storage (NetApp FabricPool, id=files24)"
-    weight: 0
-    badges:
-      - type: more_stable
-    files_dir: "/data/dnb09/galaxy_db/files"
+#  - id: files24
+#    type: disk
+#    store_by: uuid
+#    device: "dnb09"
+#    name: "University of Freiburg storage (NetApp FabricPool, id=files24)"
+#    weight: 0
+#    badges:
+#      - type: more_stable
+#    files_dir: "/data/dnb09/galaxy_db/files"
 
-  - id: files25
-    type: disk
-    store_by: uuid
-    device: "dnb09"
-    name: "University of Freiburg storage (NetApp FabricPool, id=files25)"
-    weight: 0
-    badges:
-      - type: more_stable
-    files_dir: "/data/dnb09/galaxy_db/files"
+#  - id: files25
+#    type: disk
+#    store_by: uuid
+#    device: "dnb09"
+#    name: "University of Freiburg storage (NetApp FabricPool, id=files25)"
+#    weight: 0
+#    badges:
+#      - type: more_stable
+#    files_dir: "/data/dnb09/galaxy_db/files"
 
-  - id: files26
-    type: disk
-    store_by: uuid
-    device: "dnb09"
-    name: "University of Freiburg storage (NetApp FabricPool, id=files26)"
-    weight: 0
-    badges:
-      - type: more_stable
-    files_dir: "/data/dnb09/galaxy_db/files"
+#  - id: files26
+#    type: disk
+#    store_by: uuid
+#    device: "dnb09"
+#    name: "University of Freiburg storage (NetApp FabricPool, id=files26)"
+#    weight: 0
+#    badges:
+#      - type: more_stable
+#    files_dir: "/data/dnb09/galaxy_db/files"
 
   - id: files27
     type: disk
@@ -181,15 +181,15 @@ backends:
       - type: more_stable
     files_dir: "/data/dnb10/galaxy_db/files"
 
-  - id: files28
-    type: disk
-    store_by: uuid
-    device: "dnb10"
-    name: "University of Freiburg storage (NetApp FabricPool, id=files28)"
-    weight: 0
-    badges:
-      - type: more_stable
-    files_dir: "/data/dnb10/galaxy_db/files"
+#  - id: files28
+#    type: disk
+#    store_by: uuid
+#    device: "dnb10"
+#    name: "University of Freiburg storage (NetApp FabricPool, id=files28)"
+#    weight: 0
+#    badges:
+#      - type: more_stable
+#    files_dir: "/data/dnb10/galaxy_db/files"
 
   - id: files29
     type: disk
@@ -201,44 +201,44 @@ backends:
       - type: more_stable
     files_dir: "/data/dnb11/galaxy_db/files"
 
-  - id: files30
-    type: disk
-    store_by: uuid
-    device: "dnb11"
-    name: "University of Freiburg storage (NetApp FabricPool, id=files30)"
-    weight: 0
-    badges:
-      - type: more_stable
-    files_dir: "/data/dnb11/galaxy_db/files"
-    extra_dirs:
-      - type: job_work
-        path: "/data/jwd08/main"
+#  - id: files30
+#    type: disk
+#    store_by: uuid
+#    device: "dnb11"
+#    name: "University of Freiburg storage (NetApp FabricPool, id=files30)"
+#    weight: 0
+#    badges:
+#      - type: more_stable
+#    files_dir: "/data/dnb11/galaxy_db/files"
+#    extra_dirs:
+#      - type: job_work
+#        path: "/data/jwd08/main"
 
-  - id: files31
-    type: disk
-    store_by: uuid
-    device: "dnb11"
-    name: "University of Freiburg storage (NetApp FabricPool, id=files31)"
-    weight: 0
-    badges:
-      - type: more_stable
-    files_dir: "/data/dnb11/galaxy_db/files"
-    extra_dirs:
-      - type: job_work
-        path: "/data/jwd06/main"
+#  - id: files31
+#    type: disk
+#    store_by: uuid
+#    device: "dnb11"
+#    name: "University of Freiburg storage (NetApp FabricPool, id=files31)"
+#    weight: 0
+#    badges:
+#      - type: more_stable
+#    files_dir: "/data/dnb11/galaxy_db/files"
+#    extra_dirs:
+#      - type: job_work
+#        path: "/data/jwd06/main"
 
-  - id: files32
-    type: disk
-    store_by: uuid
-    device: "dnb11"
-    name: "University of Freiburg storage (NetApp FabricPool, id=files32)"
-    weight: 0
-    badges:
-      - type: more_stable
-    files_dir: "/data/dnb11/galaxy_db/files"
-    extra_dirs:
-      - type: job_work
-        path: "/data/jwd08/main"
+#  - id: files32
+#    type: disk
+#    store_by: uuid
+#    device: "dnb11"
+#    name: "University of Freiburg storage (NetApp FabricPool, id=files32)"
+#    weight: 0
+#    badges:
+#      - type: more_stable
+#    files_dir: "/data/dnb11/galaxy_db/files"
+#    extra_dirs:
+#      - type: job_work
+#        path: "/data/jwd08/main"
 
   - id: files33
     type: disk
@@ -253,31 +253,31 @@ backends:
       - type: job_work
         path: "/data/jwd08/main"
 
-  - id: files34
-    type: disk
-    store_by: uuid
-    device: "dnb12"
-    name: "University of Freiburg storage (NetApp FabricPool, id=files34)"
-    weight: 0
-    badges:
-      - type: more_stable
-    files_dir: "/data/dnb12/galaxy_db/files"
-    extra_dirs:
-      - type: job_work
-        path: "/data/jwd07/main"
+#  - id: files34
+#    type: disk
+#    store_by: uuid
+#    device: "dnb12"
+#    name: "University of Freiburg storage (NetApp FabricPool, id=files34)"
+#    weight: 0
+#    badges:
+#      - type: more_stable
+#    files_dir: "/data/dnb12/galaxy_db/files"
+#    extra_dirs:
+#      - type: job_work
+#        path: "/data/jwd07/main"
 
-  - id: files35
-    type: disk
-    store_by: uuid
-    device: "dnb12"
-    name: "University of Freiburg storage (NetApp FabricPool, id=files35)"
-    weight: 0
-    badges:
-      - type: more_stable
-    files_dir: "/data/dnb12/galaxy_db/files"
-    extra_dirs:
-      - type: job_work
-        path: "/data/jwd06/main"
+#  - id: files35
+#    type: disk
+#    store_by: uuid
+#    device: "dnb12"
+#    name: "University of Freiburg storage (NetApp FabricPool, id=files35)"
+#    weight: 0
+#    badges:
+#      - type: more_stable
+#    files_dir: "/data/dnb12/galaxy_db/files"
+#    extra_dirs:
+#      - type: job_work
+#        path: "/data/jwd06/main"
 
   - id: files36
     type: disk


### PR DESCRIPTION
We need to run these SQL commands:

```
update dataset set object_store_id = 'files23' WHERE object_store_id = 'files24';
update dataset set object_store_id = 'files23' WHERE object_store_id = 'files25';
update dataset set object_store_id = 'files23' WHERE object_store_id = 'files26';

update dataset set object_store_id = 'files27' WHERE object_store_id = 'files28';

update dataset set object_store_id = 'files29' WHERE object_store_id = 'files30';
update dataset set object_store_id = 'files29' WHERE object_store_id = 'files31';
update dataset set object_store_id = 'files29' WHERE object_store_id = 'files32';

update dataset set object_store_id = 'files33' WHERE object_store_id = 'files34';
update dataset set object_store_id = 'files33' WHERE object_store_id = 'files35';
```  

And then we can merge this PR or even remove the comments.

For more background: https://gist.github.com/bgruening/8354e165b4877889da4ab0d7c22c0ede