### PR TITLE
Add memory and cores configuration for wgcna_softpower

### DIFF
--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -950,6 +950,11 @@ tools:
     mem: 32
     cores: 4
 
+  
+  toolshed.g2.bx.psu.edu/repos/iuc/wgcna_softpower/wgcna_softpower/.*:
+    mem: 32
+    cores: 4
+
   toolshed.g2.bx.psu.edu/repos/iuc/celltypist/celltypist/.*:
     mem: 8
     cores: 4


### PR DESCRIPTION
Added core and memory values for wgcna_softpower for the same reason as wgcna_network: the tool can require additional resources for larger inputs.