### PR TITLE
Updates Ensembl FTP host path

### DIFF
--- a/templates/galaxy/config/file_sources_conf.yml.j2
+++ b/templates/galaxy/config/file_sources_conf.yml.j2
@@ -83,7 +83,7 @@
   id: ensembl-ftp
   label: "ENSEMBL FTP server"
   doc: "ENSEMBL FTP server"
-  host: "ftp.ensemblgenomes.org/vol1/pub/"
+  host: "ftp.ensemblgenomes.org/pub/"
   user: "anonymous"
   passwd: ""
   timeout: 10


### PR DESCRIPTION
Removes a no longer existent directory segment from the Ensembl FTP server host path to ensure correct access to file source data.

Detected while fixing https://github.com/galaxyproject/galaxy/issues/23398