### PR TITLE
Serve FTP usage instructions on ftp.usegalaxy.eu via Traefik

### DIFF
--- a/files/traefik/rules/ftp.yml
+++ b/files/traefik/rules/ftp.yml
@@ -11,3 +11,28 @@ tcp:
       loadBalancer:
         servers:
           - address: "ftp.bi.privat:21"
+
+http:
+  routers:
+    ftp-instructions-rtr:
+      rule: "Host(`ftp.usegalaxy.eu`)"
+      service: noop@internal
+      entryPoints:
+        - websecure
+      priority: 100
+      middlewares:
+        - ftp-instructions-redirect
+      tls:
+        certResolver: "route53"
+        domains:
+          # note that CertBot on the FTP node also obtains a certificate for
+          # `ftp.usegalaxy.eu` via DNS challenge, but both certificates can
+          # coexist
+          - main: "ftp.usegalaxy.eu"
+
+  middlewares:
+    ftp-instructions-redirect:
+      redirectRegex:
+        regex: "^.*$"  # any URL
+        replacement: "https://galaxyproject.org/ftp-upload/"
+        permanent: false


### PR DESCRIPTION
The NGINX template (templates/nginx/ftp.j2) that proxied the FTP usage instructions to usegalaxy-eu.github.io/ftp/ was removed in 2e929e1, since NGINX no longer runs on the FTP node. In addition, the FTP instructions for EU have since moved to https://galaxyproject.org/ftp-upload/.

Rather than proxying to instructions like it was done before, redirect ftp.usegalaxy.eu to the current location of the instructions.