### PR TITLE
Make condorv2 default

### DIFF
--- a/files/galaxy/config/user_preferences_extra_conf.yml
+++ b/files/galaxy/config/user_preferences_extra_conf.yml
@@ -52,7 +52,6 @@ preferences:
               required: False
               options:
                   - ["default - Galaxy will decide where to put your job", None]
-                  - ["Freiburg (Germany) - Experimental HTCondor job runner (do not use for production workloads)", condorv2]
                   # - ["Freiburg (Germany) - Condor cluster using Singularity with Conda", condor_singularity_with_conda]
                   # - ["Joint remote GPU cluster using docker engine - Galaxy will decide where to put your job", remote_condor_cluster_gpu_docker]
                   # - ["Joint remote CPU cluster using singularity engine - Galaxy will decide where to put your job", remote_condor_cluster_singularity]

--- a/files/galaxy/tpv/destinations.yml.j2
+++ b/files/galaxy/tpv/destinations.yml.j2
@@ -203,7 +203,6 @@ destinations:
         - conda
         - singularity
         - docker
-        - condor-tpv
 
   pulsar_mira_tpv:
     inherits: pulsar_default

--- a/files/galaxy/tpv/destinations.yml.j2
+++ b/files/galaxy/tpv/destinations.yml.j2
@@ -551,9 +551,6 @@ destinations:
         - docker
         - singularity
 
-  # TEMPORARY FOR TESTING PURPOSES
-
-
   condor_container_gpu:
     inherits: condor_container
     max_accepted_cores: 128

--- a/files/galaxy/tpv/destinations.yml.j2
+++ b/files/galaxy/tpv/destinations.yml.j2
@@ -492,7 +492,7 @@ destinations:
 
 
   condor_container:
-    runner: condor
+    runner: condorv2
     max_accepted_cores: 64
     max_accepted_mem: 1000
     min_accepted_gpus: 0
@@ -553,12 +553,7 @@ destinations:
         - singularity
 
   # TEMPORARY FOR TESTING PURPOSES
-  condor_container_v2:
-    inherits: condor_container
-    runner: condorv2
-    scheduling:
-      require:
-        - condorv2
+
 
   condor_container_gpu:
     inherits: condor_container
@@ -619,7 +614,7 @@ destinations:
 
   condor_singularity_with_conda:
     inherits: basic_singularity_destination
-    runner: condor
+    runner: condorv2
     max_accepted_cores: 64
     max_accepted_mem: 1000
     min_accepted_gpus: 0
@@ -642,16 +637,8 @@ destinations:
         - singularity
         - conda
 
-  # TEMPORARY FOR TESTING PURPOSES
-  condor_singularity_with_conda_v2:
-    inherits: condor_singularity_with_conda
-    runner: condorv2
-    scheduling:
-      require:
-        - condorv2
-
   condor_internal:
-    runner: condor
+    runner: condorv2
     max_accepted_cores: 20
     max_accepted_mem: 10
     min_accepted_gpus: 0
@@ -665,11 +652,3 @@ destinations:
     scheduling:
       require:
         - internal
-
-  # TEMPORARY FOR TESTING PURPOSES
-  condor_internal_v2:
-    inherits: condor_internal
-    runner: condorv2
-    scheduling:
-      require:
-        - condorv2

--- a/files/galaxy/tpv/tool_defaults.yml.j2
+++ b/files/galaxy/tpv/tool_defaults.yml.j2
@@ -124,8 +124,6 @@ tools:
       - id: interactive_tool
         if: not (dry_run_mode := job_wrapper is None) and (tool.tool_type == 'interactive')
         # `job_wrapper is None` occurs when TPV is launched in dry-run mode
-        cores: 1
-        mem: 4
         params:
           docker_volumes: $defaults
           container_monitor_result: callback

--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -214,9 +214,6 @@ tools:
   toolshed.g2.bx.psu.edu/repos/rnateam/htseq_clip/htseq_clip/.*:
     cores: 4
     mem: 16
-    #scheduling:
-    #  prefer:
-    #    - condor-tpv
 
   toolshed.g2.bx.psu.edu/repos/galaxy-australia/alphafold2/alphafold/.*:
     cores: 10


### PR DESCRIPTION
Makes the condorv2 the default runner.

Removes the mem and cpu hard limits of ITs tool_defaults rules - for any  interactive tool that we have increased the default value, the rule would have reverted it - the default value is already 3.8G and 1CPU

Closes https://github.com/usegalaxy-eu/issues/issues/989, closes https://github.com/usegalaxy-eu/infrastructure-playbook/issues/1926.