### PR TITLE
Revert "add http to https middleware redirect with priority instead of an entrypoint"

### DIFF
--- a/files/traefik/rules/cvmfs-stratum0-router.yml
+++ b/files/traefik/rules/cvmfs-stratum0-router.yml
@@ -1,13 +1,3 @@
-http:
-  routers:
-    cvmfs-stratum0-rtr:
-      # cvmfs-stratum0 is served over plain HTTP, please keep it exempt from
-      # the HTTPS redirection
-      rule: "Host(`cvmfs-stratum0.galaxyproject.eu`)"
-      service: cvmfs-stratum0
-      entryPoints:
-        - web
-
 tcp:
   routers:
     cvmfs-stratum0-rsync:

--- a/files/traefik/rules/cvmfs-stratum0-service.yml
+++ b/files/traefik/rules/cvmfs-stratum0-service.yml
@@ -1,10 +1,3 @@
-http:
-  services:
-    cvmfs-stratum0:
-      loadBalancer:
-        servers:
-          - url: "http://10.4.68.179:80"
-
 tcp:
   services:
     cvmfs-stratum0-rsync:

--- a/files/traefik/rules/galaxyproject-eu-router.yml
+++ b/files/traefik/rules/galaxyproject-eu-router.yml
@@ -5,10 +5,7 @@ http:
       service: galaxyproject-eu
       entryPoints:
         - websecure
-        - web
       tls:
         certResolver: "route53"
         domains:
           - main: "galaxyproject.eu"
-      middlewares:
-        - https-redirect

--- a/files/traefik/rules/gdpr-router.yml
+++ b/files/traefik/rules/gdpr-router.yml
@@ -5,7 +5,6 @@ http:
       service: usegalaxy-github
       entryPoints:
         - websecure
-        - web
       tls:
         certResolver: "route53"
         domains:
@@ -13,7 +12,6 @@ http:
             sans:
               - "*.usegalaxy.eu"
       middlewares:
-        - https-redirect
         - replace-terms
   middlewares:
     replace-terms:

--- a/files/traefik/rules/https-redirect-middleware.yml
+++ b/files/traefik/rules/https-redirect-middleware.yml
@@ -1,6 +1,0 @@
-http:
-  middlewares:
-    https-redirect:
-      redirectScheme:
-        scheme: https
-        permanent: true

--- a/files/traefik/rules/jenkins-router.yml
+++ b/files/traefik/rules/jenkins-router.yml
@@ -5,10 +5,7 @@ http:
       service: jenkins
       entryPoints:
         - websecure
-        - web
       tls:
         certResolver: "route53"
         domains:
           - main: "build.galaxyproject.eu"
-      middlewares:
-        - https-redirect

--- a/files/traefik/rules/plausible-router.yml
+++ b/files/traefik/rules/plausible-router.yml
@@ -5,11 +5,9 @@ http:
       service: plausible
       entryPoints:
         - websecure
-        - web
       tls:
         certResolver: "route53"
         domains:
           - main: "plausible.galaxyproject.eu"
       middlewares:
-        - https-redirect
         - plausible-allow-iframe

--- a/files/traefik/rules/sse-router.yml
+++ b/files/traefik/rules/sse-router.yml
@@ -4,7 +4,4 @@ http:
       rule: "Host(`*.usegalaxy.eu`) && PathPrefix(`/api/events/stream`)"
       entryPoints:
         - websecure
-        - web
       service: usegalaxy-eu-sse
-      middlewares:
-        - https-redirect

--- a/files/traefik/rules/stats-router.yml
+++ b/files/traefik/rules/stats-router.yml
@@ -5,9 +5,7 @@ http:
       service: stats
       entryPoints:
         - websecure
-        - web
       middlewares:
-        - https-redirect
         - stats-compress
       tls:
         certResolver: "route53"

--- a/files/traefik/rules/template-subdomains.yml
+++ b/files/traefik/rules/template-subdomains.yml
@@ -4,9 +4,6 @@
       service: usegalaxy-eu
       entryPoints:
         - websecure
-        - web
-      middlewares:
-        - https-redirect
       tls:
         certResolver: "route53"
         domains:

--- a/files/traefik/rules/ticketsystem-router.yml
+++ b/files/traefik/rules/ticketsystem-router.yml
@@ -5,10 +5,7 @@ http:
       service: ticketsystem
       entryPoints:
         - websecure
-        - web
       tls:
         certResolver: "route53"
         domains:
           - main: "ticketsystem.galaxyproject.eu"
-      middlewares:
-        - https-redirect

--- a/files/traefik/rules/tpv-broker-router.yml
+++ b/files/traefik/rules/tpv-broker-router.yml
@@ -5,10 +5,7 @@ http:
       service: tpv-broker
       entryPoints:
         - websecure
-        - web
       tls:
         certResolver: "route53"
         domains:
           - main: "tpv-broker.galaxyproject.eu"
-      middlewares:
-        - https-redirect

--- a/files/traefik/rules/ucsc-genome-browser-router.yml
+++ b/files/traefik/rules/ucsc-genome-browser-router.yml
@@ -5,9 +5,7 @@ http:
       service: ucsc-genome-browser
       entryPoints:
         - websecure
-        - web
       middlewares:
-        - https-redirect
         - ucsc-genome-browser-compress
       tls:
         certResolver: "route53"

--- a/files/traefik/rules/usegalaxy-eu-middleware.yml
+++ b/files/traefik/rules/usegalaxy-eu-middleware.yml
@@ -1,7 +1,0 @@
-http:
-  middlewares:
-    usegalaxy-eu-ratelimit:
-      rateLimit:
-        average: 10
-        period: 1s
-        burst: 50

--- a/files/traefik/rules/usegalaxy-eu-router.yml
+++ b/files/traefik/rules/usegalaxy-eu-router.yml
@@ -5,12 +5,9 @@ http:
       service: "usegalaxy-eu"
       entryPoints:
         - websecure
-        - web
       tls:
         certResolver: "route53"
         domains:
           - main: "usegalaxy.eu"
             sans:
               - "*.ep.interactivetool.usegalaxy.eu"
-      middlewares:
-        - https-redirect

--- a/group_vars/traefik.yml
+++ b/group_vars/traefik.yml
@@ -85,6 +85,8 @@ traefik_containers:
       - --entryPoints.influxdb.address=:8086
       - "--entryPoints.cvmfs-rsync.address=:{{ traefik_cvmfs_rsync_port.port }}"
       - "--entryPoints.dokku-ssh.address=:{{ traefik_dokku_ssh_port.port }}"
+      - --entryPoints.web.http.redirections.entryPoint.to=websecure
+      - --entryPoints.web.http.redirections.entryPoint.scheme=https
       - --entryPoints.metrics.address=:8082
       #- "--entryPoints.websecure.http.tls.domains[0].main={{ traefik_domain }}"
       #- --entryPoints.https.http.tls.certresolver=route53


### PR DESCRIPTION
Reverts usegalaxy-eu/infrastructure-playbook#2287.

Something is wrong.

```shell
$ curl -v http://usegalaxy.eu
* Host usegalaxy.eu:80 was resolved.
* IPv6: (none)
* IPv4: 132.230.103.37
*   Trying 132.230.103.37:80...
* Established connection to usegalaxy.eu (132.230.103.37 port 80) from XXX.XXX.XXX.XXX port 36824 
* using HTTP/1.x
> GET / HTTP/1.1
> Host: usegalaxy.eu
> User-Agent: curl/8.21.0
> Accept: */*
> 
* Request completely sent off
< HTTP/1.1 404 Not Found
< Content-Type: text/plain; charset=utf-8
< X-Content-Type-Options: nosniff
< Date: Wed, 02 Sep 2026 15:28:37 GMT
< Content-Length: 19
< 
404 page not found
* Connection #0 to host usegalaxy.eu:80 left intact
```

I will try again tomorrow.