### PR TITLE
Add memory allocation for proteomiqon tool

### DIFF
--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -221,6 +221,9 @@ tools:
     cores: 4
     mem: 16
 
+  toolshed.g2.bx.psu.edu/repos/galaxyp/proteomiqon_peptidespectrummatching/proteomiqon_peptidespectrummatching/.*:
+    mem: 16
+
   toolshed.g2.bx.psu.edu/repos/galaxy-australia/alphafold2/alphafold/.*:
     cores: 10
     mem: 32


### PR DESCRIPTION
Add more memory for huge mass spectrometry data for the ProteomIQon Tool chain