### PR TITLE
Redirect galaxyproject.eu /storage and /subdomains to the hub

### DIFF
--- a/templates/nginx/galaxyproject.j2
+++ b/templates/nginx/galaxyproject.j2
@@ -142,6 +142,8 @@ server {
 	location ~* "^/tools(?:\.html|/)?$" { return 301 https://galaxyproject.org/eu/tools/; }
 	location ~* "^/citations(?:\.html|/)?$" { return 301 https://galaxyproject.org/eu/citations/; }
 	location ~* "^/tiaas(?:\.html|/)?$" { return 301 https://galaxyproject.org/eu/tiaas/; }
+	location ~* "^/storage(?:\.html|/)?$" { return 301 https://galaxyproject.org/eu/storage/; }
+	location ~* "^/subdomains(?:\.html|/)?$" { return 301 https://galaxyproject.org/eu/subdomains/; }
 	location ~* "^/gga(?:\.html|/)?$" { return 301 https://galaxyproject.org/use/gga/; }
 	location ~* "^/ftp/?$" { return 301 https://galaxyproject.org/ftp-upload/; }
 	location ~* "^/widgets/?$" { return 301 https://galaxyproject.org/eu/widgets/; }


### PR DESCRIPTION
## Body

`https://galaxyproject.eu/storage` 301s to `https://usegalaxy-eu.github.io/storage`, which 404s. `https://galaxyproject.eu/subdomains` is broken the same way.

Both pages were written for the hub during the website migration and never existed on the legacy site, so neither appears in the generated redirect table in `galaxyproject.j2`. With no rule of their own they match the catch-all at the bottom of the `galaxyproject.eu` server block, which forwards unmatched paths to the legacy host — where those paths have never existed.

### Change

Two regex `location` blocks alongside the other core EU informational pages, above the migration table:

- `/storage`, `/storage/`, `/storage.html` → `https://galaxyproject.org/eu/storage/`
- `/subdomains`, `/subdomains/`, `/subdomains.html` → `https://galaxyproject.org/eu/subdomains/`

```nginx
	location ~* "^/storage(?:\.html|/)?$" { return 301 https://galaxyproject.org/eu/storage/; }
	location ~* "^/subdomains(?:\.html|/)?$" { return 301 https://galaxyproject.org/eu/subdomains/; }
```

`~*` matches the other core-page rules around it, so the case variants that exist in the wild are covered too. Nothing below is touched: deeper paths such as `/storage/extra` keep falling through to the catch-all, since there is no hub page behind them either.

### Verification

The `galaxyproject.eu` server block was extracted into a standalone nginx instance (`nginx -t` clean) and served locally; every form was requested with `Host: galaxyproject.eu`:

| Request                                                          | 301 target                                          |
| ---------------------------------------------------------------- | --------------------------------------------------- |
| `/storage`, `/storage/`, `/storage.html`, `/Storage`, `/STORAGE/` | `https://galaxyproject.org/eu/storage/`             |
| `/subdomains`, `/subdomains/`, `/subdomains.html`, `/Subdomains`  | `https://galaxyproject.org/eu/subdomains/`          |
| `/about`, `/tiaas`                                                | unchanged                                           |
| `/storage/extra`, any unmatched path                              | unchanged, still handled by the github.io catch-all |

Both hub targets return 200 today.