### PR TITLE
move logs to data directory in maintenance

### DIFF
--- a/roles/usegalaxy_eu.galaxy_cleanup/defaults/main.yml
+++ b/roles/usegalaxy_eu.galaxy_cleanup/defaults/main.yml
@@ -16,3 +16,5 @@ galaxy_cleanup_scratchstorage: {}
 # Default: runs daily at 1:00 AM
 galaxy_cleanup_minute: 0
 galaxy_cleanup_hour: 1
+
+galaxy_cleanup_log_dir: /storage/galaxy_cleanup/

--- a/roles/usegalaxy_eu.galaxy_cleanup/templates/cleanup_storage.sh.j2
+++ b/roles/usegalaxy_eu.galaxy_cleanup/templates/cleanup_storage.sh.j2
@@ -27,9 +27,9 @@ for action in {delete_userless_histories,delete_exported_histories,purge_deleted
 			-U \
 			-o "60" \
 			-b "5000" \
-			-l "{{ galaxy_log_dir }}" \
+			-l "{{ galaxy_cleanup_log_dir }}" \
 			-s $action \
 			-w 128MB \
-			 >> "{{ galaxy_log_dir }}/cleanup-$(date --rfc-3339=seconds)-${action}.log" \
-			2>> "{{ galaxy_log_dir }}/cleanup-$(date --rfc-3339=seconds)-${action}.err";
+			 >> "{{ galaxy_cleanup_log_dir }}/cleanup-$(date --rfc-3339=seconds)-${action}.log" \
+			2>> "{{ galaxy_cleanup_log_dir }}/cleanup-$(date --rfc-3339=seconds)-${action}.err";
 	done


### PR DESCRIPTION
The pgcleanup script by default writes to `/var/log/galaxy/`. As I recall, we said this could be usefull information for future analysis so we should keep the logs.

Moving the logs from the root disk to nfs (data) disk should be okay for long time.
```
~$ du -sh /var/log/galaxy/
1.5G    /var/log/galaxy/
```

closes: https://github.com/usegalaxy-eu/issues/issues/968