### PR TITLE
Add macro for CVMFS based singularity destinations

### DIFF
--- a/files/galaxy/tpv/destinations.yml.j2
+++ b/files/galaxy/tpv/destinations.yml.j2
@@ -28,12 +28,16 @@
         $working_directory:rw,
         {{ cvmfs.data.path }}:{{ cvmfs.data.docker_perm }}
 {%- endmacro %}
-{% macro pulsar_cz_container_resolvers() -%}
+{% macro cvmfs_container_resolvers() -%}
 container_resolvers:
   - type: explicit_singularity
   - type: cached_mulled_singularity
     cache_directory: /cvmfs/singularity.galaxyproject.org/all/
     cache_directory_cacher_type: dir_mtime
+{%- endmacro %}
+{% macro pulsar_cz_container_resolvers() -%}
+container_resolvers:
+{{ cvmfs_container_resolvers() | indent(2, false) }}
   - type: mulled_singularity
     cache_directory: {{ cache.cache08.path }}/container_cache/singularity/mulled/
     # the `cache_directory` setting may break the resolver if
@@ -41,6 +45,8 @@ container_resolvers:
     # configuration should be revised
     auto_install: true
 {%- endmacro %}
+
+
 ---
 # NOTE: Use dashes (-) exclusively for tags and underscores (_) exclusively for destinations.
 # submit_request_cpus its called in pulsar and in plain condor only request_cpus
@@ -454,7 +460,7 @@ destinations:
       singularity_run_extra_arguments: --disable-cache
       submit_user: $__user_email__
       submit_native_specification: "--qos=galaxy -p galaxy -t 24:00:00 --cpus-per-task={int(cores)} --mem-per-cpu={int(mem/cores)}G"
-      {{ pulsar_cz_container_resolvers() | indent(6, false) }}
+      {{ cvmfs_container_resolvers() | indent(6, false) }}
     scheduling:
       require:
         - ufz-eve-pulsar


### PR DESCRIPTION
Mostly based on intuition .. 

And wondering what 

```yaml
  - type: mulled_singularity
    cache_directory: {{ cache.cache08.path }}/container_cache/singularity/mulled/
```

is good for. Is this for containers not on CVMFS?