### PR TITLE
Give each EU Gunicorn instance a unique Galaxy server name

### DIFF
--- a/group_vars/sn09/sn09.yml
+++ b/group_vars/sn09/sn09.yml
@@ -237,7 +237,7 @@ galaxy_systemd_workflow_schedulers: 3
 galaxy_systemd_common_env: '{{ apollo_env }} GALAXY_ONEDRIVE_CLIENT_ID={{ onedrive_client_id }} GALAXY_ONEDRIVE_CLIENT_SECRET={{ onedrive_client_secret }} GALAXY_DROPBOX_APP_CLIENT_ID={{ dropbox_app_client_id }} GALAXY_DROPBOX_APP_CLIENT_SECRET={{ dropbox_app_client_secret }} GALAXY_GOOGLE_DRIVE_APP_CLIENT_ID={{ google_drive_oauth_client_id }} GALAXY_GOOGLE_DRIVE_APP_CLIENT_SECRET={{ google_drive_oauth_client_secret }} GALAXY_VIRTUAL_ENV={{ galaxy_venv_dir }} GALAXY_LIB={{ galaxy_server_dir }}/lib'
 # Each Gunicorn master needs a distinct base name for its workers' control queues.
 # Systemd expands %i to the galaxy-gunicorn@ instance number.
-galaxy_systemd_gunicorn_env: '{{ galaxy_systemd_common_env }} GALAXY_CONFIG_SERVER_NAME=web_%i'
+galaxy_systemd_gunicorn_env: '{{ galaxy_systemd_common_env }} GALAXY_CONFIG_SERVER_NAME=web_sn09_%i'
 galaxy_systemd_handler_env: '{{ galaxy_systemd_common_env }} PULSAR_RELAY_ALLOW_INSECURE=1'
 galaxy_systemd_workflow_scheduler_env: '{{ galaxy_systemd_common_env }}'
 

--- a/group_vars/sn09/sn09.yml
+++ b/group_vars/sn09/sn09.yml
@@ -234,9 +234,12 @@ galaxy_systemd_gunicorn_timeout: 600
 galaxy_systemd_handlers: 6
 galaxy_systemd_workflow_schedulers: 3
 
-galaxy_systemd_gunicorn_env: '{{ apollo_env }} GALAXY_ONEDRIVE_CLIENT_ID={{ onedrive_client_id }} GALAXY_ONEDRIVE_CLIENT_SECRET={{ onedrive_client_secret }} GALAXY_DROPBOX_APP_CLIENT_ID={{ dropbox_app_client_id }} GALAXY_DROPBOX_APP_CLIENT_SECRET={{ dropbox_app_client_secret }} GALAXY_GOOGLE_DRIVE_APP_CLIENT_ID={{ google_drive_oauth_client_id }} GALAXY_GOOGLE_DRIVE_APP_CLIENT_SECRET={{ google_drive_oauth_client_secret }} GALAXY_VIRTUAL_ENV={{ galaxy_venv_dir }} GALAXY_LIB={{ galaxy_server_dir }}/lib'
-galaxy_systemd_handler_env: '{{ galaxy_systemd_gunicorn_env }} PULSAR_RELAY_ALLOW_INSECURE=1'
-galaxy_systemd_workflow_scheduler_env: '{{ galaxy_systemd_gunicorn_env }}'
+galaxy_systemd_common_env: '{{ apollo_env }} GALAXY_ONEDRIVE_CLIENT_ID={{ onedrive_client_id }} GALAXY_ONEDRIVE_CLIENT_SECRET={{ onedrive_client_secret }} GALAXY_DROPBOX_APP_CLIENT_ID={{ dropbox_app_client_id }} GALAXY_DROPBOX_APP_CLIENT_SECRET={{ dropbox_app_client_secret }} GALAXY_GOOGLE_DRIVE_APP_CLIENT_ID={{ google_drive_oauth_client_id }} GALAXY_GOOGLE_DRIVE_APP_CLIENT_SECRET={{ google_drive_oauth_client_secret }} GALAXY_VIRTUAL_ENV={{ galaxy_venv_dir }} GALAXY_LIB={{ galaxy_server_dir }}/lib'
+# Each Gunicorn master needs a distinct base name for its workers' control queues.
+# Systemd expands %i to the galaxy-gunicorn@ instance number.
+galaxy_systemd_gunicorn_env: '{{ galaxy_systemd_common_env }} GALAXY_CONFIG_SERVER_NAME=web_%i'
+galaxy_systemd_handler_env: '{{ galaxy_systemd_common_env }} PULSAR_RELAY_ALLOW_INSECURE=1'
+galaxy_systemd_workflow_scheduler_env: '{{ galaxy_systemd_common_env }}'
 
 galaxy_systemd_sse_monitor: false
 


### PR DESCRIPTION
This should fix internal IPC (SSE, reload toolbox when tools are installed or modified, reloading data tables, config watching, database heartbeat, sanitize allowlist)