### PR TITLE
Set up HTTP-based Traefik certificate resolver

### DIFF
--- a/group_vars/traefik.yml
+++ b/group_vars/traefik.yml
@@ -103,8 +103,15 @@ traefik_containers:
 
       - "--providers.file.directory=/rules"
       - "--providers.file.watch=true"
-      ## DNS Challenge
+      # Certificates Resolvers
+      ## HTTP-01 Challenge (LetsEncrypt)
+      - --certificatesResolvers.http.acme.storage=/letsencrypt/acme-http.json
+      - --certificatesResolvers.http.acme.httpChallenge.entryPoint=web
+      - --certificatesResolvers.http.acme.caserver=https://acme-v02.api.letsencrypt.org/directory
+      - "--certificatesresolvers.http.acme.email={{ traefik_letsencrypt_mail }}"
+      ## Tailscale
       - --certificatesResolvers.ts.tailscale=true
+      ## DNS-01 Challenge via Route53 (LetsEncrypt)
       - --certificatesResolvers.route53.acme.storage=/letsencrypt/acme.json
       - --certificatesResolvers.route53.acme.dnsChallenge.provider=route53
       - --certificatesresolvers.route53.acme.caserver=https://acme-v02.api.letsencrypt.org/directory


### PR DESCRIPTION
This certificate resolver configuration is targeted to situations in which a domain name that does not belong to us points to Traefik.

Specifically, the PR is motivated by the migration of OSIRIS from bwCloud to KVM. The domain `osiris.denbi.de` (not under our control) points to `osiris-denbi.galaxyproject.eu` (under our control) via a CNAME record. In this case, a DNS-based challenge won't work.

Part of https://github.com/usegalaxy-eu/issues/issues/1050.