### PR TITLE
📱Add router for apps and Dokku SSH

### DIFF
--- a/files/traefik/rules/template-apps-router.yml
+++ b/files/traefik/rules/template-apps-router.yml
@@ -1,0 +1,17 @@
+{{define "apps"}}
+    {{ . }}-apps-rtr:
+      rule: Host(`{{ . }}.apps.galaxyproject.eu`)
+      service: apps
+      entryPoints:
+        - websecure
+      tls:
+        certResolver: "route53"
+        domains:
+          - main: "{{ . }}.apps.galaxyproject.eu"
+{{end}}
+
+http:
+  routers:
+{{template "apps" "ptdk"}}
+{{template "apps" "oembed"}}
+{{template "apps" "dnanalyzer"}}

--- a/group_vars/traefik.yml
+++ b/group_vars/traefik.yml
@@ -16,6 +16,13 @@ telegraf_plugins_extra:
       - metric_version = 2
       - name_override = "traefik"
 
+traefik_cvmfs_rsync_port:
+  port: 9087
+  protocol: tcp
+traefik_dokku_ssh_port:
+  port: 3022
+  protocol: tcp
+
 traefik_force_validation: true
 traefik_manage_secrets: true
 
@@ -75,7 +82,8 @@ traefik_containers:
       - --entryPoints.websecure.address=:443
       - --entryPoints.amqps.address=:5671
       - --entryPoints.influxdb.address=:8086
-      - --entryPoints.cvmfs-rsync.address=:9087
+      - "--entryPoints.cvmfs-rsync.address=:{{ traefik_cvmfs_rsync_port.port }}"
+      - "--entryPoints.dokku-ssh.address=:{{ traefik_dokku_ssh_port.port }}"
       - --entryPoints.web.http.redirections.entryPoint.to=websecure
       - --entryPoints.web.http.redirections.entryPoint.scheme=https
       - --entryPoints.metrics.address=:8082
@@ -162,9 +170,13 @@ traefik_containers:
         published_port: 8086
         protocol: tcp
         mode: host
-      - target_port: 9087
-        published_port: 9087
-        protocol: tcp
+      - target_port: "{{ traefik_cvmfs_rsync_port.port }}"
+        published_port: "{{ traefik_cvmfs_rsync_port.port }}"
+        protocol: "{{ traefik_cvmfs_rsync_port.protocol }}"
+        mode: host
+      - target_port: "{{ traefik_dokku_ssh_port.port }}"
+        published_port: "{{ traefik_dokku_ssh_port.port }}"
+        protocol: "{{ traefik_dokku_ssh_port.protocol }}"
         mode: host
 
     secrets:

--- a/traefik-proxy.yml
+++ b/traefik-proxy.yml
@@ -29,13 +29,16 @@
         - https
         - ntp
 
-    - name: Configure CVMFS rsync port
+    - name: Configure extra ports
       ansible.posix.firewalld:
-        port: 9087/tcp
+        port: "{{ item.port }}/{{ item.protocol }}"
         permanent: true
         immediate: true
         zone: public
         state: enabled
+      with_items:
+        - traefik_cvmfs_rsync_port
+        - traefik_dokku_ssh_port
 
     - name: Install python docker
       become: true


### PR DESCRIPTION
part of:
 - https://github.com/usegalaxy-eu/issues/issues/1037
 
Dokku runs on apps.bi.privat and the individual apps running on it are deployed via GitHub actions (see [Dokku manual](https://dokku.com/docs/deployment/application-deployment/) and [example](https://github.com/StreetScienceCommunity/DNAnalyzer/blob/main/.github/workflows/deploy.yml)). The SSH port is not the VMs SSH deamon, but the one *inside* the Dokku container on that VM.