### PR TITLE
Replace all `cvmfs0-tacc0.galaxyproject.org` references with `cvmfs0-psu0.galaxyproject.org` for CVMFS Stratum 1

### DIFF
--- a/cvmfs.yml
+++ b/cvmfs.yml
@@ -17,14 +17,14 @@
         group: root
         state: link
         force: true
-    - name: Replace all `cvmfs0-tacc0.galaxyproject.org` references with `cvmfs0-psu0.galaxyproject.org` in role defaults
+    - name: Replace all `cvmfs0-tacc0.galaxyproject.org` references with `cvmfs0-psu1.galaxyproject.org` in role defaults
       # workaround until https://github.com/galaxyproject/ansible-cvmfs/pull/93 is merged
       ansible.builtin.set_fact:
         galaxy_cvmfs_repositories: >-
           {%- set ns = namespace(out=[]) -%}
           {%- for repo in galaxy_cvmfs_repositories -%}
           {%-   set _ = ns.out.append(
-                  repo | combine({'stratum0': 'cvmfs0-psu0.galaxyproject.org'})
+                  repo | combine({'stratum0': 'cvmfs0-psu1.galaxyproject.org'})
                   if repo.stratum0 | default('') == 'cvmfs0-tacc0.galaxyproject.org'
                   else repo
                 ) -%}

--- a/cvmfs.yml
+++ b/cvmfs.yml
@@ -17,6 +17,19 @@
         group: root
         state: link
         force: true
+    - name: Replace all `cvmfs0-tacc0.galaxyproject.org` references with `cvmfs0-psu0.galaxyproject.org` in role defaults
+      # workaround until https://github.com/galaxyproject/ansible-cvmfs/pull/93 is merged
+      ansible.builtin.set_fact:
+        galaxy_cvmfs_repositories: >-
+          {%- set ns = namespace(out=[]) -%}
+          {%- for repo in galaxy_cvmfs_repositories -%}
+          {%-   set _ = ns.out.append(
+                  repo | combine({'stratum0': 'cvmfs0-psu0.galaxyproject.org'})
+                  if repo.stratum0 | default('') == 'cvmfs0-tacc0.galaxyproject.org'
+                  else repo
+                ) -%}
+          {%- endfor -%}
+          {{- ns.out -}}
   post_tasks:
     - name: Disable SELinux
       selinux:


### PR DESCRIPTION
`galaxyproject.cvmfs` is broken, some CVMFS repo entries point `cvmfs0-tacc0.galaxyproject.org` which has been decommissioned. Replace the role defaults with the correct address `cvmfs0-psu0.galaxyproject.org`.

This is just a workaround until https://github.com/galaxyproject/ansible-cvmfs/pull/93 is merged.