### PR TITLE
rm deprectated cmd_line

### DIFF
--- a/roles/usegalaxy-eu.galaxy-procstat/templates/telegraf-procstat.conf.j2
+++ b/roles/usegalaxy-eu.galaxy-procstat/templates/telegraf-procstat.conf.j2
@@ -4,19 +4,16 @@
 [[inputs.procstat]]
 	cgroup = "systemd/system.slice/system-galaxy\\x2dgunicorn.slice/galaxy-gunicorn@{{ gunicorn }}.service"
 	process_name = "galaxy-gunicorn@{{ gunicorn }}"
-	cmdline_tag = true
 {% endfor %}
 
 {% for handler in range(galaxy_systemd_handlers) %}
 [[inputs.procstat]]
 	cgroup = "systemd/system.slice/system-galaxy\\x2dhandler.slice/galaxy-handler@{{ handler }}.service"
 	process_name = "galaxy-handler@{{ handler }}"
-	cmdline_tag = true
 {% endfor %}
 
 {% for handler in range(galaxy_systemd_workflow_schedulers) %}
 [[inputs.procstat]]
 	cgroup = "systemd/system.slice/system-galaxy\\x2dworkflow\\x2dscheduler.slice/galaxy-workflow-scheduler@{{ handler }}.service"
 	process_name = "galaxy-workflow-scheduler@{{ handler }}"
-	cmdline_tag = true
 {% endfor %}


### PR DESCRIPTION
This option was deprecated and now removed on telegraf v1.40.0 via https://github.com/influxdata/telegraf/pull/19118 from the release notes https://github.com/influxdata/telegraf/releases/tag/v1.40.0 breaking sn09 playbook run.

```
sn09:~$ telegraf --version
Telegraf 1.40.0 (git: HEAD@e9017dc3
```