### PR TITLE
Allow access to UCSC Genome Browser VM on the internal network via port forwarding

### DIFF
--- a/group_vars/ucsc_genome_browser/vars.yml
+++ b/group_vars/ucsc_genome_browser/vars.yml
@@ -15,6 +15,8 @@ ucsc_genome_browser_vm_state: present  # use `absent` to remove the VM
 ucsc_genome_browser_vm_cpus: 2
 ucsc_genome_browser_vm_memory: 16384
 ucsc_genome_browser_vm_ports:
+  - host: 2201
+    guest: 22
   - host: 8030
     guest: 80
 ucsc_genome_browser_vm_shares:


### PR DESCRIPTION
Forward port 2201 of sn10 (the host for UCSC Genome Browser's VM) to the SSH port of the VM.