### PR TITLE
Revert "Remove temporary conda-in-container rule for barchart_gnuplot"

### DIFF
--- a/files/galaxy/tpv/conda_in_container.yml.j2
+++ b/files/galaxy/tpv/conda_in_container.yml.j2
@@ -12,6 +12,11 @@ tools:
   toolshed.g2.bx.psu.edu/repos/iuc/snpfreqplot/snpfreqplot/.*:
     inherits: _conda_in_container
 
+  # python3 introduced changes to Gnuplot model more info in the issue bellow
+  # rm after closing: https://github.com/usegalaxy-eu/issues/issues/979
+  barchart_gnuplot:
+    inherits: _conda_in_container
+
   # these wrapper versions do not declare their coreutils requirement; the busybox host of the container brings its own non-standard
   # implementation of the split command, which doesn't offer the -n option that the coreutils version has and which the tool requires.
   toolshed.g2.bx.psu.edu/repos/iuc/datamash_transpose/datamash_transpose/1.8\+galaxy.:


### PR DESCRIPTION
Reverts usegalaxy-eu/infrastructure-playbook#2327.

```
File "/usr/local/lib/python3.11/site-packages/_Gnuplot.py", line 250, in _add_to_queue
elif type(item) is types.StringType:
AttributeError: module 'types' has no attribute 'StringType'
```

See https://github.com/usegalaxy-eu/issues/issues/979#issuecomment-5583159191 for more details.