### PR TITLE
Always report GitHub Actions job statuses for "Total Perspective Vortex" workflow

### DIFF
--- a/.github/workflows/tpv.yml
+++ b/.github/workflows/tpv.yml
@@ -3,17 +3,41 @@ name: Total Perspective Vortex
 
 "on":
   pull_request:
-    paths:
-      - "files/galaxy/tpv/**"
   push:
     branches:
       - master
     paths:
-      - "files/galaxy/tpv/**"
+      - &tpv_path "files/galaxy/tpv/**"
 
 jobs:
+  orchestrator:
+    name: Total Perspective Vortex orchestrator
+    runs-on: ubuntu-latest
+    outputs:
+      changed: ${{ steps.detect.outputs.changed }}
+    steps:
+      - name: Check out the codebase.
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Detect TPV configuration changes.
+        id: detect
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.after }}
+          TPV_PATH: *tpv_path
+        run: |
+          if git diff --quiet "$BASE_SHA" "$HEAD_SHA" -- "$TPV_PATH"; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
   lint:
     name: Total Perspective Vortex linter
+    needs: orchestrator
+    if: needs.orchestrator.outputs.changed == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Check out the codebase.
@@ -165,6 +189,8 @@ jobs:
 
   dry-run:
     name: Total Perspective Vortex dry-run
+    needs: orchestrator
+    if: needs.orchestrator.outputs.changed == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Check out the codebase.

--- a/.github/workflows/tpv.yml
+++ b/.github/workflows/tpv.yml
@@ -11,7 +11,7 @@ name: Total Perspective Vortex
 
 jobs:
   orchestrator:
-    name: Total Perspective Vortex orchestrator
+    name: Orchestrator
     runs-on: ubuntu-latest
     outputs:
       changed: ${{ steps.detect.outputs.changed }}
@@ -35,7 +35,7 @@ jobs:
           fi
 
   lint:
-    name: Total Perspective Vortex linter
+    name: Lint
     needs: orchestrator
     if: needs.orchestrator.outputs.changed == 'true'
     runs-on: ubuntu-latest
@@ -188,7 +188,7 @@ jobs:
           done
 
   dry-run:
-    name: Total Perspective Vortex dry-run
+    name: Dry-run
     needs: orchestrator
     if: needs.orchestrator.outputs.changed == 'true'
     runs-on: ubuntu-latest

--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -93,7 +93,7 @@ tools:
   ucsc_table_direct1:
     inherits: _basic_internal_tool
 
-  # example for overwriting the OOM memory multiplier for a specific tool.
+  # example for overwriting the OOM memory multiplier for a specific tool
   # toolshed.g2.bx.psu.edu/repos/example_owner/example_tool/example_tool/.*:
   #   context:
   #     OOM_SCALING_FACTOR: 3


### PR DESCRIPTION
I added the Total Perspective Vortex status checks as required to merge PRs, assuming that GitHub would be smart enough to not require them if they do not have to run (because no files are modified).

It turns out I was wrong, GitHub Actions is not that smart. This workaround offloads the change detection to an "orchestrator" workflow step (that unfortunately always runs, there is no way around it) and **skips the remaining steps if no changes were detected**.