### PR TITLE
Update Traefik image version to v3.7.13

### DIFF
--- a/group_vars/traefik.yml
+++ b/group_vars/traefik.yml
@@ -64,7 +64,7 @@ traefik_networks:
 traefik_containers:
   - name: traefik
     replicas: 1
-    image: traefik:v3.7.9
+    image: traefik:v3.7.13
     url: "https://traefik.{{ tailscale_domain }}/dashboard/#/"
     environment:
       AWS_SHARED_CREDENTIALS_FILE: "/run/secrets/aws_shared_credentials"


### PR DESCRIPTION
Currently we are unable to launch certificates, bumping minor version from v3.7.9 -> v.3.7.13 sounds promising from the release notes: https://github.com/traefik/traefik/pull/13710

Specifically this pr: https://github.com/traefik/traefik/pull/13710 witch goes according to our suspicions that the dns resolver is somehow broken or changed behavior with the increase in  DNS challenges handler by traefik.