### PR TITLE
add resubmission with TPV, re-enable `htcondor` runner

### DIFF
--- a/files/galaxy/tpv/destinations.yml.j2
+++ b/files/galaxy/tpv/destinations.yml.j2
@@ -546,12 +546,6 @@ destinations:
           # Most times this fallback is needed for very old tools
           # Centos 7 has libncurses.so.5.9 and python 2.7
           identifier: "/cvmfs/main.galaxyproject.org/singularity/usegalaxy.org-legacy-environment--0"
-    resubmit:
-      oom_retry:
-        condition: memory_limit_reached and attempt <= 3
-        environment: tpv_dispatcher
-        # Delay is in seconds before Galaxy dispatches the resubmitted job.
-        delay: 60
     scheduling:
       accept:
         - docker
@@ -634,12 +628,6 @@ destinations:
           # Most times this fallback is needed for very old tools
           # Centos 7 has libncurses.so.5.9 and python 2.7
           identifier: "/cvmfs/main.galaxyproject.org/singularity/usegalaxy.org-legacy-environment--0"
-    resubmit:
-      oom_retry:
-        condition: memory_limit_reached and attempt <= 3
-        environment: tpv_dispatcher
-        # Delay is in seconds before Galaxy dispatches the resubmitted job.
-        delay: 60
     scheduling:
       require:
         - singularity
@@ -657,12 +645,6 @@ destinations:
     params:
       requirements: "GalaxyTraining == false"
       rank: 'GalaxyGroup == "internal"'
-    resubmit:
-      oom_retry:
-        condition: memory_limit_reached and attempt <= 3
-        environment: tpv_dispatcher
-        # Delay is in seconds before Galaxy dispatches the resubmitted job.
-        delay: 60
     scheduling:
       require:
         - internal

--- a/files/galaxy/tpv/destinations.yml.j2
+++ b/files/galaxy/tpv/destinations.yml.j2
@@ -491,7 +491,7 @@ destinations:
 
 
   condor_container:
-    runner: condor
+    runner: htcondor
     max_accepted_cores: 64
     max_accepted_mem: 1000
     min_accepted_gpus: 0
@@ -610,7 +610,7 @@ destinations:
 
   condor_singularity_with_conda:
     inherits: basic_singularity_destination
-    runner: condor
+    runner: htcondor
     max_accepted_cores: 64
     max_accepted_mem: 1000
     min_accepted_gpus: 0
@@ -634,7 +634,7 @@ destinations:
         - conda
 
   condor_internal:
-    runner: condor
+    runner: htcondor
     max_accepted_cores: 20
     max_accepted_mem: 10
     min_accepted_gpus: 0

--- a/files/galaxy/tpv/destinations.yml.j2
+++ b/files/galaxy/tpv/destinations.yml.j2
@@ -546,6 +546,12 @@ destinations:
           # Most times this fallback is needed for very old tools
           # Centos 7 has libncurses.so.5.9 and python 2.7
           identifier: "/cvmfs/main.galaxyproject.org/singularity/usegalaxy.org-legacy-environment--0"
+    resubmit:
+      oom_retry:
+        condition: memory_limit_reached and attempt <= 3
+        environment: tpv_dispatcher
+        # Delay is in seconds before Galaxy dispatches the resubmitted job.
+        delay: 60
     scheduling:
       accept:
         - docker
@@ -628,6 +634,12 @@ destinations:
           # Most times this fallback is needed for very old tools
           # Centos 7 has libncurses.so.5.9 and python 2.7
           identifier: "/cvmfs/main.galaxyproject.org/singularity/usegalaxy.org-legacy-environment--0"
+    resubmit:
+      oom_retry:
+        condition: memory_limit_reached and attempt <= 3
+        environment: tpv_dispatcher
+        # Delay is in seconds before Galaxy dispatches the resubmitted job.
+        delay: 60
     scheduling:
       require:
         - singularity
@@ -645,6 +657,12 @@ destinations:
     params:
       requirements: "GalaxyTraining == false"
       rank: 'GalaxyGroup == "internal"'
+    resubmit:
+      oom_retry:
+        condition: memory_limit_reached and attempt <= 3
+        environment: tpv_dispatcher
+        # Delay is in seconds before Galaxy dispatches the resubmitted job.
+        delay: 60
     scheduling:
       require:
         - internal

--- a/files/galaxy/tpv/tool_defaults.yml.j2
+++ b/files/galaxy/tpv/tool_defaults.yml.j2
@@ -5,8 +5,10 @@ global:
   context:
     # Base multiplier applied on each OOM resubmission. The accumulated
     # factor is persisted in the OOM_MEM_SCALE destination param (see
-    # params below), which Galaxy carries across resubmissions.
+    # params below), which Galaxy carries across resubmissions. Memory
+    # requirements for resubmitted jobs are capped at OOM_SCALING_CAP.
     OOM_SCALING_FACTOR: 2
+    OOM_SCALING_CAP: 512
 tools:
   default:
     abstract: true
@@ -66,8 +68,7 @@ tools:
         if: job is not None and job.state == "resubmitted"
         execute: |
           _scale = int(job.destination_params.get('OOM_MEM_SCALE', OOM_SCALING_FACTOR)) if job.destination_params else 1
-          entity.mem = int(min(entity.mem * _scale, 512))
-          # memory is capped at 512GB
+          entity.mem = int(min(entity.mem * _scale, OOM_SCALING_CAP))
 
         # Set accounting group user for jobs
       - id: jobs_user_accounting_group

--- a/files/galaxy/tpv/tool_defaults.yml.j2
+++ b/files/galaxy/tpv/tool_defaults.yml.j2
@@ -66,7 +66,8 @@ tools:
         if: job is not None and job.state == "resubmitted"
         execute: |
           _scale = int(job.destination_params.get('OOM_MEM_SCALE', OOM_SCALING_FACTOR)) if job.destination_params else 1
-          entity.mem = f"min(({entity.mem}) * {_scale}, 512)
+          entity.mem = int(min(entity.mem * _scale, 512))
+          # memory is capped at 512GB
 
         # Set accounting group user for jobs
       - id: jobs_user_accounting_group

--- a/files/galaxy/tpv/tool_defaults.yml.j2
+++ b/files/galaxy/tpv/tool_defaults.yml.j2
@@ -66,7 +66,7 @@ tools:
         if: job is not None and job.state == "resubmitted"
         execute: |
           _scale = int(job.destination_params.get('OOM_MEM_SCALE', OOM_SCALING_FACTOR)) if job.destination_params else 1
-          entity.mem = f"{entity.mem} * {_scale}"
+          entity.mem = f"min(({entity.mem}) * {_scale}, 512)
 
         # Set accounting group user for jobs
       - id: jobs_user_accounting_group

--- a/files/galaxy/tpv/tool_defaults.yml.j2
+++ b/files/galaxy/tpv/tool_defaults.yml.j2
@@ -17,7 +17,7 @@ tools:
     gpus: 0
     resubmit:
       oom_retry:
-        condition: memory_limit_reached and attempt <= 3
+        condition: memory_limit_reached and attempt <= 3 and (mem * OOM_SCALING_FACTOR ** (attempt - 2)) < OOM_SCALING_CAP
         environment: tpv_dispatcher
         # Delay is in seconds before Galaxy dispatches the resubmitted job.
         delay: 60

--- a/files/galaxy/tpv/tool_defaults.yml.j2
+++ b/files/galaxy/tpv/tool_defaults.yml.j2
@@ -13,6 +13,12 @@ tools:
     cores: 1
     mem: cores * 3.8
     gpus: 0
+    resubmit:
+      oom_retry:
+        condition: memory_limit_reached and attempt <= 3
+        environment: tpv_dispatcher
+        # Delay is in seconds before Galaxy dispatches the resubmitted job.
+        delay: 60
     env:
       ## The execute statement should be removed once https://github.com/galaxyproject/galaxy/issues/20562 is fixed
       - execute: cd $_GALAXY_JOB_DIR

--- a/files/galaxy/tpv/tool_defaults.yml.j2
+++ b/files/galaxy/tpv/tool_defaults.yml.j2
@@ -18,6 +18,9 @@ tools:
     resubmit:
       oom_retry:
         condition: memory_limit_reached and attempt <= 3 and (mem * OOM_SCALING_FACTOR ** (attempt - 2)) < OOM_SCALING_CAP
+        # `(mem * OOM_SCALING_FACTOR ** (attempt - 2)) < OOM_SCALING_CAP`
+        # allows only one resubmission capped at OOM_SCALING_CAP, subsequent
+        # resubmission attempts are rejected.
         environment: tpv_dispatcher
         # Delay is in seconds before Galaxy dispatches the resubmitted job.
         delay: 60

--- a/files/galaxy/tpv/tool_defaults.yml.j2
+++ b/files/galaxy/tpv/tool_defaults.yml.j2
@@ -2,6 +2,11 @@
 # ALL tags must be with dashes (-) instead of underscores (_)
 global:
   default_inherits: default
+  context:
+    # Base multiplier applied on each OOM resubmission. The accumulated
+    # factor is persisted in the OOM_MEM_SCALE destination param (see
+    # params below), which Galaxy carries across resubmissions.
+    OOM_SCALING_FACTOR: 2
 tools:
   default:
     abstract: true
@@ -39,10 +44,24 @@ tools:
       submit_request_gpus: "{gpus or 0}"
       docker_memory: "{mem}G"
       description: "{tool.id if not tool.id.count('/') == 5 else tool.id.split('/')[4]}"
+      # We persist OOM_MEM_SCALE across resubmissions by using job.destination_params.
+      # On the first run this records the base factor (OOM_SCALING_FACTOR).
+      # On each resubmit TPV re-evaluates this expression, reading the
+      # previously persisted value and multiplying by OOM_SCALING_FACTOR.
+      OOM_MEM_SCALE: "{OOM_SCALING_FACTOR * int(job.destination_params.get('OOM_MEM_SCALE', OOM_SCALING_FACTOR)) if job.destination_params else OOM_SCALING_FACTOR}"
     scheduling:
       reject:
         - offline
     rules:  # executed in order
+        # The accumulated scaling factor is read from the
+        # persisted OOM_MEM_SCALE destination param,
+        # which Galaxy carries across resubmissions.
+      - id: oom_resubmit_increase_memory
+        if: job is not None and job.state == "resubmitted"
+        execute: |
+          _scale = int(job.destination_params.get('OOM_MEM_SCALE', OOM_SCALING_FACTOR)) if job.destination_params else 1
+          entity.mem = f"{entity.mem} * {_scale}"
+
         # Set accounting group user for jobs
       - id: jobs_user_accounting_group
         if: user is not None

--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -93,6 +93,11 @@ tools:
   ucsc_table_direct1:
     inherits: _basic_internal_tool
 
+  # example for overwriting the OOM memory multiplier for a specific tool.
+  # toolshed.g2.bx.psu.edu/repos/example_owner/example_tool/example_tool/.*:
+  #   context:
+  #     OOM_SCALING_FACTOR: 3
+
   toolshed.g2.bx.psu.edu/repos/iuc/compose_text_param/compose_text_param/.*:
     inherits: _basic_internal_tool
 

--- a/htcondor.yml
+++ b/htcondor.yml
@@ -96,12 +96,12 @@
     - name: galaxyproject.gxadmin
       when: htcondor_role_submit
     - grycap.htcondor
-    - name: usegalaxy-eu.htcondor_release
-      when: htcondor_role_submit and inventory_hostname == "sn09.galaxyproject.eu"
+    #- name: usegalaxy-eu.htcondor_release
+    #  when: htcondor_role_submit and inventory_hostname == "sn09.galaxyproject.eu"
     - name: usegalaxy-eu.fix-stop-ITs
       when: htcondor_role_submit and inventory_hostname != "maintenance.bi.privat"
-    - name: usegalaxy-eu.remove-orphan-condor-jobs
-      when: htcondor_role_submit and inventory_hostname != "maintenance.bi.privat"
+    #- name: usegalaxy-eu.remove-orphan-condor-jobs
+    #  when: htcondor_role_submit and inventory_hostname != "maintenance.bi.privat"
   post_tasks:
     - name: Add /usr/local/bin to Galaxy's PATH in bashrc file. (usegalaxy-eu.fix-stop-ITs)
       become: true

--- a/htcondor.yml
+++ b/htcondor.yml
@@ -96,8 +96,6 @@
     - name: galaxyproject.gxadmin
       when: htcondor_role_submit
     - grycap.htcondor
-    #- name: usegalaxy-eu.htcondor_release
-    #  when: htcondor_role_submit and inventory_hostname == "sn09.galaxyproject.eu"
     - name: usegalaxy-eu.fix-stop-ITs
       when: htcondor_role_submit and inventory_hostname != "maintenance.bi.privat"
     - name: usegalaxy-eu.remove-orphan-condor-jobs

--- a/htcondor.yml
+++ b/htcondor.yml
@@ -100,8 +100,8 @@
     #  when: htcondor_role_submit and inventory_hostname == "sn09.galaxyproject.eu"
     - name: usegalaxy-eu.fix-stop-ITs
       when: htcondor_role_submit and inventory_hostname != "maintenance.bi.privat"
-    #- name: usegalaxy-eu.remove-orphan-condor-jobs
-    #  when: htcondor_role_submit and inventory_hostname != "maintenance.bi.privat"
+    - name: usegalaxy-eu.remove-orphan-condor-jobs
+      when: htcondor_role_submit and inventory_hostname != "maintenance.bi.privat"
   post_tasks:
     - name: Add /usr/local/bin to Galaxy's PATH in bashrc file. (usegalaxy-eu.fix-stop-ITs)
       become: true

--- a/maintenance.yml
+++ b/maintenance.yml
@@ -156,7 +156,6 @@
     # - usegalaxy-eu.fix-unscheduled-workflows
     - usegalaxy-eu.fix-ancient-ftp-data
     # - usegalaxy-eu.fix-user-quotas
-    - usegalaxy-eu.remove-orphan-condor-jobs
     # - ssh_hardening
     - usegalaxy-eu.job-radar-stats-influxdb
     - dj-wasabi.telegraf

--- a/maintenance.yml
+++ b/maintenance.yml
@@ -156,7 +156,7 @@
     # - usegalaxy-eu.fix-unscheduled-workflows
     - usegalaxy-eu.fix-ancient-ftp-data
     # - usegalaxy-eu.fix-user-quotas
-    - usegalaxy-eu.remove-orphan-condor-jobs
+    #- usegalaxy-eu.remove-orphan-condor-jobs
     # - ssh_hardening
     - usegalaxy-eu.job-radar-stats-influxdb
     - dj-wasabi.telegraf

--- a/maintenance.yml
+++ b/maintenance.yml
@@ -156,7 +156,7 @@
     # - usegalaxy-eu.fix-unscheduled-workflows
     - usegalaxy-eu.fix-ancient-ftp-data
     # - usegalaxy-eu.fix-user-quotas
-    #- usegalaxy-eu.remove-orphan-condor-jobs
+    - usegalaxy-eu.remove-orphan-condor-jobs
     # - ssh_hardening
     - usegalaxy-eu.job-radar-stats-influxdb
     - dj-wasabi.telegraf


### PR DESCRIPTION
I haven't found evidence that ORG or AU have enabled this. So not sure its working, or that I configured it correctly.

If this should work, we should disable our HTCondor cron job, that does the resubmission on htcondor side.

xref: https://total-perspective-vortex.readthedocs.io/en/latest/topics/tpv_by_example.html#job-resubmission

Partially resolves https://github.com/usegalaxy-eu/issues/issues/1044.

