### PR TITLE
Attempt to fix issues with conda.lock during `gunicorn` restarts by setting `conda_auto_init` to `false`

### DIFF
--- a/group_vars/gxconfig.yml
+++ b/group_vars/gxconfig.yml
@@ -256,7 +256,7 @@ base_app_main: &BASE_APP_MAIN
   # automatically if it cannot find a local copy and conda_exec is not
   # configured. The default is true if running Galaxy from source, and
   # false if running from installed packages.
-  #conda_auto_init: false
+  conda_auto_init: false
 
   # You must set this to true if conda_prefix and job_working_directory
   # are not on the same volume, or some conda dependencies will fail to


### PR DESCRIPTION
I think we have just seen the comment and assumed that `false` is the default, but the fine print says "The default is true if running Galaxy from source", which is precisely what we are doing. So I believe we actually need to set it to `false`.