### PR TITLE
Remove temporary conda-in-container rule for barchart_gnuplot

### DIFF
--- a/files/galaxy/tpv/conda_in_container.yml.j2
+++ b/files/galaxy/tpv/conda_in_container.yml.j2
@@ -12,11 +12,6 @@ tools:
   toolshed.g2.bx.psu.edu/repos/iuc/snpfreqplot/snpfreqplot/.*:
     inherits: _conda_in_container
 
-  # python3 introduced changes to Gnuplot model more info in the issue bellow
-  # rm after closing: https://github.com/usegalaxy-eu/issues/issues/979
-  barchart_gnuplot:
-    inherits: _conda_in_container
-
   # these wrapper versions do not declare their coreutils requirement; the busybox host of the container brings its own non-standard
   # implementation of the split command, which doesn't offer the -n option that the coreutils version has and which the tool requires.
   toolshed.g2.bx.psu.edu/repos/iuc/datamash_transpose/datamash_transpose/1.8\+galaxy.:


### PR DESCRIPTION
As described in https://github.com/usegalaxy-eu/issues/issues/979

Reverts the temporary rule added in #2023, annotated "rm after closing".

The upstream fix (galaxyproject/galaxy#22597, merged 2026-05-20) is present
on usegalaxy_26.1 and .eu is running 26.1.2.dev0, so the tool can go back to
the singularity image gnuplot-py:1.8--pyhdc42f0e_2.

Verified the tool currently works under the existing rule (job
4838ba20a6d8676560708719a4247fd6), so this is cleanup.
 
Will re-run the same input after deploy before closing the issue.

