### PR TITLE
OSIRIS: Attempt to fix "Permission denied" in ansible tmp dir

### DIFF
--- a/roles/denbi.osiris/tasks/osiris_version.yml
+++ b/roles/denbi.osiris/tasks/osiris_version.yml
@@ -7,6 +7,8 @@
     update: true
   become: yes
   become_user: "apache"
+  environment:
+    ANSIBLE_SYSTEM_WARNINGS: "False"
   vars:
     # Prevent ansible from using $HOME/.ansible/tmp
     # which for 'apache' is /usr/share/httpd/.ansible/tmp

--- a/roles/denbi.osiris/tasks/osiris_version.yml
+++ b/roles/denbi.osiris/tasks/osiris_version.yml
@@ -7,6 +7,10 @@
     update: true
   become: yes
   become_user: "apache"
+  environment:
+    # Prevent ansible from using $HOME/.ansible/tmp
+    # which for 'apache' is /usr/share/httpd/.ansible/tmp
+    ANSIBLE_REMOTE_TMP: /tmp/ansible-apache
 
 - name: "Ensure permissions for OSIRIS PHP files"
   ansible.builtin.file:

--- a/roles/denbi.osiris/tasks/osiris_version.yml
+++ b/roles/denbi.osiris/tasks/osiris_version.yml
@@ -7,10 +7,10 @@
     update: true
   become: yes
   become_user: "apache"
-  environment:
+  vars:
     # Prevent ansible from using $HOME/.ansible/tmp
     # which for 'apache' is /usr/share/httpd/.ansible/tmp
-    ANSIBLE_REMOTE_TMP: /tmp/ansible-apache
+    ansible_remote_tmp: /tmp/ansible_osiris_checkout
 
 - name: "Ensure permissions for OSIRIS PHP files"
   ansible.builtin.file:


### PR DESCRIPTION
Ansible defaults to `$HOME/.ansible/tmp` which for the `apache` user is `/usr/share/httpd/.ansible/tmp` and is not writable.

Instead use `/tmp/ansible-apache` which is writable.

Please merge this before deploying #2270 - @domgz 