### PR TITLE
Add conda inheritance for Arriba tool

### DIFF
--- a/files/galaxy/tpv/conda_in_container.yml.j2
+++ b/files/galaxy/tpv/conda_in_container.yml.j2
@@ -122,6 +122,10 @@ tools:
   toolshed.g2.bx.psu.edu/repos/iuc/qiime_pick_otus/qiime_pick_otus/.*:
     inherits: _conda_in_container
 
+  # toolshed.g2.bx.psu.edu/repos/iuc/arriba/arriba/2.5.1+galaxy0 and lower needs conda, some ugly find hack needs the directory structure of conda
+  toolshed.g2.bx.psu.edu/repos/iuc/arriba/arriba/.*:
+    inherits: _conda_in_container
+
   # Nate's legacy tools (https://github.com/galaxyproject/usegalaxy-playbook/blob/f1fc7264642a471f5eed55739869bb0d7292c736/env/common/templates/galaxy/config/tpv/tools.yaml.j2#L1889)
   toolshed.g2.bx.psu.edu/repos/arkarachai-fungtammasan/str_fm/GenotypeSTR/2.0.0: {inherits: _conda_in_container}
   toolshed.g2.bx.psu.edu/repos/arkarachai-fungtammasan/str_fm/Profilegenerator/2.0.0: {inherits: _conda_in_container}


### PR DESCRIPTION
We need this, otherwise the tool is not working I think.

If someone has time to fiddle in the `rule` for the `<=` this version, that would be nice.