### PR TITLE
add more memory to the ProteomIQon-PSMBasedQuantificationTIMs Tool

### DIFF
--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -439,6 +439,9 @@ tools:
   toolshed.g2.bx.psu.edu/repos/galaxyp/proteomiqon_psmstatistics/proteomiqon_psmstatistics/.*:
     mem: 16
 
+  toolshed.g2.bx.psu.edu/repos/galaxyp/proteomiqon_psmbasedquantification/proteomiqon_psmbasedquantification/.*:
+    mem: 16
+
   toolshed.g2.bx.psu.edu/repos/galaxyp/peptideshaker/peptide_shaker/.*:
     cores: 12
     mem: 32


### PR DESCRIPTION
please add more memory to the PSMBasedTIMs Tool, which is an Extension of the PSMBasedQuantification Tool but suitable for TIMs data