### PR TITLE
Revert "Revert "Disable SSE monitor""

### DIFF
--- a/group_vars/sn09/sn09.yml
+++ b/group_vars/sn09/sn09.yml
@@ -238,7 +238,7 @@ galaxy_systemd_gunicorn_env: '{{ apollo_env }} GALAXY_ONEDRIVE_CLIENT_ID={{ oned
 galaxy_systemd_handler_env: '{{ galaxy_systemd_gunicorn_env }} PULSAR_RELAY_ALLOW_INSECURE=1'
 galaxy_systemd_workflow_scheduler_env: '{{ galaxy_systemd_gunicorn_env }}'
 
-galaxy_systemd_sse_monitor: true
+galaxy_systemd_sse_monitor: false
 
 galaxy_systemd_memory_limit: 35
 galaxy_systemd_memory_limit_handler: 40


### PR DESCRIPTION
Reverts usegalaxy-eu/infrastructure-playbook#2330.

According to @mvdbeek, it is not planned to fix the monitor (it does not make much sense to have the monitor in the first place).