### PR TITLE
set gput rule for bbflow run in simorgh

### DIFF
--- a/files/galaxy/tpv/tools.yml
+++ b/files/galaxy/tpv/tools.yml
@@ -980,5 +980,18 @@ tools:
     cores: 5
 
   toolshed.g2.bx.psu.edu/repos/bgruening/simorgh/simorgh/.*:
-    mem: 10
     cores: 5
+    rules:
+      - id: bbflow
+        if: |
+          retval = False
+          options = job.get_param_values(app)
+          if options:
+            bbflow_condi = options.get('bbflow_condi', {})
+            if bbflow_condi and isinstance(bbflow_condi, dict):
+              bbflow = bbflow_condi.get('bbflow', '')
+              retval = bbflow == 'yes'
+          retval
+        params:
+          docker_run_extra_arguments: --gpus all
+        gpus: 1


### PR DESCRIPTION
bbflow on CPU is extremely slow. I set the rule to assign a GPU to SIMORGH if bbflow is selected.

I also removed the mem, because it hardly uses 1 GB of memory, so 10 GB is too much.

Still I'm trying to see why is simorgh itself slow, probalby that also needs to be run in GPU