### PR TITLE
Enable HTTPS for UCSC Genome Browser login form and GenArk accessions

### DIFF
--- a/group_vars/ucsc_genome_browser/vars.yml
+++ b/group_vars/ucsc_genome_browser/vars.yml
@@ -3,6 +3,10 @@ ucsc_genome_browser_setup_script_checksum: sha256:e47cd21c479a53d3157a4cd54f867d
 
 ucsc_genome_browser_setting_GBDBDIR: "{{ ucsc_genome_browser_vm_gbd_dir }}/gbdb/"
 
+ucsc_genome_browser_hg_conf_settings:
+  login.https: "on"
+  genarkHubPrefix: "https://hgdownload.soe.ucsc.edu/hubs"
+
 ucsc_genome_browser_offline_mode: true
 
 ucsc_genome_browser_assemblies: []


### PR DESCRIPTION
Follow-up to ansible-ucsc-genome-browser #5 and #6, using the settings idea from #5.

`login.https`: the setup script writes `off`, kent defaults it to on. Result is
hgLogin posting over plain http on an https page, which Chrome blocks.

`genarkHubPrefix`: never set by the setup script. Without it the lookup bails
before it queries the genark table, so no accession resolves. The table itself
is fine.

Both tested on my own deployment of the role.