### PR TITLE
Revert² http to https

### DIFF
--- a/files/traefik/rules/cvmfs-stratum0-router.yml
+++ b/files/traefik/rules/cvmfs-stratum0-router.yml
@@ -1,13 +1,3 @@
-http:
-  routers:
-    cvmfs-stratum0-rtr:
-      # cvmfs-stratum0 is served over plain HTTP, please keep it exempt from
-      # the HTTPS redirection
-      rule: "Host(`cvmfs-stratum0.galaxyproject.eu`)"
-      service: cvmfs-stratum0
-      entryPoints:
-        - web
-
 tcp:
   routers:
     cvmfs-stratum0-rsync:

--- a/files/traefik/rules/cvmfs-stratum0-router.yml
+++ b/files/traefik/rules/cvmfs-stratum0-router.yml
@@ -1,3 +1,12 @@
+http:
+  routers:
+    cvmfs-stratum0-rtr:
+      # cvmfs-stratum0 is served over plain HTTP, please keep it exempt from
+      # the HTTPS redirection
+      rule: "Host(`cvmfs-stratum0.galaxyproject.eu`)"
+      service: cvmfs-stratum0
+      entryPoints:
+        - web
 tcp:
   routers:
     cvmfs-stratum0-rsync:

--- a/files/traefik/rules/cvmfs-stratum0-service.yml
+++ b/files/traefik/rules/cvmfs-stratum0-service.yml
@@ -1,3 +1,9 @@
+http:
+  services:
+    cvmfs-stratum0:
+      loadBalancer:
+        servers:
+          - url: "http://10.4.68.179:80"
 tcp:
   services:
     cvmfs-stratum0-rsync:

--- a/files/traefik/rules/cvmfs-stratum0-service.yml
+++ b/files/traefik/rules/cvmfs-stratum0-service.yml
@@ -1,10 +1,3 @@
-http:
-  services:
-    cvmfs-stratum0:
-      loadBalancer:
-        servers:
-          - url: "http://10.4.68.179:80"
-
 tcp:
   services:
     cvmfs-stratum0-rsync:

--- a/files/traefik/rules/galaxyproject-eu-router.yml
+++ b/files/traefik/rules/galaxyproject-eu-router.yml
@@ -5,10 +5,7 @@ http:
       service: galaxyproject-eu
       entryPoints:
         - websecure
-        - web
       tls:
         certResolver: "route53"
         domains:
           - main: "galaxyproject.eu"
-      middlewares:
-        - https-redirect

--- a/files/traefik/rules/gdpr-router.yml
+++ b/files/traefik/rules/gdpr-router.yml
@@ -5,7 +5,6 @@ http:
       service: usegalaxy-github
       entryPoints:
         - websecure
-        - web
       tls:
         certResolver: "route53"
         domains:
@@ -13,7 +12,6 @@ http:
             sans:
               - "*.usegalaxy.eu"
       middlewares:
-        - https-redirect
         - replace-terms
   middlewares:
     replace-terms:

--- a/files/traefik/rules/http-catchall-rtr.yml
+++ b/files/traefik/rules/http-catchall-rtr.yml
@@ -1,0 +1,13 @@
+http:
+  middlewares:
+    redirect-https:
+      redirectScheme:
+        scheme: https
+  routers:
+    http-catchall-rtr:
+      rule: Host(`*`)
+      service: noop@internal
+      entryPoints:
+        - web
+      middlewares:
+        - redirect-https

--- a/files/traefik/rules/https-redirect-middleware.yml
+++ b/files/traefik/rules/https-redirect-middleware.yml
@@ -1,6 +1,0 @@
-http:
-  middlewares:
-    https-redirect:
-      redirectScheme:
-        scheme: https
-        permanent: true

--- a/files/traefik/rules/jenkins-router.yml
+++ b/files/traefik/rules/jenkins-router.yml
@@ -5,10 +5,7 @@ http:
       service: jenkins
       entryPoints:
         - websecure
-        - web
       tls:
         certResolver: "route53"
         domains:
           - main: "build.galaxyproject.eu"
-      middlewares:
-        - https-redirect

--- a/files/traefik/rules/plausible-router.yml
+++ b/files/traefik/rules/plausible-router.yml
@@ -5,11 +5,9 @@ http:
       service: plausible
       entryPoints:
         - websecure
-        - web
       tls:
         certResolver: "route53"
         domains:
           - main: "plausible.galaxyproject.eu"
       middlewares:
-        - https-redirect
         - plausible-allow-iframe

--- a/files/traefik/rules/sse-router.yml
+++ b/files/traefik/rules/sse-router.yml
@@ -4,7 +4,4 @@ http:
       rule: "Host(`*.usegalaxy.eu`) && PathPrefix(`/api/events/stream`)"
       entryPoints:
         - websecure
-        - web
       service: usegalaxy-eu-sse
-      middlewares:
-        - https-redirect

--- a/files/traefik/rules/stats-router.yml
+++ b/files/traefik/rules/stats-router.yml
@@ -5,9 +5,7 @@ http:
       service: stats
       entryPoints:
         - websecure
-        - web
       middlewares:
-        - https-redirect
         - stats-compress
       tls:
         certResolver: "route53"

--- a/files/traefik/rules/template-subdomains.yml
+++ b/files/traefik/rules/template-subdomains.yml
@@ -4,9 +4,6 @@
       service: usegalaxy-eu
       entryPoints:
         - websecure
-        - web
-      middlewares:
-        - https-redirect
       tls:
         certResolver: "route53"
         domains:

--- a/files/traefik/rules/ticketsystem-router.yml
+++ b/files/traefik/rules/ticketsystem-router.yml
@@ -5,10 +5,7 @@ http:
       service: ticketsystem
       entryPoints:
         - websecure
-        - web
       tls:
         certResolver: "route53"
         domains:
           - main: "ticketsystem.galaxyproject.eu"
-      middlewares:
-        - https-redirect

--- a/files/traefik/rules/tpv-broker-router.yml
+++ b/files/traefik/rules/tpv-broker-router.yml
@@ -5,10 +5,7 @@ http:
       service: tpv-broker
       entryPoints:
         - websecure
-        - web
       tls:
         certResolver: "route53"
         domains:
           - main: "tpv-broker.galaxyproject.eu"
-      middlewares:
-        - https-redirect

--- a/files/traefik/rules/ucsc-genome-browser-router.yml
+++ b/files/traefik/rules/ucsc-genome-browser-router.yml
@@ -5,9 +5,7 @@ http:
       service: ucsc-genome-browser
       entryPoints:
         - websecure
-        - web
       middlewares:
-        - https-redirect
         - ucsc-genome-browser-compress
       tls:
         certResolver: "route53"

--- a/files/traefik/rules/usegalaxy-eu-middleware.yml
+++ b/files/traefik/rules/usegalaxy-eu-middleware.yml
@@ -1,7 +1,0 @@
-http:
-  middlewares:
-    usegalaxy-eu-ratelimit:
-      rateLimit:
-        average: 10
-        period: 1s
-        burst: 50

--- a/files/traefik/rules/usegalaxy-eu-router.yml
+++ b/files/traefik/rules/usegalaxy-eu-router.yml
@@ -5,12 +5,9 @@ http:
       service: "usegalaxy-eu"
       entryPoints:
         - websecure
-        - web
       tls:
         certResolver: "route53"
         domains:
           - main: "usegalaxy.eu"
             sans:
               - "*.ep.interactivetool.usegalaxy.eu"
-      middlewares:
-        - https-redirect

--- a/group_vars/traefik.yml
+++ b/group_vars/traefik.yml
@@ -89,6 +89,8 @@ traefik_containers:
       - "--entryPoints.cvmfs-rsync.address=:{{ traefik_cvmfs_rsync_port.port }}"
       - "--entryPoints.dokku-ssh.address=:{{ traefik_dokku_ssh_port.port }}"
       - "--entryPoints.osiris-ssh.address=:{{ traefik_osiris_ssh_port.port }}"
+      - --entryPoints.web.http.redirections.entryPoint.to=websecure
+      - --entryPoints.web.http.redirections.entryPoint.scheme=https
       - --entryPoints.metrics.address=:8082
       #- "--entryPoints.websecure.http.tls.domains[0].main={{ traefik_domain }}"
       #- --entryPoints.https.http.tls.certresolver=route53

--- a/group_vars/traefik.yml
+++ b/group_vars/traefik.yml
@@ -89,8 +89,6 @@ traefik_containers:
       - "--entryPoints.cvmfs-rsync.address=:{{ traefik_cvmfs_rsync_port.port }}"
       - "--entryPoints.dokku-ssh.address=:{{ traefik_dokku_ssh_port.port }}"
       - "--entryPoints.osiris-ssh.address=:{{ traefik_osiris_ssh_port.port }}"
-      - --entryPoints.web.http.redirections.entryPoint.to=websecure
-      - --entryPoints.web.http.redirections.entryPoint.scheme=https
       - --entryPoints.metrics.address=:8082
       #- "--entryPoints.websecure.http.tls.domains[0].main={{ traefik_domain }}"
       #- --entryPoints.https.http.tls.certresolver=route53


### PR DESCRIPTION
Reverts usegalaxy-eu/infrastructure-playbook#2323

[@gsaudade99 's commit](https://github.com/usegalaxy-eu/infrastructure-playbook/commit/684c1e0eeae105020f2234d4d2289c352011628d) was completely right.
What happens with the [here](https://github.com/usegalaxy-eu/infrastructure-playbook/pull/2326) reverted approach is, that
the http (port 80) requests never reach the routers, because the [TLS
option](https://doc.traefik.io/traefik/reference/routing-configuration/http/tls/overview/#general) blocks them.
So they never reach the `redirectScheme` middleware and traefik just
shows `404`. With the catchall router, all requests **that are not
catched** by web entrypoint routers with higher priority are redirected
to https. Higher [priority](https://doc.traefik.io/traefik/reference/routing-configuration/http/routing/rules-and-priority/#priority-calculation) basically means longer `rules` strings. So this way CVMFS requests will not be catched by the catchall router, but the CVMFS router.