### PR TITLE
make `embedded_pulsar_docker_gpu_pxe` use interative

### DIFF
--- a/files/galaxy/tpv/destinations.yml.j2
+++ b/files/galaxy/tpv/destinations.yml.j2
@@ -121,7 +121,7 @@ destinations:
     env:
       GPU_AVAILABLE: "1"
     context:
-      galaxy_group: 'GalaxyGroup == "pxe-gpu"'
+      galaxy_group: 'GalaxyGroup == "interactive"'
     params:
       submit_requirements: "{galaxy_group}"
       request_gpus: "{gpus or 0}"


### PR DESCRIPTION
This fixes ITs that need to run GPUs alongside https://github.com/usegalaxy-eu/vgcn-infrastructure-playbook/pull/99 . I believe we are using embedded pulsar runner to run ITs specially with GPU anyways

closes: https://github.com/usegalaxy-eu/issues/issues/1046