### PR TITLE
Refactor resubmission condition and memory scaling

### DIFF
--- a/files/galaxy/tpv/tool_defaults.yml.j2
+++ b/files/galaxy/tpv/tool_defaults.yml.j2
@@ -17,7 +17,7 @@ tools:
     gpus: 0
     resubmit:
       oom_retry:
-        condition: memory_limit_reached and attempt <= 3 and (mem * OOM_SCALING_FACTOR ** (attempt - 2)) < OOM_SCALING_CAP
+        condition: memory_limit_reached and attempt <= 3
         # `(mem * OOM_SCALING_FACTOR ** (attempt - 2)) < OOM_SCALING_CAP`
         # allows only one resubmission capped at OOM_SCALING_CAP, subsequent
         # resubmission attempts are rejected.
@@ -71,7 +71,7 @@ tools:
         if: job is not None and job.state == "resubmitted"
         execute: |
           _scale = int(job.destination_params.get('OOM_MEM_SCALE', OOM_SCALING_FACTOR)) if job.destination_params else 1
-          entity.mem = int(min(entity.mem * _scale, OOM_SCALING_CAP))
+          entity.mem = f"min(({entity.mem}) * {_scale}, {OOM_SCALING_CAP})"
 
         # Set accounting group user for jobs
       - id: jobs_user_accounting_group


### PR DESCRIPTION
entity.mem is by default a string and not an int 

>Since your `default` tool sets `mem: cores * 3.8`, at the point your rule runs, `entity.mem` is still the literal string `"cores * 3.8"`, not a number (unless a specific tool overrides `mem` with a plain numeric literal). Doing `entity.mem * _scale` on a string just repeats the string in Python, and `min(str, int)` will raise a `TypeError`.

> The safer approach is to keep deferring evaluation, by building a new expression string instead of computing a number immediately:

xref: https://github.com/usegalaxy-eu/issues/issues/1044