### PR TITLE
Fix concurrency limit for ITs

### DIFF
--- a/templates/galaxy/config/job_conf.yml
+++ b/templates/galaxy/config/job_conf.yml
@@ -297,7 +297,7 @@ galaxy_jobconf:
     # Limited time for Interactive tools
     - type: "destination_user_concurrent_jobs"
       value: "2"
-      id: "pulsar_embedded"
+      id: "embedded_pulsar_docker"
     - type: "output_size"
       value: "'300GB'"
     - type: "registered_user_concurrent_jobs"


### PR DESCRIPTION
Sense we only running ITs in pulsar embedded runner we can maybe limit the `embedded_pulsar_docker` destination instead? 

I might have to say that the documentation is very scarce. 